### PR TITLE
Add organization filter UI to timeline

### DIFF
--- a/src/components/OrgFilter.tsx
+++ b/src/components/OrgFilter.tsx
@@ -15,8 +15,14 @@ export default function OrgFilter({ orgs, selected, onSelect }: Props) {
     "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700";
 
   return (
-    <div className="flex flex-wrap gap-2">
+    <div
+      role="group"
+      aria-label="Filter by organization"
+      className="flex flex-wrap gap-2"
+    >
       <button
+        type="button"
+        aria-pressed={selected === null}
         className={`${pillBase} ${selected === null ? active : inactive}`}
         onClick={() => onSelect(null)}
       >
@@ -25,6 +31,8 @@ export default function OrgFilter({ orgs, selected, onSelect }: Props) {
       {orgs.map((org) => (
         <button
           key={org.id}
+          type="button"
+          aria-pressed={selected === org.id}
           className={`${pillBase} ${selected === org.id ? active : inactive}`}
           onClick={() => onSelect(org.id)}
         >

--- a/src/components/OrgFilter.tsx
+++ b/src/components/OrgFilter.tsx
@@ -1,0 +1,36 @@
+import type { OrgOption } from "../lib/timeline";
+
+type Props = {
+  orgs: OrgOption[];
+  selected: string | null;
+  onSelect: (id: string | null) => void;
+};
+
+export default function OrgFilter({ orgs, selected, onSelect }: Props) {
+  const pillBase =
+    "rounded-full px-3 py-1 text-sm font-medium transition-colors cursor-pointer";
+  const active =
+    "bg-slate-700 text-white dark:bg-slate-300 dark:text-slate-900";
+  const inactive =
+    "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700";
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        className={`${pillBase} ${selected === null ? active : inactive}`}
+        onClick={() => onSelect(null)}
+      >
+        All
+      </button>
+      {orgs.map((org) => (
+        <button
+          key={org.id}
+          className={`${pillBase} ${selected === org.id ? active : inactive}`}
+          onClick={() => onSelect(org.id)}
+        >
+          {org.label} ({org.count})
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/TimelineList.tsx
+++ b/src/components/TimelineList.tsx
@@ -1,0 +1,62 @@
+import type { TimelineItem } from "../lib/timeline";
+
+type Props = {
+  items: TimelineItem[];
+};
+
+function fmt(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString("en-CA", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export default function TimelineList({ items }: Props) {
+  if (items.length === 0) {
+    return (
+      <p className="mt-10 text-slate-500 dark:text-slate-400">
+        No items match this filter.
+      </p>
+    );
+  }
+
+  return (
+    <ol className="mt-10 space-y-8 border-l border-slate-200 dark:border-slate-800">
+      {items.map((item) => (
+        <li key={item.id} className="relative pl-6">
+          <span className="absolute -left-[5px] top-2 h-2.5 w-2.5 rounded-full bg-slate-400 dark:bg-slate-600" />
+          <time
+            dateTime={item.date}
+            className="text-sm text-slate-500 dark:text-slate-400"
+          >
+            {fmt(item.date)}
+          </time>
+          <h2 className="mt-1 text-lg font-semibold">
+            <a href={item.href} className="hover:underline">
+              {item.title}
+            </a>
+          </h2>
+          <div className="mt-1 flex flex-wrap gap-2 text-xs">
+            <span className="rounded bg-slate-100 px-2 py-0.5 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+              {item.badge}
+            </span>
+            {item.tags.map((t) => (
+              <span
+                key={t}
+                className="rounded bg-slate-50 px-2 py-0.5 text-slate-600 dark:bg-slate-900 dark:text-slate-400"
+              >
+                #{t}
+              </span>
+            ))}
+          </div>
+          {item.description && (
+            <p className="mt-2 text-slate-700 dark:text-slate-300">
+              {item.description}
+            </p>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/components/TimelineList.tsx
+++ b/src/components/TimelineList.tsx
@@ -9,6 +9,7 @@ function fmt(isoDate: string): string {
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone: "UTC",
   });
 }
 

--- a/src/components/TimelineWithFilter.tsx
+++ b/src/components/TimelineWithFilter.tsx
@@ -12,22 +12,31 @@ type Props = {
 export default function TimelineWithFilter({ items, orgs }: Props) {
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(null);
 
-  // Read ?org= from URL on mount
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const org = params.get("org");
-    if (org) {
-      setSelectedOrgId(org);
+    function resolveOrg(): string | null {
+      const params = new URLSearchParams(window.location.search);
+      const org = params.get("org");
+      return org && orgs.some((o) => o.id === org) ? org : null;
     }
-  }, []);
+
+    const initial = resolveOrg();
+    setSelectedOrgId(initial);
+    const raw = new URLSearchParams(window.location.search).get("org");
+    if (raw && !initial) {
+      history.replaceState({}, "", window.location.pathname);
+    }
+
+    function onPopState() {
+      setSelectedOrgId(resolveOrg());
+    }
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [orgs]);
 
   function handleSelect(orgId: string | null) {
     setSelectedOrgId(orgId);
-    if (orgId !== null) {
-      history.replaceState({}, "", "?org=" + orgId);
-    } else {
-      history.replaceState({}, "", window.location.pathname);
-    }
+    const url = orgId !== null ? "?org=" + orgId : window.location.pathname;
+    history.pushState({}, "", url);
   }
 
   const filteredItems = useMemo(

--- a/src/components/TimelineWithFilter.tsx
+++ b/src/components/TimelineWithFilter.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect, useMemo } from "react";
+import type { TimelineItem, OrgOption } from "../lib/timeline";
+import { filterByOrg } from "../lib/timeline";
+import OrgFilter from "./OrgFilter";
+import TimelineList from "./TimelineList";
+
+type Props = {
+  items: TimelineItem[];
+  orgs: OrgOption[];
+};
+
+export default function TimelineWithFilter({ items, orgs }: Props) {
+  const [selectedOrgId, setSelectedOrgId] = useState<string | null>(null);
+
+  // Read ?org= from URL on mount
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const org = params.get("org");
+    if (org) {
+      setSelectedOrgId(org);
+    }
+  }, []);
+
+  function handleSelect(orgId: string | null) {
+    setSelectedOrgId(orgId);
+    if (orgId !== null) {
+      history.replaceState({}, "", "?org=" + orgId);
+    } else {
+      history.replaceState({}, "", window.location.pathname);
+    }
+  }
+
+  const filteredItems = useMemo(
+    () => filterByOrg(items, selectedOrgId),
+    [items, selectedOrgId],
+  );
+
+  return (
+    <>
+      <OrgFilter orgs={orgs} selected={selectedOrgId} onSelect={handleSelect} />
+      <TimelineList items={filteredItems} />
+    </>
+  );
+}

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -1,0 +1,25 @@
+export type TimelineItem = {
+  id: string;
+  kind: "event" | "artifact";
+  title: string;
+  date: string; // ISO string — sorted in Astro before passing
+  description?: string;
+  tags: string[];
+  href: string;
+  badge: string;
+  orgIds: string[]; // flattened org IDs for filtering
+};
+
+export type OrgOption = {
+  id: string;
+  label: string; // short_name ?? name
+  count: number; // pre-counted items referencing this org
+};
+
+export function filterByOrg(
+  items: TimelineItem[],
+  orgId: string | null,
+): TimelineItem[] {
+  if (!orgId) return items;
+  return items.filter((i) => i.orgIds.includes(orgId));
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,50 +1,64 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import TimelineWithFilter from "../components/TimelineWithFilter";
+import type { TimelineItem, OrgOption } from "../lib/timeline";
 
 const events = await getCollection("events");
 const artifacts = await getCollection("artifacts");
+const organizations = await getCollection("organizations");
 
-type TimelineItem = {
-  id: string;
-  kind: "event" | "artifact";
-  title: string;
-  date: Date;
-  description?: string;
-  tags: string[];
-  href: string;
-  badge: string;
-};
+// Build org lookup map: id -> { name, short_name }
+const orgMap = new Map<string, { name: string; short_name?: string }>();
+for (const org of organizations) {
+  orgMap.set(org.id, { name: org.data.name, short_name: org.data.short_name });
+}
 
 const items: TimelineItem[] = [
   ...events.map((e) => ({
     id: e.id,
     kind: "event" as const,
     title: e.data.title,
-    date: e.data.date,
+    date: e.data.date.toISOString(),
     description: e.data.description,
     tags: e.data.tags,
     href: `/events/${e.id}/`,
     badge: e.data.type,
+    orgIds: e.data.organizations.map((o) => o.id.id),
   })),
   ...artifacts.map((a) => ({
     id: a.id,
     kind: "artifact" as const,
     title: a.data.title,
-    date: a.data.published_date,
+    date: a.data.published_date.toISOString(),
     description: a.data.description,
     tags: a.data.tags,
     href: `/artifacts/${a.id}/`,
     badge: a.data.type,
+    orgIds: a.data.organizations.map((o) => o.id.id),
   })),
-].sort((a, b) => b.date.getTime() - a.date.getTime());
+].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
-const fmt = (d: Date) =>
-  d.toLocaleDateString("en-CA", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
+// Build OrgOption list: only orgs that appear in at least one item
+const orgCounts = new Map<string, number>();
+for (const item of items) {
+  for (const orgId of item.orgIds) {
+    orgCounts.set(orgId, (orgCounts.get(orgId) ?? 0) + 1);
+  }
+}
+
+const orgs: OrgOption[] = [];
+for (const [orgId, count] of orgCounts.entries()) {
+  const org = orgMap.get(orgId);
+  if (!org) continue;
+  orgs.push({
+    id: orgId,
+    label: org.short_name ?? org.name,
+    count,
   });
+}
+// Sort orgs by count descending, then label ascending
+orgs.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
 ---
 
 <BaseLayout
@@ -56,39 +70,5 @@ const fmt = (d: Date) =>
     Canadian AI governance and policy events, reports, and government action.
   </p>
 
-  <ol class="mt-10 space-y-8 border-l border-slate-200 dark:border-slate-800">
-    {
-      items.map((item) => (
-        <li class="relative pl-6">
-          <span class="absolute -left-[5px] top-2 h-2.5 w-2.5 rounded-full bg-slate-400 dark:bg-slate-600" />
-          <time
-            datetime={item.date.toISOString()}
-            class="text-sm text-slate-500 dark:text-slate-400"
-          >
-            {fmt(item.date)}
-          </time>
-          <h2 class="mt-1 text-lg font-semibold">
-            <a href={item.href} class="hover:underline">
-              {item.title}
-            </a>
-          </h2>
-          <div class="mt-1 flex flex-wrap gap-2 text-xs">
-            <span class="rounded bg-slate-100 px-2 py-0.5 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
-              {item.badge}
-            </span>
-            {item.tags.map((t) => (
-              <span class="rounded bg-slate-50 px-2 py-0.5 text-slate-600 dark:bg-slate-900 dark:text-slate-400">
-                #{t}
-              </span>
-            ))}
-          </div>
-          {item.description && (
-            <p class="mt-2 text-slate-700 dark:text-slate-300">
-              {item.description}
-            </p>
-          )}
-        </li>
-      ))
-    }
-  </ol>
+  <TimelineWithFilter client:load items={items} orgs={orgs} />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Adds an `OrgFilter` component and wires it into the timeline via a new `TimelineWithFilter` wrapper
- Introduces `src/lib/timeline.ts` to centralize filtering logic
- Refactors `src/pages/index.astro` to use the new filter-aware timeline
- Post-review fixes (329ef87): URL param validation, Back/Forward sync via pushState + popstate, ARIA attributes on filter pills, UTC-pinned date formatting

## Test plan
- [ ] Load the timeline and confirm all events render when no org is selected
- [ ] Select each org in the filter and confirm only matching events remain
- [ ] Clear the filter and confirm all events return
- [ ] Check that non-event records (e.g. artifacts) still display correctly

### Manual smoke tests for review fixes (not covered by build)
- [ ] **Back/Forward sync:** Click an org filter, then browser Back — filter should clear and URL should return to `/`. Click Forward — filter should reapply from `?org=<id>`.
- [ ] **Invalid `?org=`:** Visit `/?org=bogus-id` directly — UI should show all items (no filter active) and the URL should be cleaned to `/`.
- [ ] **ARIA / keyboard:** Tab through filter pills, confirm active pill is announced as pressed (VoiceOver / screen reader), and that `type="button"` prevents any form-submission surprises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)