### PR TITLE
Add Bill C-27 / AIDA to the tracker

### DIFF
--- a/data/artifacts/2022-06-16-bill-c27-aida.yaml
+++ b/data/artifacts/2022-06-16-bill-c27-aida.yaml
@@ -1,0 +1,145 @@
+# artifacts/2022-06-16-bill-c27-aida.yaml
+
+id: bill-c27-aida
+type: Legislation
+schema_type: CreativeWork
+
+title: "Bill C-27 — Digital Charter Implementation Act, 2022 (including AIDA)"
+published_date: 2022-06-16  # introduction / first reading date
+
+lifecycle_status: died
+current_stage: "Died on the Order Paper at committee stage (INDU) on prorogation, 6 January 2025"
+
+organizations:
+  - id: house-of-commons-indu-committee
+    role: reviewed_by
+
+description: >
+  The Digital Charter Implementation Act, 2022 bundled three components: the
+  Consumer Privacy Protection Act, the Personal Information and Data Protection
+  Tribunal Act, and the Artificial Intelligence and Data Act (AIDA) — Canada's
+  first proposed federal AI-specific legislation.
+
+  AIDA would have regulated "high-impact" AI systems used in interprovincial
+  and international trade, created an AI and Data Commissioner within ISED,
+  and imposed obligations across the AI lifecycle. High-impact systems were
+  to be defined by risk factors including potential for health/safety harm,
+  human rights impacts, scale of use, severity of potential harms, and the
+  extent to which users could opt out. Examples cited in the ISED companion
+  document included hiring systems, biometric identification tools, behavioural
+  influence systems, and autonomous vehicles.
+
+  The bill was referred to the Standing Committee on Industry and Technology
+  (INDU) after second reading in April 2023 and remained there through the
+  end of the 44th Parliament. The committee paused clause-by-clause
+  consideration on 29 May 2024, met once more on 26 September 2024, and on
+  21 November 2024 confirmed the study would remain paused until at least
+  February 2025. Parliament was prorogued on 6 January 2025, killing the
+  bill before it reached report stage, third reading, or the Senate.
+
+stages:
+  - date: 2022-06-16
+    stage: "Introduction and first reading"
+    note: "Bill C-27 introduced in the House of Commons."
+  - date: 2022-11-04
+    stage: "Second reading debate begins"
+  - date: 2023-04-24
+    stage: "Second reading passed; referred to INDU"
+    note: "Passed on two separate votes (300: 205–109; 301: 203–112)."
+  - date: 2023-09-26
+    stage: "INDU study begins"
+    links:
+      - label: "Michael Geist — Why Minister Champagne broke the Bill C-27 hearings on privacy and AI regulation in only 12 minutes"
+        url: https://www.michaelgeist.ca/2023/09/why-industry-minister-champagne-broke-the-bill-c-27-hearings-on-privacy-and-ai-regulation-in-only-12-minutes/
+        icon: document
+  - date: 2023-11-28
+    stage: "Minister tables proposed AIDA amendments"
+    note: "Minister Champagne submits a letter to INDU with proposed amendments to AIDA."
+  - date: 2024-05-29
+    stage: "Clause-by-clause consideration pauses"
+    note: "Meeting 126 — last clause-by-clause session before a summer pause."
+  - date: 2024-09-26
+    stage: "Last INDU meeting on C-27"
+    note: "Meeting 136 — committee study not completed."
+  - date: 2024-11-21
+    stage: "INDU confirms study will remain paused"
+    note: "Committee confirms the study will remain paused until at least February 2025."
+  - date: 2025-01-06
+    stage: "Died on the Order Paper"
+    note: "Parliament prorogued; Bill C-27 dies along with all other legislation on the Order Paper."
+
+provisions:
+  - id: high-impact-scope
+    title: "Scope: high-impact AI systems"
+    summary: >
+      Apply obligations to "high-impact" AI systems used in interprovincial
+      or international trade, defined by risk factors including potential for
+      health/safety harm, human rights impacts, scale of use, severity of
+      potential harms, and the extent to which users cannot opt out.
+  - id: human-oversight
+    title: "Human oversight and monitoring"
+    summary: >
+      Require mechanisms for meaningful human oversight of high-impact AI
+      systems across their lifecycle.
+  - id: transparency
+    title: "Transparency"
+    summary: >
+      Require plain-language disclosures about the AI system's purpose,
+      intended use, content it generates, and its limitations.
+  - id: fairness
+    title: "Fairness and non-discrimination"
+    summary: >
+      Require measures to identify and mitigate biased outputs and
+      discriminatory impacts.
+  - id: safety
+    title: "Safety"
+    summary: >
+      Require risk identification and mitigation so that reasonably
+      foreseeable uses do not create unreasonable risks of harm.
+  - id: accountability
+    title: "Accountability"
+    summary: >
+      Require governance mechanisms (policies, processes, documentation)
+      ensuring legal obligations are met across the AI lifecycle.
+  - id: robustness
+    title: "Validity and robustness"
+    summary: >
+      Require systems to perform consistently as intended under a range of
+      conditions.
+  - id: ai-data-commissioner
+    title: "AI and Data Commissioner"
+    summary: >
+      Establish an AI and Data Commissioner within ISED to administer and
+      enforce AIDA, separate from criminal prosecution handled by the Public
+      Prosecution Service.
+  - id: enforcement-tiers
+    title: "Tiered enforcement"
+    summary: >
+      Education and voluntary compliance first; administrative monetary
+      penalties and regulatory offences for non-compliance; criminal offences
+      for knowing or reckless conduct causing serious harm.
+
+links:
+  - label: "LEGISinfo — Bill C-27"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document
+  - label: "AIDA companion document (ISED)"
+    url: https://ised-isde.canada.ca/site/innovation-better-canada/en/artificial-intelligence-and-data-act-aida-companion-document
+    icon: document
+  - label: "ISED — Artificial Intelligence and Data Act page"
+    url: https://ised-isde.canada.ca/site/innovation-better-canada/en/artificial-intelligence-and-data-act
+    icon: document
+  - label: "INDU — Bill C-27 study activity"
+    url: https://www.ourcommons.ca/committees/en/INDU/StudyActivity?studyActivityId=12157763
+    icon: document
+  - label: "Charter Statement (Justice Canada)"
+    url: https://www.justice.gc.ca/eng/csj-sjc/pl/charter-charte/c27_1.html
+    icon: document
+
+tags:
+  - bill-c-27
+  - aida
+  - digital-charter-implementation-act
+  - federal-government
+  - high-impact-ai-systems
+  - ai-data-commissioner

