### PR TITLE
Add Playwright e2e tests + CI job (PR 2 of issue #5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,39 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm test
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - run: pnpm test:e2e
+
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 .DS_Store
 .claude/settings.local.json
 CLAUDE.local.md
+playwright-report/
+test-results/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ pnpm test:watch    # re-run on file changes
 
 Tests live alongside the source files they cover (`foo.test.ts` next to `foo.ts`).
 
+### End-to-end tests
+
+Browser tests run with [Playwright](https://playwright.dev/) against the production build.
+
+```bash
+pnpm test:e2e              # build + run all e2e tests
+pnpm exec playwright test  # skip the build (assumes dist/ is fresh)
+```
+
+The HTML report lands in `playwright-report/` (gitignored). Specs live in `e2e/`.
+
 ## License
 
 This project uses a dual license:

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test("homepage has no axe-detectable a11y violations", async ({ page }) => {
+  await page.goto("/");
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});

--- a/e2e/timeline.spec.ts
+++ b/e2e/timeline.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+const CIGI_ID = "cigi-global-ai-risks-initiative";
+
+test.describe("timeline", () => {
+  test("homepage loads and renders timeline items", async ({ page }) => {
+    await page.goto("/");
+    const items = page.locator("ol > li");
+    await expect(items.first()).toBeVisible();
+    expect(await items.count()).toBeGreaterThan(0);
+  });
+
+  test("clicking an org pill narrows the list and updates the URL", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const initialCount = await page.locator("ol > li").count();
+
+    await page.getByRole("button", { name: /CIGI/ }).click();
+
+    await expect(page).toHaveURL(new RegExp(`\\?org=${CIGI_ID}$`));
+    const filteredCount = await page.locator("ol > li").count();
+    expect(filteredCount).toBeLessThan(initialCount);
+    expect(filteredCount).toBeGreaterThan(0);
+  });
+
+  test("browser Back restores the previous filter state", async ({ page }) => {
+    await page.goto("/");
+    const initialCount = await page.locator("ol > li").count();
+
+    await page.getByRole("button", { name: /CIGI/ }).click();
+    await expect(page).toHaveURL(new RegExp(`\\?org=${CIGI_ID}$`));
+
+    await page.goBack();
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByRole("button", { name: "All" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(await page.locator("ol > li").count()).toBe(initialCount);
+  });
+
+  test("invalid ?org= shows all items and cleans the URL", async ({ page }) => {
+    await page.goto("/?org=bogus-xyz");
+
+    await expect(page).toHaveURL(/\/$/);
+    const items = page.locator("ol > li");
+    expect(await items.count()).toBeGreaterThan(0);
+    await expect(page.getByRole("button", { name: "All" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+});

--- a/e2e/timeline.spec.ts
+++ b/e2e/timeline.spec.ts
@@ -1,11 +1,19 @@
 import { test, expect } from "@playwright/test";
 
 const CIGI_ID = "cigi-global-ai-risks-initiative";
+const CIGI_EVENT_TITLE = /AI National Security Scenarios Workshop/i;
+const NON_CIGI_EVENT_TITLE = /INDU Meeting 27/i;
+
+function timelineItems(page: import("@playwright/test").Page) {
+  return page
+    .getByRole("list", { name: /timeline/i })
+    .getByRole("listitem");
+}
 
 test.describe("timeline", () => {
   test("homepage loads and renders timeline items", async ({ page }) => {
     await page.goto("/");
-    const items = page.locator("ol > li");
+    const items = timelineItems(page);
     await expect(items.first()).toBeVisible();
     expect(await items.count()).toBeGreaterThan(0);
   });
@@ -14,19 +22,23 @@ test.describe("timeline", () => {
     page,
   }) => {
     await page.goto("/");
-    const initialCount = await page.locator("ol > li").count();
+    const initialCount = await timelineItems(page).count();
 
     await page.getByRole("button", { name: /CIGI/ }).click();
 
     await expect(page).toHaveURL(new RegExp(`\\?org=${CIGI_ID}$`));
-    const filteredCount = await page.locator("ol > li").count();
+    await expect(page.getByRole("heading", { name: CIGI_EVENT_TITLE })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: NON_CIGI_EVENT_TITLE }),
+    ).toHaveCount(0);
+
+    const filteredCount = await timelineItems(page).count();
     expect(filteredCount).toBeLessThan(initialCount);
-    expect(filteredCount).toBeGreaterThan(0);
   });
 
   test("browser Back restores the previous filter state", async ({ page }) => {
     await page.goto("/");
-    const initialCount = await page.locator("ol > li").count();
+    const initialCount = await timelineItems(page).count();
 
     await page.getByRole("button", { name: /CIGI/ }).click();
     await expect(page).toHaveURL(new RegExp(`\\?org=${CIGI_ID}$`));
@@ -38,15 +50,14 @@ test.describe("timeline", () => {
       "aria-pressed",
       "true",
     );
-    expect(await page.locator("ol > li").count()).toBe(initialCount);
+    expect(await timelineItems(page).count()).toBe(initialCount);
   });
 
   test("invalid ?org= shows all items and cleans the URL", async ({ page }) => {
     await page.goto("/?org=bogus-xyz");
 
     await expect(page).toHaveURL(/\/$/);
-    const items = page.locator("ol > li");
-    expect(await items.count()).toBeGreaterThan(0);
+    expect(await timelineItems(page).count()).toBeGreaterThan(0);
     await expect(page.getByRole("button", { name: "All" })).toHaveAttribute(
       "aria-pressed",
       "true",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "astro build && playwright test"
   },
   "dependencies": {
     "@astrojs/react": "^4.2.1",
@@ -25,6 +26,8 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "e2e",
+  forbidOnly: !!process.env.CI,
+  reporter: [["html"]],
+  use: {
+    baseURL: "http://localhost:4321",
+  },
+  webServer: {
+    command: "pnpm preview",
+    url: "http://localhost:4321",
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,12 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.2
+        version: 4.11.2(playwright-core@1.59.1)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -88,6 +94,11 @@ packages:
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@axe-core/playwright@4.11.2':
+    resolution: {integrity: sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -679,6 +690,11 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1123,6 +1139,10 @@ packages:
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
+  axe-core@4.11.3:
+    resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
+    engines: {node: '>=4'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1411,6 +1431,11 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1875,6 +1900,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -2481,6 +2516,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@axe-core/playwright@4.11.2(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.3
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -2889,6 +2929,10 @@ snapshots:
       fastq: 1.20.1
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3370,6 +3414,8 @@ snapshots:
       - uploadthing
       - yaml
 
+  axe-core@4.11.3: {}
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -3653,6 +3699,9 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -4300,6 +4349,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.10:
     dependencies:

--- a/src/components/TimelineList.tsx
+++ b/src/components/TimelineList.tsx
@@ -23,7 +23,10 @@ export default function TimelineList({ items }: Props) {
   }
 
   return (
-    <ol className="mt-10 space-y-8 border-l border-slate-200 dark:border-slate-800">
+    <ol
+      aria-label="Timeline"
+      className="mt-10 space-y-8 border-l border-slate-200 dark:border-slate-800"
+    >
       {items.map((item) => (
         <li key={item.id} className="relative pl-6">
           <span className="absolute -left-[5px] top-2 h-2.5 w-2.5 rounded-full bg-slate-400 dark:bg-slate-600" />

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: "happy-dom",
     globals: true,
     setupFiles: ["src/test/setup.ts"],
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
   },
 });


### PR DESCRIPTION
Closes #5. Second and final PR in the testing rollout.

## Summary

- Adds `@playwright/test` + `@axe-core/playwright`, chromium-only.
- 5 e2e tests under `e2e/`:
  - 4 timeline behaviors: homepage loads, filter narrows list + updates URL, Back restores state, invalid `?org=` cleans URL
  - 1 axe accessibility scan of the homepage
- `playwright.config.ts` auto-starts `pnpm preview` via `webServer` (no shell juggling locally or in CI).
- `vitest.config.ts` excludes `e2e/**` so the two runners don't clash.
- New `e2e` GitHub Actions job runs in parallel with the existing `unit` job, caches browser binaries keyed on the lockfile, uploads `playwright-report/` on failure.
- README documents `pnpm test:e2e`.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-22-playwright-e2e-design.md`
- Plan: `docs/superpowers/plans/2026-04-22-playwright-e2e.md`

## Test plan

- [ ] Local `pnpm test:e2e` reports 5 passing (not run in the authoring sandbox — macOS `sandbox-exec` blocks chromium Mach port rendezvous; CI is the first real execution)
- [ ] `pnpm test` still reports 7 passing (Vitest after exclude)
- [ ] `Test / unit` GitHub Actions check green
- [ ] `Test / e2e` GitHub Actions check green
- [ ] If `e2e` fails, download the `playwright-report` artifact from the run summary and inspect

## Notes

- Explicitly skipped the "no hydration mismatch" smoke test from the original issue. `astro preview` serves the production bundle which doesn't emit hydration warnings, and the PR #4 timezone fix already made dates deterministic. The remaining five tests cover the real regressions.
- After this lands: write a testing-stack ADR under `docs/adr/` distilling the two PR specs (Vitest + Playwright + CI) into a single architectural record.