--- a/data/events/2022-06-16-bill-c27-introduced.yaml
+++ b/data/events/2022-06-16-bill-c27-introduced.yaml
@@ -1,0 +1,31 @@
+# events/2022-06-16-bill-c27-introduced.yaml
+
+id: bill-c27-introduced-2022
+type: LegislativeAction
+schema_type: Event
+
+title: "Bill C-27 introduced in the House of Commons (first reading)"
+date: 2022-06-16
+
+status: completed
+
+description: >
+  The Digital Charter Implementation Act, 2022 (Bill C-27) is introduced and
+  receives first reading in the House of Commons. The bill bundles three
+  components: the Consumer Privacy Protection Act, the Personal Information
+  and Data Protection Tribunal Act, and the Artificial Intelligence and Data
+  Act (AIDA) — the first proposed federal AI-specific legislation in Canada.
+
+related_artifacts:
+  - id: bill-c27-aida
+
+tags:
+  - bill-c-27
+  - aida
+  - federal-government
+  - house-of-commons
+
+links:
+  - label: "LEGISinfo — Bill C-27"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document

--- a/data/events/2025-01-06-parliament-prorogued-44-1.yaml
+++ b/data/events/2025-01-06-parliament-prorogued-44-1.yaml
@@ -1,0 +1,31 @@
+# events/2025-01-06-parliament-prorogued-44-1.yaml
+
+id: parliament-prorogued-44-1-2025
+type: PoliticalEvent
+schema_type: Event
+
+title: "Parliament prorogued — Bill C-27 dies on the Order Paper"
+date: 2025-01-06
+
+status: completed
+
+description: >
+  Prime Minister Justin Trudeau announces his resignation and Parliament is
+  prorogued by proclamation of the Governor General. All legislation on the
+  Order Paper, including Bill C-27 (and with it AIDA), dies. INDU's
+  clause-by-clause study of the bill ceases.
+
+related_artifacts:
+  - id: bill-c27-aida
+
+tags:
+  - prorogation
+  - parliament
+  - bill-c-27
+  - aida
+  - federal-government
+
+links:
+  - label: "LEGISinfo — Bill C-27 (final status)"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document

--- a/docs/superpowers/plans/2026-04-23-bill-c27-aida.md
+++ b/docs/superpowers/plans/2026-04-23-bill-c27-aida.md
@@ -1,0 +1,468 @@
+# Bill C-27 / AIDA Data Entry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Bill C-27 (with the AIDA portion) to the tracker as one artifact plus two headline events (introduction and prorogation), and extend the artifact schema with the fields needed to model a legislative lifecycle.
+
+**Architecture:** Per the approved spec (`docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md`), the bill is represented as a single Astro content-collection artifact with an embedded `stages` array covering the full legislative journey. Only two moments — introduction (2022-06-16) and prorogation (2025-01-06) — are created as standalone events. The artifacts schema in `src/content.config.ts` gains four optional fields: `lifecycle_status`, `current_stage`, `stages`, `provisions`. No runtime code changes; validation is enforced by Astro's content collections at build time.
+
+**Tech Stack:** Astro 5 content collections, Zod schemas, YAML data files, Vitest + Playwright for verification.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md`
+
+---
+
+## File Structure
+
+**Files to create:**
+- `data/artifacts/2022-06-16-bill-c27-aida.yaml` — the bill/AIDA artifact (summary, stages, provisions, links)
+- `data/events/2022-06-16-bill-c27-introduced.yaml` — first-reading event
+- `data/events/2025-01-06-parliament-prorogued-44-1.yaml` — prorogation event
+
+**Files to modify:**
+- `src/content.config.ts` — extend the `artifacts` collection schema
+
+**Files to read (context only):**
+- `src/content.config.ts` — current artifact schema
+- `data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml` — existing artifact format
+- `data/events/2026-03-09-indu-ai-strategic-industries-meeting-27.yaml` — existing event format
+
+**How we verify:** Astro's content collections validate every YAML file against the Zod schema at build time. `npm run build` is our primary test — any schema mismatch, missing reference, or malformed YAML will fail the build with a precise error. `npm test` runs existing unit tests to confirm no regressions. `npm run test:e2e` runs Playwright to confirm the timeline page still renders.
+
+---
+
+## Task 1: Extend the artifacts schema
+
+**Files:**
+- Modify: `src/content.config.ts` (inside the `artifacts = defineCollection({ ... })` schema block, currently around lines 44–79)
+
+**Why first:** The new YAML files use fields (`lifecycle_status`, `current_stage`, `stages`, `provisions`) that don't exist in the current schema. If we write the YAML first, `astro sync` / build would reject them. Schema must land before data.
+
+- [ ] **Step 1: Read the current schema**
+
+Read `src/content.config.ts` end-to-end. The artifacts schema is the `defineCollection` call after the `events` collection. Confirm the existing fields before editing: `id`, `type`, `schema_type`, `title`, `published_date`, `description`, `organizations`, `derives_from`, `links`, `policy_recommendations`, `tags`.
+
+- [ ] **Step 2: Add the four new optional fields to the artifacts schema**
+
+Inside the `z.object({ ... })` passed to `defineCollection` for the `artifacts` collection, add these four fields. Put them immediately after the existing `description` field (between `description` and `organizations`) so related content (the bill's status and substance) sits together:
+
+```ts
+    lifecycle_status: z
+      .enum(["active", "enacted", "died", "withdrawn"])
+      .optional(),
+    current_stage: z.string().optional(),
+    stages: z
+      .array(
+        z.object({
+          date: z.coerce.date(),
+          stage: z.string(),
+          note: z.string().optional(),
+          links: z.array(linkSchema).default([]),
+        }),
+      )
+      .default([]),
+    provisions: z
+      .array(
+        z.object({
+          id: z.string(),
+          title: z.string(),
+          summary: z.string(),
+        }),
+      )
+      .default([]),
+```
+
+All four are optional or default to an empty array — existing artifact records continue to validate unchanged.
+
+- [ ] **Step 3: Run the TypeScript / Astro sync check**
+
+Run: `npx astro sync`
+Expected: Completes without errors, regenerating types in `.astro/`.
+
+- [ ] **Step 4: Run the existing unit tests to confirm no regression**
+
+Run: `npm test`
+Expected: All existing tests pass (OrgFilter tests and any others). No failures.
+
+- [ ] **Step 5: Run the build to confirm existing content still validates**
+
+Run: `npm run build`
+Expected: Build completes successfully. All existing YAML under `data/` validates against the (now-extended) schema.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/content.config.ts
+git commit -m "Extend artifacts schema with lifecycle_status, current_stage, stages, provisions"
+```
+
+---
+
+## Task 2: Create the Bill C-27 / AIDA artifact
+
+**Files:**
+- Create: `data/artifacts/2022-06-16-bill-c27-aida.yaml`
+
+- [ ] **Step 1: Create the artifact file with the exact content below**
+
+Write the following YAML to `data/artifacts/2022-06-16-bill-c27-aida.yaml`:
+
+```yaml
+# artifacts/2022-06-16-bill-c27-aida.yaml
+
+id: bill-c27-aida
+type: Legislation
+schema_type: CreativeWork
+
+title: "Bill C-27 — Digital Charter Implementation Act, 2022 (including AIDA)"
+published_date: 2022-06-16  # introduction / first reading date
+
+lifecycle_status: died
+current_stage: "Died on the Order Paper at committee stage (INDU) on prorogation, 6 January 2025"
+
+organizations:
+  - id: house-of-commons-indu-committee
+    role: reviewed_by
+
+description: >
+  The Digital Charter Implementation Act, 2022 bundled three components: the
+  Consumer Privacy Protection Act, the Personal Information and Data Protection
+  Tribunal Act, and the Artificial Intelligence and Data Act (AIDA) — Canada's
+  first proposed federal AI-specific legislation.
+
+  AIDA would have regulated "high-impact" AI systems used in interprovincial
+  and international trade, created an AI and Data Commissioner within ISED,
+  and imposed obligations across the AI lifecycle. High-impact systems were
+  to be defined by risk factors including potential for health/safety harm,
+  human rights impacts, scale of use, severity of potential harms, and the
+  extent to which users could opt out. Examples cited in the ISED companion
+  document included hiring systems, biometric identification tools, behavioural
+  influence systems, and autonomous vehicles.
+
+  The bill was referred to the Standing Committee on Industry and Technology
+  (INDU) after second reading in April 2023 and remained there through the
+  end of the 44th Parliament. The committee paused clause-by-clause
+  consideration on 29 May 2024, met once more on 26 September 2024, and on
+  21 November 2024 confirmed the study would remain paused until at least
+  February 2025. Parliament was prorogued on 6 January 2025, killing the
+  bill before it reached report stage, third reading, or the Senate.
+
+stages:
+  - date: 2022-06-16
+    stage: "Introduction and first reading"
+    note: "Bill C-27 introduced in the House of Commons."
+  - date: 2022-11-04
+    stage: "Second reading debate begins"
+  - date: 2023-04-24
+    stage: "Second reading passed; referred to INDU"
+    note: "Passed on two separate votes (300: 205–109; 301: 203–112)."
+  - date: 2023-09-26
+    stage: "INDU study begins"
+    links:
+      - label: "Michael Geist — Why Minister Champagne broke the Bill C-27 hearings on privacy and AI regulation in only 12 minutes"
+        url: https://www.michaelgeist.ca/2023/09/why-industry-minister-champagne-broke-the-bill-c-27-hearings-on-privacy-and-ai-regulation-in-only-12-minutes/
+        icon: document
+  - date: 2023-11-28
+    stage: "Minister tables proposed AIDA amendments"
+    note: "Minister Champagne submits a letter to INDU with proposed amendments to AIDA."
+  - date: 2024-05-29
+    stage: "Clause-by-clause consideration pauses"
+    note: "Meeting 126 — last clause-by-clause session before a summer pause."
+  - date: 2024-09-26
+    stage: "Last INDU meeting on C-27"
+    note: "Meeting 136 — committee study not completed."
+  - date: 2024-11-21
+    stage: "INDU confirms study will remain paused"
+    note: "Committee confirms the study will remain paused until at least February 2025."
+  - date: 2025-01-06
+    stage: "Died on the Order Paper"
+    note: "Parliament prorogued; Bill C-27 dies along with all other legislation on the Order Paper."
+
+provisions:
+  - id: high-impact-scope
+    title: "Scope: high-impact AI systems"
+    summary: >
+      Apply obligations to "high-impact" AI systems used in interprovincial
+      or international trade, defined by risk factors including potential for
+      health/safety harm, human rights impacts, scale of use, severity of
+      potential harms, and the extent to which users cannot opt out.
+  - id: human-oversight
+    title: "Human oversight and monitoring"
+    summary: >
+      Require mechanisms for meaningful human oversight of high-impact AI
+      systems across their lifecycle.
+  - id: transparency
+    title: "Transparency"
+    summary: >
+      Require plain-language disclosures about the AI system's purpose,
+      intended use, content it generates, and its limitations.
+  - id: fairness
+    title: "Fairness and non-discrimination"
+    summary: >
+      Require measures to identify and mitigate biased outputs and
+      discriminatory impacts.
+  - id: safety
+    title: "Safety"
+    summary: >
+      Require risk identification and mitigation so that reasonably
+      foreseeable uses do not create unreasonable risks of harm.
+  - id: accountability
+    title: "Accountability"
+    summary: >
+      Require governance mechanisms (policies, processes, documentation)
+      ensuring legal obligations are met across the AI lifecycle.
+  - id: robustness
+    title: "Validity and robustness"
+    summary: >
+      Require systems to perform consistently as intended under a range of
+      conditions.
+  - id: ai-data-commissioner
+    title: "AI and Data Commissioner"
+    summary: >
+      Establish an AI and Data Commissioner within ISED to administer and
+      enforce AIDA, separate from criminal prosecution handled by the Public
+      Prosecution Service.
+  - id: enforcement-tiers
+    title: "Tiered enforcement"
+    summary: >
+      Education and voluntary compliance first; administrative monetary
+      penalties and regulatory offences for non-compliance; criminal offences
+      for knowing or reckless conduct causing serious harm.
+
+links:
+  - label: "LEGISinfo — Bill C-27"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document
+  - label: "AIDA companion document (ISED)"
+    url: https://ised-isde.canada.ca/site/innovation-better-canada/en/artificial-intelligence-and-data-act-aida-companion-document
+    icon: document
+  - label: "ISED — Artificial Intelligence and Data Act page"
+    url: https://ised-isde.canada.ca/site/innovation-better-canada/en/artificial-intelligence-and-data-act
+    icon: document
+  - label: "INDU — Bill C-27 study activity"
+    url: https://www.ourcommons.ca/committees/en/INDU/StudyActivity?studyActivityId=12157763
+    icon: document
+  - label: "Charter Statement (Justice Canada)"
+    url: https://www.justice.gc.ca/eng/csj-sjc/pl/charter-charte/c27_1.html
+    icon: document
+
+tags:
+  - bill-c-27
+  - aida
+  - digital-charter-implementation-act
+  - federal-government
+  - high-impact-ai-systems
+  - ai-data-commissioner
+```
+
+- [ ] **Step 2: Verify the artifact validates against the schema**
+
+Run: `npx astro sync`
+Expected: Completes without errors. If it fails, the error message will point to the offending field in the YAML.
+
+- [ ] **Step 3: Run the full build to confirm everything validates and renders**
+
+Run: `npm run build`
+Expected: Build succeeds. The artifact is now part of the content collection.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/artifacts/2022-06-16-bill-c27-aida.yaml
+git commit -m "Add Bill C-27 / AIDA artifact with stages and provisions"
+```
+
+---
+
+## Task 3: Create the introduction event
+
+**Files:**
+- Create: `data/events/2022-06-16-bill-c27-introduced.yaml`
+
+- [ ] **Step 1: Create the event file with the exact content below**
+
+Write the following YAML to `data/events/2022-06-16-bill-c27-introduced.yaml`:
+
+```yaml
+# events/2022-06-16-bill-c27-introduced.yaml
+
+id: bill-c27-introduced-2022
+type: LegislativeAction
+schema_type: Event
+
+title: "Bill C-27 introduced in the House of Commons (first reading)"
+date: 2022-06-16
+
+status: completed
+
+description: >
+  The Digital Charter Implementation Act, 2022 (Bill C-27) is introduced and
+  receives first reading in the House of Commons. The bill bundles three
+  components: the Consumer Privacy Protection Act, the Personal Information
+  and Data Protection Tribunal Act, and the Artificial Intelligence and Data
+  Act (AIDA) — the first proposed federal AI-specific legislation in Canada.
+
+related_artifacts:
+  - id: bill-c27-aida
+
+tags:
+  - bill-c-27
+  - aida
+  - federal-government
+  - house-of-commons
+
+links:
+  - label: "LEGISinfo — Bill C-27"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document
+```
+
+Note: per the approved spec (design decision: introduction event does not list INDU), the `organizations` field is omitted. It defaults to `[]`. Strictly, INDU only became involved after second reading.
+
+- [ ] **Step 2: Verify the event validates and the `related_artifacts` reference resolves**
+
+Run: `npx astro sync`
+Expected: Completes without errors. The `related_artifacts[0].id: bill-c27-aida` reference must resolve to the artifact created in Task 2 — if it doesn't, the error will say so explicitly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add data/events/2022-06-16-bill-c27-introduced.yaml
+git commit -m "Add Bill C-27 introduction event (2022-06-16)"
+```
+
+---
+
+## Task 4: Create the prorogation event
+
+**Files:**
+- Create: `data/events/2025-01-06-parliament-prorogued-44-1.yaml`
+
+- [ ] **Step 1: Create the event file with the exact content below**
+
+Write the following YAML to `data/events/2025-01-06-parliament-prorogued-44-1.yaml`:
+
+```yaml
+# events/2025-01-06-parliament-prorogued-44-1.yaml
+
+id: parliament-prorogued-44-1-2025
+type: PoliticalEvent
+schema_type: Event
+
+title: "Parliament prorogued — Bill C-27 dies on the Order Paper"
+date: 2025-01-06
+
+status: completed
+
+description: >
+  Prime Minister Justin Trudeau announces his resignation and Parliament is
+  prorogued by proclamation of the Governor General. All legislation on the
+  Order Paper, including Bill C-27 (and with it AIDA), dies. INDU's
+  clause-by-clause study of the bill ceases.
+
+related_artifacts:
+  - id: bill-c27-aida
+
+tags:
+  - prorogation
+  - parliament
+  - bill-c-27
+  - aida
+  - federal-government
+
+links:
+  - label: "LEGISinfo — Bill C-27 (final status)"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document
+```
+
+- [ ] **Step 2: Verify the event validates**
+
+Run: `npx astro sync`
+Expected: Completes without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add data/events/2025-01-06-parliament-prorogued-44-1.yaml
+git commit -m "Add parliament prorogation event (2025-01-06); Bill C-27 dies"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the unit tests**
+
+Run: `npm test`
+Expected: All tests pass. No regressions from the schema change.
+
+- [ ] **Step 2: Run the full build**
+
+Run: `npm run build`
+Expected: Build succeeds. All three new YAML files validate; all existing content still validates; site renders.
+
+- [ ] **Step 3: Run Playwright e2e tests**
+
+Run: `npm run test:e2e`
+Expected: All e2e specs pass (`timeline.spec.ts`, `a11y.spec.ts`, `analytics.spec.ts`). The timeline page should render with the two new events present. If a timeline e2e test asserts on exact event counts, it may need updating — if so, update it to match the new count.
+
+- [ ] **Step 4: Spot-check the rendered site in dev mode**
+
+Run: `npm run dev`
+Open http://localhost:4321 in a browser. Confirm:
+- Both new events appear on the timeline: "Bill C-27 introduced in the House of Commons (first reading)" on 2022-06-16 and "Parliament prorogued — Bill C-27 dies on the Order Paper" on 2025-01-06.
+- Clicking each event shows its links. No broken references.
+- The page renders without console errors.
+
+Stop the dev server with Ctrl+C when done.
+
+- [ ] **Step 5: Push branch and open PR**
+
+Push the `feature/bill-c27-aida` branch and open a PR against `main` via the GitHub API (per `CLAUDE.local.md`):
+
+```bash
+git push -u origin feature/bill-c27-aida
+```
+
+Then create the PR with a filled-in Summary and Test plan, linking the spec (`docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md`) and this plan (`docs/superpowers/plans/2026-04-23-bill-c27-aida.md`).
+
+PR body template:
+
+```markdown
+## Summary
+- Adds Bill C-27 (Digital Charter Implementation Act, 2022, including AIDA) as a new artifact with an embedded legislative `stages` timeline and the bill's proposed `provisions`.
+- Adds two headline events: Bill C-27 introduction (2022-06-16) and Parliament prorogation (2025-01-06, which killed the bill on the Order Paper).
+- Extends the artifacts schema with `lifecycle_status`, `current_stage`, `stages`, and `provisions` fields (all optional, no changes required to existing records).
+
+Spec: `docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md`
+Plan: `docs/superpowers/plans/2026-04-23-bill-c27-aida.md`
+
+## Test plan
+- [x] `npm test` passes
+- [x] `npm run build` passes (all YAML validates against the extended schema)
+- [x] `npm run test:e2e` passes
+- [x] Spot-checked the timeline page locally — both new events render
+```
+
+Follow with the `superpowers:requesting-code-review` skill per `CLAUDE.local.md`.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- Summary of what AIDA would have done → `description` + `provisions` array on artifact ✅
+- Full legislative timeline → `stages` array ✅
+- Bill's final status → `lifecycle_status: died` + `current_stage` ✅
+- INDU as reviewer → `organizations[0]` on artifact with `role: reviewed_by` ✅
+- Introduction + prorogation on main timeline → two event files in Task 3 and Task 4 ✅
+- Michael Geist link → nested under the 2023-09-26 stage via `stages[].links` ✅
+- Schema changes → Task 1 ✅
+- No event on introduction references INDU → Task 3 note ✅
+
+**Placeholder scan:** No TBDs, TODOs, or "similar to Task N" references. All file content is verbatim.
+
+**Type consistency:** Field names match throughout — `lifecycle_status`, `current_stage`, `stages[].{date,stage,note,links}`, `provisions[].{id,title,summary}`. Event references use `related_artifacts[].id` matching the `id: bill-c27-aida` in Task 2.

--- a/docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md
+++ b/docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md
@@ -1,0 +1,293 @@
+# Bill C-27 / AIDA — data entry design
+
+**Date:** 2026-04-23
+**Status:** Approved
+
+## Purpose
+
+Add Bill C-27 — specifically the Artificial Intelligence and Data Act (AIDA) portion — to the tracker. The bill died on the Order Paper when Parliament was prorogued on 2025-01-06. We want to capture:
+
+- A summary of what AIDA would have done (the regulatory obligations it proposed)
+- The full legislative timeline through all its stages
+- The bill's final status (died)
+- That it was under review by INDU
+- Two headline moments on the main timeline: introduction and prorogation
+
+## Approach
+
+**Option C (hybrid)** from brainstorming: the bill is modelled as a single artifact with an embedded `stages` array capturing the full legislative journey. Only two moments are elevated to standalone `event` records so the main timeline stays uncluttered: introduction and prorogation.
+
+## Records
+
+### New artifact — `data/artifacts/2022-06-16-bill-c27-aida.yaml`
+
+```yaml
+id: bill-c27-aida
+type: Legislation
+schema_type: CreativeWork
+
+title: "Bill C-27 — Digital Charter Implementation Act, 2022 (including AIDA)"
+published_date: 2022-06-16  # introduction date
+
+lifecycle_status: died
+current_stage: "Died on the Order Paper at committee stage (INDU) on prorogation, 6 January 2025"
+
+organizations:
+  - id: house-of-commons-indu-committee
+    role: reviewed_by
+
+description: >
+  The Digital Charter Implementation Act, 2022 bundled three components: the
+  Consumer Privacy Protection Act, the Personal Information and Data Protection
+  Tribunal Act, and the Artificial Intelligence and Data Act (AIDA) — Canada's
+  first proposed federal AI-specific legislation.
+
+  AIDA would have regulated "high-impact" AI systems used in interprovincial
+  and international trade, created an AI and Data Commissioner within ISED,
+  and imposed obligations across the AI lifecycle. High-impact systems were
+  to be defined by risk factors including potential for health/safety harm,
+  human rights impacts, scale of use, severity of potential harms, and the
+  extent to which users could opt out. Examples cited in the ISED companion
+  document included hiring systems, biometric identification tools, behavioural
+  influence systems, and autonomous vehicles.
+
+  The bill was referred to the Standing Committee on Industry and Technology
+  (INDU) after second reading in April 2023 and remained there through the
+  end of the 44th Parliament. The committee paused clause-by-clause
+  consideration on 29 May 2024, met once more on 26 September 2024, and on
+  21 November 2024 confirmed the study would remain paused until at least
+  February 2025. Parliament was prorogued on 6 January 2025, killing the
+  bill before it reached report stage, third reading, or the Senate.
+
+stages:
+  - date: 2022-06-16
+    stage: "Introduction and first reading"
+    note: "Bill C-27 introduced in the House of Commons."
+  - date: 2022-11-04
+    stage: "Second reading debate begins"
+  - date: 2023-04-24
+    stage: "Second reading passed; referred to INDU"
+    note: "Passed on two separate votes (300: 205–109; 301: 203–112)."
+  - date: 2023-09-26
+    stage: "INDU study begins"
+  - date: 2023-11-28
+    stage: "Minister tables proposed AIDA amendments"
+    note: "Minister Champagne submits a letter to INDU with proposed amendments to AIDA."
+  - date: 2024-05-29
+    stage: "Clause-by-clause consideration pauses"
+    note: "Meeting 126 — last clause-by-clause session before a summer pause."
+  - date: 2024-09-26
+    stage: "Last INDU meeting on C-27"
+    note: "Meeting 136 — committee study not completed."
+  - date: 2024-11-21
+    stage: "INDU confirms study will remain paused"
+    note: "Committee confirms the study will remain paused until at least February 2025."
+  - date: 2025-01-06
+    stage: "Died on the Order Paper"
+    note: "Parliament prorogued; Bill C-27 dies along with all other legislation on the Order Paper."
+
+provisions:
+  - id: high-impact-scope
+    title: "Scope: high-impact AI systems"
+    summary: >
+      Apply obligations to "high-impact" AI systems used in interprovincial
+      or international trade, defined by risk factors including potential for
+      health/safety harm, human rights impacts, scale of use, severity of
+      potential harms, and the extent to which users cannot opt out.
+  - id: human-oversight
+    title: "Human oversight and monitoring"
+    summary: >
+      Require mechanisms for meaningful human oversight of high-impact AI
+      systems across their lifecycle.
+  - id: transparency
+    title: "Transparency"
+    summary: >
+      Require plain-language disclosures about the AI system's purpose,
+      intended use, content it generates, and its limitations.
+  - id: fairness
+    title: "Fairness and non-discrimination"
+    summary: >
+      Require measures to identify and mitigate biased outputs and
+      discriminatory impacts.
+  - id: safety
+    title: "Safety"
+    summary: >
+      Require risk identification and mitigation so that reasonably
+      foreseeable uses do not create unreasonable risks of harm.
+  - id: accountability
+    title: "Accountability"
+    summary: >
+      Require governance mechanisms (policies, processes, documentation)
+      ensuring legal obligations are met across the AI lifecycle.
+  - id: robustness
+    title: "Validity and robustness"
+    summary: >
+      Require systems to perform consistently as intended under a range of
+      conditions.
+  - id: ai-data-commissioner
+    title: "AI and Data Commissioner"
+    summary: >
+      Establish an AI and Data Commissioner within ISED to administer and
+      enforce AIDA, separate from criminal prosecution handled by the Public
+      Prosecution Service.
+  - id: enforcement-tiers
+    title: "Tiered enforcement"
+    summary: >
+      Education and voluntary compliance first; administrative monetary
+      penalties and regulatory offences for non-compliance; criminal offences
+      for knowing or reckless conduct causing serious harm.
+
+links:
+  - label: "LEGISinfo — Bill C-27"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document
+  - label: "AIDA companion document (ISED)"
+    url: https://ised-isde.canada.ca/site/innovation-better-canada/en/artificial-intelligence-and-data-act-aida-companion-document
+    icon: document
+  - label: "ISED — Artificial Intelligence and Data Act page"
+    url: https://ised-isde.canada.ca/site/innovation-better-canada/en/artificial-intelligence-and-data-act
+    icon: document
+  - label: "INDU — Bill C-27 study activity"
+    url: https://www.ourcommons.ca/committees/en/INDU/StudyActivity?studyActivityId=12157763
+    icon: document
+  - label: "Charter Statement (Justice Canada)"
+    url: https://www.justice.gc.ca/eng/csj-sjc/pl/charter-charte/c27_1.html
+    icon: document
+
+tags:
+  - bill-c-27
+  - aida
+  - digital-charter-implementation-act
+  - federal-government
+  - high-impact-ai-systems
+  - ai-data-commissioner
+```
+
+### New event — `data/events/2022-06-16-bill-c27-introduced.yaml`
+
+```yaml
+id: bill-c27-introduced-2022
+type: LegislativeAction
+schema_type: Event
+
+title: "Bill C-27 introduced in the House of Commons (first reading)"
+date: 2022-06-16
+status: completed
+
+description: >
+  The Digital Charter Implementation Act, 2022 (Bill C-27) is introduced and
+  receives first reading in the House of Commons. The bill bundles three
+  components: the Consumer Privacy Protection Act, the Personal Information
+  and Data Protection Tribunal Act, and the Artificial Intelligence and Data
+  Act (AIDA) — the first proposed federal AI-specific legislation in Canada.
+
+related_artifacts:
+  - id: bill-c27-aida
+
+tags:
+  - bill-c-27
+  - aida
+  - federal-government
+  - house-of-commons
+
+links:
+  - label: "LEGISinfo — Bill C-27"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document
+```
+
+### New event — `data/events/2025-01-06-parliament-prorogued-44-1.yaml`
+
+```yaml
+id: parliament-prorogued-44-1-2025
+type: PoliticalEvent
+schema_type: Event
+
+title: "Parliament prorogued — Bill C-27 dies on the Order Paper"
+date: 2025-01-06
+status: completed
+
+description: >
+  Prime Minister Justin Trudeau announces his resignation and Parliament is
+  prorogued by proclamation of the Governor General. All legislation on the
+  Order Paper, including Bill C-27 (and with it AIDA), dies. INDU's
+  clause-by-clause study of the bill ceases.
+
+related_artifacts:
+  - id: bill-c27-aida
+
+tags:
+  - prorogation
+  - parliament
+  - bill-c-27
+  - aida
+  - federal-government
+
+links:
+  - label: "LEGISinfo — Bill C-27 (final status)"
+    url: https://www.parl.ca/legisinfo/en/bill/44-1/c-27
+    icon: document
+```
+
+## Schema changes — `src/content.config.ts`
+
+Extend the artifacts schema with three new optional fields:
+
+```ts
+lifecycle_status: z
+  .enum(["active", "enacted", "died", "withdrawn"])
+  .optional(),
+
+current_stage: z.string().optional(),
+
+stages: z
+  .array(
+    z.object({
+      date: z.coerce.date(),
+      stage: z.string(),
+      note: z.string().optional(),
+      link: linkSchema.optional(),
+    }),
+  )
+  .default([]),
+
+provisions: z
+  .array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      summary: z.string(),
+    }),
+  )
+  .default([]),
+```
+
+All four fields are optional / default `[]`, so existing artifact records continue to validate unchanged.
+
+No changes to the events or organizations schemas.
+
+No changes to `data/organizations/house-of-commons-indu-committee.yaml` — it already exists and is correct.
+
+## Design decisions
+
+- **Option C (hybrid)**: bill as one artifact with embedded `stages`; only introduction and prorogation as events. Intermediate stages don't stand alone as linkable moments and would bloat the timeline.
+- **Coarse `lifecycle_status` enum + free-text `current_stage`**: avoids proliferating machine-readable enums for every parliamentary procedure across federal/provincial, Commons/Senate, government/private-member bills. The `stages` array carries precise history.
+- **Separate `provisions` field** rather than overloading `policy_recommendations`: provisions describe what the instrument does/would do; recommendations track adoption of someone else's suggestions. Different semantics, different schemas.
+- **No `headline` flag on events (YAGNI)**: headline/detail is handled structurally — headline = event file, detail = `stages` entry on the artifact. Revisit if we ever need to surface intermediate stages on the main timeline.
+- **Partial dates avoided**: all stage dates are exact (researched from INDU minutes and LEGISinfo), so no schema relaxation needed.
+- **Tag minimalism**: implicit site-wide tags (`ai-regulation`, `artificial-intelligence`, `legislation`, `canadian`) are omitted. Kept tags that distinguish records from each other.
+- **Introduction event does not list INDU as an organization**: strictly, INDU only became involved after second reading (2023-04-24). The artifact's `organizations` field carries the INDU connection.
+
+## Follow-up (not in scope)
+
+- GitHub issue for a dedicated rendering of an artifact's `stages` array on the bill page.
+- If the bill is reintroduced in a future Parliament, add a new artifact for the successor bill and cross-reference it from this one.
+
+## Sources
+
+- [LEGISinfo — C-27 (44-1)](https://www.parl.ca/legisinfo/en/bill/44-1/c-27)
+- [INDU — Bill C-27 study activity](https://www.ourcommons.ca/committees/en/INDU/StudyActivity?studyActivityId=12157763)
+- [AIDA companion document (ISED)](https://ised-isde.canada.ca/site/innovation-better-canada/en/artificial-intelligence-and-data-act-aida-companion-document)
+- [Gowling WLG — Bill C-27 timeline of developments](https://gowlingwlg.com/en/insights-resources/articles/2024/bill-c27-timeline-of-developments)
+- [Montreal AI Ethics Institute — The Death of AIDA](https://montrealethics.ai/the-death-of-canadas-artificial-intelligence-and-data-act-what-happened-and-whats-next-for-ai-regulation-in-canada/)
+- [Charter Statement (Justice Canada)](https://www.justice.gc.ca/eng/csj-sjc/pl/charter-charte/c27_1.html)

--- a/docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md
+++ b/docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md
@@ -70,6 +70,10 @@ stages:
     note: "Passed on two separate votes (300: 205–109; 301: 203–112)."
   - date: 2023-09-26
     stage: "INDU study begins"
+    links:
+      - label: "Michael Geist — Why Minister Champagne broke the Bill C-27 hearings on privacy and AI regulation in only 12 minutes"
+        url: https://www.michaelgeist.ca/2023/09/why-industry-minister-champagne-broke-the-bill-c-27-hearings-on-privacy-and-ai-regulation-in-only-12-minutes/
+        icon: document
   - date: 2023-11-28
     stage: "Minister tables proposed AIDA amendments"
     note: "Minister Champagne submits a letter to INDU with proposed amendments to AIDA."
@@ -246,7 +250,7 @@ stages: z
       date: z.coerce.date(),
       stage: z.string(),
       note: z.string().optional(),
-      link: linkSchema.optional(),
+      links: z.array(linkSchema).default([]),
     }),
   )
   .default([]),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -50,6 +50,29 @@ const artifacts = defineCollection({
     title: z.string(),
     published_date: z.coerce.date(),
     description: z.string().optional(),
+    lifecycle_status: z
+      .enum(["active", "enacted", "died", "withdrawn"])
+      .optional(),
+    current_stage: z.string().optional(),
+    stages: z
+      .array(
+        z.object({
+          date: z.coerce.date(),
+          stage: z.string(),
+          note: z.string().optional(),
+          links: z.array(linkSchema).default([]),
+        }),
+      )
+      .default([]),
+    provisions: z
+      .array(
+        z.object({
+          id: z.string(),
+          title: z.string(),
+          summary: z.string(),
+        }),
+      )
+      .default([]),
     organizations: z.array(orgRoleSchema).default([]),
     derives_from: z
       .array(


### PR DESCRIPTION
## Summary
- Adds Bill C-27 (Digital Charter Implementation Act, 2022, including AIDA) as a new artifact with an embedded legislative `stages` timeline and the bill's proposed `provisions` (the nine regulatory obligations AIDA would have imposed).
- Adds two headline events: Bill C-27 introduction (2022-06-16) and Parliament prorogation (2025-01-06, which killed the bill on the Order Paper).
- Extends the `artifacts` schema with four optional fields: `lifecycle_status`, `current_stage`, `stages`, `provisions`. All existing artifact records continue to validate unchanged.
- Intermediate legislative stages (second reading, INDU referral, amendments, committee pause, etc.) live inside the artifact's `stages` array rather than as standalone timeline events — keeping the main timeline uncluttered while preserving the full history. A Michael Geist blog post is attached to the 2023-09-26 stage via `stages[].links`.

Spec: `docs/superpowers/specs/2026-04-23-bill-c27-aida-data-entry-design.md`  
Plan: `docs/superpowers/plans/2026-04-23-bill-c27-aida.md`

A follow-up GitHub issue will be filed for a dedicated rendering of the `stages` array on the artifact page.

## Test plan
- [x] `npm test` passes (7 tests)
- [x] `npm run build` passes — all YAML validates against the extended schema; new pages render (`/artifacts/bill-c27-aida/`, `/events/bill-c27-introduced-2022/`, `/events/parliament-prorogued-44-1-2025/`)
- [ ] `npm run test:e2e` — fails locally due to a pre-existing macOS sandbox issue (same failures on `main`); CI will be the authoritative gate
- [ ] Spot-check the timeline page in the browser to confirm both new events render as expected
