### PR TITLE
Add homepage, move timeline to /timeline/, rename site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 CLAUDE.local.md
 playwright-report/
 test-results/
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AI Safety Gov Tracker
+# AI Governance Tracker
 
 ## Project Goal
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Safety Gov Tracker
+# AI Governance Tracker
 
 A Canadian AI governance and policy timeline — tracking AI safety events such as Senate hearings, published reports, and significant government or ministerial changes.
 

--- a/docs/superpowers/plans/2026-04-25-homepage.md
+++ b/docs/superpowers/plans/2026-04-25-homepage.md
@@ -1,0 +1,482 @@
+# Homepage & Site Rename — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a homepage at `/`, move the timeline to `/timeline/`, and rename the site from "AI Safety Gov Tracker" to "AI Governance Tracker" throughout.
+
+**Architecture:** The homepage is a static Astro page with no React — no interactivity needed. The existing timeline page moves to `src/pages/timeline/index.astro` unchanged. `BaseLayout.astro` gets the rename and a new "Home" nav link. E2e tests are updated to reflect the new URLs before the routes are changed (TDD).
+
+**Tech Stack:** Astro 5, Tailwind CSS 4, Playwright (e2e)
+
+**Spec:** `docs/superpowers/specs/2026-04-25-homepage-design.md`
+
+---
+
+## File Map
+
+| Action | File | What changes |
+|---|---|---|
+| Modify | `src/layouts/BaseLayout.astro` | Rename `siteTitle`, add Home nav link |
+| Modify | `src/pages/index.astro` | Replace with homepage content |
+| Create | `src/pages/timeline/index.astro` | Timeline (moved from `index.astro`) |
+| Modify | `e2e/timeline.spec.ts` | Update URLs `/` → `/timeline/` |
+| Modify | `e2e/a11y.spec.ts` | Add `/timeline/` a11y check alongside `/` |
+| Create | `e2e/homepage.spec.ts` | New e2e tests for the homepage |
+| Modify | `README.md` | Rename site title |
+| Modify | `package.json` | Rename `name` field |
+
+---
+
+## Task 1: Rename site title everywhere
+
+No tests needed — this is a string replacement in non-functional contexts.
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro`
+- Modify: `README.md`
+- Modify: `package.json`
+
+- [ ] **Step 1: Update `BaseLayout.astro`**
+
+In `src/layouts/BaseLayout.astro`, change line 10:
+
+```astro
+const siteTitle = "AI Governance Tracker";
+```
+
+Also update the footer text on the last `<p>` in `<footer>`:
+
+```astro
+<p>A Canadian AI governance and policy timeline.</p>
+```
+
+(Footer text is already correct — no change needed there.)
+
+- [ ] **Step 2: Update `README.md`**
+
+Change the first line:
+
+```markdown
+# AI Governance Tracker
+```
+
+- [ ] **Step 3: Update `package.json`**
+
+Change the `name` field:
+
+```json
+"name": "ai-governance-tracker",
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro README.md package.json
+git commit -m "Rename site title to AI Governance Tracker"
+```
+
+---
+
+## Task 2: Move timeline to /timeline/ (test-first)
+
+Update the e2e tests to use `/timeline/` before creating the route, so they fail first and pass once the route exists.
+
+**Files:**
+- Modify: `e2e/timeline.spec.ts`
+- Modify: `e2e/a11y.spec.ts`
+- Create: `src/pages/timeline/index.astro`
+
+- [ ] **Step 1: Update `e2e/timeline.spec.ts` URLs**
+
+Replace every `page.goto("/")` with `page.goto("/timeline/")` and update URL assertions:
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+const CIGI_ID = "cigi-global-ai-risks-initiative";
+const CIGI_EVENT_TITLE = /AI National Security Scenarios Workshop/i;
+const NON_CIGI_EVENT_TITLE = /INDU Meeting 27/i;
+
+function timelineItems(page: import("@playwright/test").Page) {
+  return page
+    .getByRole("list", { name: /timeline/i })
+    .getByRole("listitem");
+}
+
+test.describe("timeline", () => {
+  test("timeline page loads and renders timeline items", async ({ page }) => {
+    await page.goto("/timeline/");
+    const items = timelineItems(page);
+    await expect(items.first()).toBeVisible();
+    expect(await items.count()).toBeGreaterThan(0);
+  });
+
+  test("clicking an org pill narrows the list and updates the URL", async ({
+    page,
+  }) => {
+    await page.goto("/timeline/");
+    const initialCount = await timelineItems(page).count();
+
+    await page.getByRole("button", { name: /CIGI/ }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/timeline/\\?org=${CIGI_ID}$`));
+    await expect(page.getByRole("heading", { name: CIGI_EVENT_TITLE })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: NON_CIGI_EVENT_TITLE }),
+    ).toHaveCount(0);
+
+    const filteredCount = await timelineItems(page).count();
+    expect(filteredCount).toBeLessThan(initialCount);
+  });
+
+  test("browser Back restores the previous filter state", async ({ page }) => {
+    await page.goto("/timeline/");
+    const initialCount = await timelineItems(page).count();
+
+    await page.getByRole("button", { name: /CIGI/ }).click();
+    await expect(page).toHaveURL(new RegExp(`/timeline/\\?org=${CIGI_ID}$`));
+
+    await page.goBack();
+
+    await expect(page).toHaveURL(/\/timeline\/$/);
+    await expect(page.getByRole("button", { name: "All" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(await timelineItems(page).count()).toBe(initialCount);
+  });
+
+  test("invalid ?org= shows all items and cleans the URL", async ({ page }) => {
+    await page.goto("/timeline/?org=bogus-xyz");
+
+    await expect(page).toHaveURL(/\/timeline\/$/);
+    expect(await timelineItems(page).count()).toBeGreaterThan(0);
+    await expect(page.getByRole("button", { name: "All" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  test("timeline does not contain artifact entries", async ({ page }) => {
+    await page.goto("/timeline/");
+    const items = timelineItems(page);
+    const count = await items.count();
+    for (let i = 0; i < count; i++) {
+      const badges = items.nth(i).locator("div.flex > span").first();
+      await expect(badges).not.toHaveText("Legislation");
+      await expect(badges).not.toHaveText("Report");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Update `e2e/a11y.spec.ts` to test both routes**
+
+```typescript
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test("homepage has no axe-detectable a11y violations", async ({ page }) => {
+  await page.goto("/");
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});
+
+test("timeline page has no axe-detectable a11y violations", async ({ page }) => {
+  await page.goto("/timeline/");
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});
+```
+
+- [ ] **Step 3: Run e2e tests — expect failures on timeline routes**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: timeline.spec.ts tests fail with 404 on `/timeline/`. The a11y `/timeline/` test also fails. The existing `/` a11y test may still pass (homepage doesn't exist yet but Astro will serve the current index).
+
+- [ ] **Step 4: Create `src/pages/timeline/index.astro`**
+
+Copy the current `src/pages/index.astro` content exactly, with one change — update the `<h1>` to read "Timeline" (it already does) and keep everything else:
+
+```astro
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import TimelineWithFilter from "../../components/TimelineWithFilter";
+import type { TimelineItem, OrgOption } from "../../lib/timeline";
+
+const events = await getCollection("events");
+const organizations = await getCollection("organizations");
+
+const orgMap = new Map<string, { name: string; short_name?: string }>();
+for (const org of organizations) {
+  orgMap.set(org.id, { name: org.data.name, short_name: org.data.short_name });
+}
+
+const items: TimelineItem[] = events
+  .map((e) => ({
+    id: e.id,
+    kind: "event" as const,
+    title: e.data.title,
+    date: e.data.date.toISOString(),
+    description: e.data.description,
+    tags: e.data.tags,
+    href: `/events/${e.id}/`,
+    badge: e.data.type,
+    orgIds: e.data.organizations.map((o) => o.id.id),
+  }))
+  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+const orgCounts = new Map<string, number>();
+for (const item of items) {
+  for (const orgId of item.orgIds) {
+    orgCounts.set(orgId, (orgCounts.get(orgId) ?? 0) + 1);
+  }
+}
+
+const orgs: OrgOption[] = [];
+for (const [orgId, count] of orgCounts.entries()) {
+  const org = orgMap.get(orgId);
+  if (!org) continue;
+  orgs.push({
+    id: orgId,
+    label: org.short_name ?? org.name,
+    count,
+  });
+}
+orgs.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+---
+
+<BaseLayout
+  title="Timeline"
+  description="Canadian AI governance and policy events, reports, and government action."
+>
+  <h1 class="text-3xl font-bold tracking-tight">Timeline</h1>
+  <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+    Canadian AI governance and policy events, reports, and government action.
+  </p>
+
+  <TimelineWithFilter client:load items={items} orgs={orgs} />
+</BaseLayout>
+```
+
+- [ ] **Step 5: Run e2e tests — expect timeline tests to pass**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: All timeline.spec.ts tests pass. The a11y `/timeline/` test passes. The `/` a11y test still passes (old homepage still at index.astro for now — will be replaced in Task 3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/timeline.spec.ts e2e/a11y.spec.ts src/pages/timeline/index.astro
+git commit -m "Move timeline to /timeline/, update e2e tests"
+```
+
+---
+
+## Task 3: Create homepage at / (test-first)
+
+**Files:**
+- Create: `e2e/homepage.spec.ts`
+- Modify: `src/pages/index.astro`
+
+- [ ] **Step 1: Write failing e2e test**
+
+Create `e2e/homepage.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+test.describe("homepage", () => {
+  test("renders site title and values statement", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1, name: /AI Governance Tracker/i })).toBeVisible();
+    await expect(page.getByText(/AI safety/i)).toBeVisible();
+  });
+
+  test("primary CTA links to /timeline/", async ({ page }) => {
+    await page.goto("/");
+    const cta = page.getByRole("link", { name: /Browse the Timeline/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("href", "/timeline/");
+  });
+
+  test("contribute link points to GitHub new issue page", async ({ page }) => {
+    await page.goto("/");
+    const link = page.getByRole("link", { name: /Contribute/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/jrhender/ai-governance-tracker/issues/new"
+    );
+  });
+
+  test("section cards link to /timeline/ and /legislation/", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("link", { name: /Timeline/i }).first()).toHaveAttribute("href", "/timeline/");
+    await expect(page.getByRole("link", { name: /Legislation/i }).first()).toHaveAttribute("href", "/legislation/");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+```bash
+pnpm exec astro build && pnpm exec playwright test --grep "homepage"
+```
+
+Expected: All 4 homepage tests fail — the current index.astro is the old timeline page, not the new homepage.
+
+- [ ] **Step 3: Replace `src/pages/index.astro` with the homepage**
+
+```astro
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="AI Governance Tracker"
+  description="Tracking Canadian AI governance and policy — Senate hearings, legislation, and government action."
+>
+  <div class="py-8">
+    <h1 class="text-4xl font-bold tracking-tight">AI Governance Tracker</h1>
+    <p class="mt-3 text-lg text-slate-600 dark:text-slate-400">
+      Tracking Canadian AI governance and policy
+    </p>
+
+    <p class="mt-6 max-w-2xl text-slate-700 dark:text-slate-300">
+      AI is one of the most consequential technologies in human history. AI safety in
+      particular deserves serious attention. This tracker follows Canada's policy
+      response — Senate hearings, legislation, and government action — so that anyone
+      who cares can stay informed.
+    </p>
+
+    <div class="mt-8 flex flex-wrap gap-3">
+      <a
+        href="/timeline/"
+        class="rounded-md bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      >
+        Browse the Timeline →
+      </a>
+      <a
+        href="https://github.com/jrhender/ai-governance-tracker/issues/new"
+        class="rounded-md border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-slate-100"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Contribute via GitHub
+      </a>
+    </div>
+
+    <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <a
+        href="/timeline/"
+        class="rounded-lg border border-slate-200 p-5 hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+      >
+        <h2 class="font-semibold">Timeline</h2>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Senate hearings, reports, and government announcements.
+        </p>
+      </a>
+      <a
+        href="/legislation/"
+        class="rounded-lg border border-slate-200 p-5 hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+      >
+        <h2 class="font-semibold">Legislation</h2>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Bills and acts tracked through Parliament.
+        </p>
+      </a>
+    </div>
+  </div>
+</BaseLayout>
+```
+
+- [ ] **Step 4: Run homepage tests — expect all to pass**
+
+```bash
+pnpm exec astro build && pnpm exec playwright test --grep "homepage"
+```
+
+Expected: All 4 homepage tests pass.
+
+- [ ] **Step 5: Run full e2e suite to check for regressions**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/homepage.spec.ts src/pages/index.astro
+git commit -m "Add homepage at /, move old index content to /timeline/"
+```
+
+---
+
+## Task 4: Update nav — add Home link
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro`
+
+- [ ] **Step 1: Update nav in `BaseLayout.astro`**
+
+Replace the `<nav>` block (lines 40–47):
+
+```astro
+<nav class="flex gap-4 text-sm text-slate-600 dark:text-slate-400">
+  <a href="/" class="hover:text-slate-900 dark:hover:text-slate-100">
+    Home
+  </a>
+  <a href="/timeline/" class="hover:text-slate-900 dark:hover:text-slate-100">
+    Timeline
+  </a>
+  <a href="/legislation/" class="hover:text-slate-900 dark:hover:text-slate-100">
+    Legislation
+  </a>
+</nav>
+```
+
+- [ ] **Step 2: Run full e2e suite**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro
+git commit -m "Update nav: add Home link, point Timeline to /timeline/"
+```
+
+---
+
+## Task 5: Open PR
+
+- [ ] **Step 1: Run unit tests**
+
+```bash
+pnpm test
+```
+
+Expected: All pass (unit tests don't touch routing).
+
+- [ ] **Step 2: Push branch and open PR**
+
+```bash
+git push -u origin feature/homepage
+```
+
+Then open a PR against `main` via the GitHub API with title "Add homepage, move timeline to /timeline/, rename site" and a summary linking to the spec and plan.

--- a/docs/superpowers/specs/2026-04-25-homepage-design.md
+++ b/docs/superpowers/specs/2026-04-25-homepage-design.md
@@ -1,0 +1,79 @@
+# Homepage & Site Rename — Design Spec
+
+**Date:** 2026-04-25  
+**Status:** Approved
+
+## Overview
+
+Add a homepage that explains the project's objective, audience, and how to contribute. Simultaneously rename the site from "AI Safety Gov Tracker" to "AI Governance Tracker" throughout the codebase.
+
+## Goals
+
+- Give first-time visitors a clear explanation of what the tracker is and why it exists
+- Express a values position (AI safety matters; Canada's policy response deserves scrutiny) without editorialising the content itself
+- Direct visitors to the Timeline as the primary entry point
+- Make it easy to contribute via a GitHub issue
+- Rename the site consistently to "AI Governance Tracker"
+
+## Audience
+
+Engaged citizens and advocates who care about AI safety and want to stay informed about Canada's policy response. Policy researchers and industry practitioners may also use the site but have deeper specialist sources; this site serves the broader informed public.
+
+## URL Structure
+
+| Route | Before | After |
+|---|---|---|
+| `/` | Timeline page | **Homepage (new)** |
+| `/timeline/` | — | Timeline page (moved) |
+| `/legislation/` | Legislation | Legislation (unchanged) |
+| `/events/[id]/` | Event detail | Event detail (unchanged) |
+| `/artifacts/[id]/` | Artifact detail | Artifact detail (unchanged) |
+| `/orgs/[id]/` | Org detail | Org detail (unchanged) |
+
+## Navigation
+
+Header nav order: **Home · Timeline · Legislation**
+
+A link to Organizations (`/orgs/`) is tracked separately in [issue #23](https://github.com/jrhender/ai-governance-tracker/issues/23) and is out of scope here.
+
+## Homepage Layout (Option A — Compact hero + section cards)
+
+### Hero
+- **Title:** "AI Governance Tracker"
+- **Subtitle:** "Tracking Canadian AI governance and policy"
+- **Values statement (2–3 sentences):** AI is one of the most consequential technologies in human history. AI safety in particular deserves serious attention. This tracker follows Canada's policy response — so that anyone who cares can stay informed.
+
+### CTAs
+- **Primary:** "Browse the Timeline →" — links to `/timeline/`
+- **Secondary:** "Contribute via GitHub" — links to the repo's new-issue page (`https://github.com/jrhender/ai-governance-tracker/issues/new`)
+
+### Section cards (2-column grid)
+Two cards below the CTAs, each with a title, short description, and a link:
+
+| Card | Title | Description | Link |
+|---|---|---|---|
+| 1 | Timeline | Senate hearings, reports, and government announcements | `/timeline/` |
+| 2 | Legislation | Bills and acts tracked through Parliament | `/legislation/` |
+
+## Site Rename
+
+Replace "AI Safety Gov Tracker" → "AI Governance Tracker" in:
+
+- `src/layouts/BaseLayout.astro` — `siteTitle` constant, nav link text
+- `src/pages/index.astro` — page `title` and `description` props (these become the homepage content)
+- `src/pages/legislation/index.astro` — `title` prop if it references the old name
+- `README.md` — title and any references
+- `package.json` — `name` field (cosmetic only, not a published package)
+
+## Implementation Notes
+
+- The timeline page (`src/pages/timeline/index.astro`) is a move of the current `src/pages/index.astro` timeline logic — no functional change to the timeline itself.
+- The new homepage is a new `src/pages/index.astro` that renders a static Astro page (no React needed — no interactivity required).
+- Styling follows the existing Tailwind conventions in `BaseLayout.astro`.
+- No new data fetching or content collections needed for the homepage.
+
+## Out of Scope
+
+- Organizations nav link (tracked in issue #23)
+- Any changes to timeline functionality, legislation page, or detail pages
+- A full "about" or FAQ page

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -6,3 +6,9 @@ test("homepage has no axe-detectable a11y violations", async ({ page }) => {
   const results = await new AxeBuilder({ page }).analyze();
   expect(results.violations).toEqual([]);
 });
+
+test("timeline page has no axe-detectable a11y violations", async ({ page }) => {
+  await page.goto("/timeline/");
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("homepage", () => {
+  test("renders site title and values statement", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1, name: /AI Governance Tracker/i })).toBeVisible();
+    await expect(page.getByText(/AI safety/i)).toBeVisible();
+  });
+
+  test("primary CTA links to /timeline/", async ({ page }) => {
+    await page.goto("/");
+    const cta = page.getByRole("link", { name: /Browse the Timeline/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("href", "/timeline/");
+  });
+
+  test("contribute link points to GitHub new issue page", async ({ page }) => {
+    await page.goto("/");
+    const link = page.getByRole("link", { name: /Contribute/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/jrhender/ai-governance-tracker/issues/new"
+    );
+  });
+
+  test("section cards link to /timeline/ and /legislation/", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("link", { name: /Timeline/i }).first()).toHaveAttribute("href", "/timeline/");
+    await expect(page.getByRole("link", { name: /Legislation/i }).first()).toHaveAttribute("href", "/legislation/");
+  });
+});

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -26,7 +26,11 @@ test.describe("homepage", () => {
 
   test("section cards link to /timeline/ and /legislation/", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("link", { name: /Timeline/i }).first()).toHaveAttribute("href", "/timeline/");
-    await expect(page.getByRole("link", { name: /Legislation/i }).first()).toHaveAttribute("href", "/legislation/");
+    await expect(
+      page.locator("main").getByRole("link", { name: /Timeline/i }).first()
+    ).toHaveAttribute("href", "/timeline/");
+    await expect(
+      page.locator("main").getByRole("link", { name: /Legislation/i }).first()
+    ).toHaveAttribute("href", "/legislation/");
   });
 });

--- a/e2e/timeline.spec.ts
+++ b/e2e/timeline.spec.ts
@@ -11,8 +11,8 @@ function timelineItems(page: import("@playwright/test").Page) {
 }
 
 test.describe("timeline", () => {
-  test("homepage loads and renders timeline items", async ({ page }) => {
-    await page.goto("/");
+  test("timeline page loads and renders timeline items", async ({ page }) => {
+    await page.goto("/timeline/");
     const items = timelineItems(page);
     await expect(items.first()).toBeVisible();
     expect(await items.count()).toBeGreaterThan(0);
@@ -21,12 +21,12 @@ test.describe("timeline", () => {
   test("clicking an org pill narrows the list and updates the URL", async ({
     page,
   }) => {
-    await page.goto("/");
+    await page.goto("/timeline/");
     const initialCount = await timelineItems(page).count();
 
     await page.getByRole("button", { name: /CIGI/ }).click();
 
-    await expect(page).toHaveURL(new RegExp(`\\?org=${CIGI_ID}$`));
+    await expect(page).toHaveURL(new RegExp(`/timeline/\\?org=${CIGI_ID}$`));
     await expect(page.getByRole("heading", { name: CIGI_EVENT_TITLE })).toBeVisible();
     await expect(
       page.getByRole("heading", { name: NON_CIGI_EVENT_TITLE }),
@@ -37,15 +37,15 @@ test.describe("timeline", () => {
   });
 
   test("browser Back restores the previous filter state", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/timeline/");
     const initialCount = await timelineItems(page).count();
 
     await page.getByRole("button", { name: /CIGI/ }).click();
-    await expect(page).toHaveURL(new RegExp(`\\?org=${CIGI_ID}$`));
+    await expect(page).toHaveURL(new RegExp(`/timeline/\\?org=${CIGI_ID}$`));
 
     await page.goBack();
 
-    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveURL(/\/timeline\/$/);
     await expect(page.getByRole("button", { name: "All" })).toHaveAttribute(
       "aria-pressed",
       "true",
@@ -54,9 +54,9 @@ test.describe("timeline", () => {
   });
 
   test("invalid ?org= shows all items and cleans the URL", async ({ page }) => {
-    await page.goto("/?org=bogus-xyz");
+    await page.goto("/timeline/?org=bogus-xyz");
 
-    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveURL(/\/timeline\/$/);
     expect(await timelineItems(page).count()).toBeGreaterThan(0);
     await expect(page.getByRole("button", { name: "All" })).toHaveAttribute(
       "aria-pressed",
@@ -65,7 +65,7 @@ test.describe("timeline", () => {
   });
 
   test("timeline does not contain artifact entries", async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/timeline/");
     const items = timelineItems(page);
     const count = await items.count();
     for (let i = 0; i < count; i++) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-safety-gov-tracker",
+  "name": "ai-governance-tracker",
   "version": "0.0.1",
   "private": true,
   "type": "module",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const { title, description } = Astro.props;
-const siteTitle = "AI Safety Gov Tracker";
+const siteTitle = "AI Governance Tracker";
 const fullTitle = title === siteTitle ? title : `${title} — ${siteTitle}`;
 ---
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,6 +39,9 @@ const fullTitle = title === siteTitle ? title : `${title} — ${siteTitle}`;
         </a>
         <nav class="flex gap-4 text-sm text-slate-600 dark:text-slate-400">
           <a href="/" class="hover:text-slate-900 dark:hover:text-slate-100">
+            Home
+          </a>
+          <a href="/timeline/" class="hover:text-slate-900 dark:hover:text-slate-100">
             Timeline
           </a>
           <a href="/legislation/" class="hover:text-slate-900 dark:hover:text-slate-100">

--- a/src/pages/artifacts/[id].astro
+++ b/src/pages/artifacts/[id].astro
@@ -42,7 +42,7 @@ const statusLabels: Record<string, string> = {
     {data.type === "Legislation" ? (
       <a href="/legislation/" class="hover:underline">← Legislation</a>
     ) : (
-      <a href="/" class="hover:underline">← Timeline</a>
+      <a href="/timeline/" class="hover:underline">← Timeline</a>
     )}
   </p>
   <h1 class="mt-4 text-3xl font-bold tracking-tight">{data.title}</h1>

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -29,7 +29,7 @@ const relatedArtifacts = await Promise.all(
 
 <BaseLayout title={data.title} description={data.description}>
   <p class="text-sm text-slate-500 dark:text-slate-400">
-    <a href="/" class="hover:underline">← Timeline</a>
+    <a href="/timeline/" class="hover:underline">← Timeline</a>
   </p>
   <h1 class="mt-4 text-3xl font-bold tracking-tight">{data.title}</h1>
   <div class="mt-2 flex flex-wrap gap-3 text-sm text-slate-600 dark:text-slate-400">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,62 +1,60 @@
 ---
-import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import TimelineWithFilter from "../components/TimelineWithFilter";
-import type { TimelineItem, OrgOption } from "../lib/timeline";
-
-const events = await getCollection("events");
-const organizations = await getCollection("organizations");
-
-// Build org lookup map: id -> { name, short_name }
-const orgMap = new Map<string, { name: string; short_name?: string }>();
-for (const org of organizations) {
-  orgMap.set(org.id, { name: org.data.name, short_name: org.data.short_name });
-}
-
-const items: TimelineItem[] = events
-  .map((e) => ({
-    id: e.id,
-    kind: "event" as const,
-    title: e.data.title,
-    date: e.data.date.toISOString(),
-    description: e.data.description,
-    tags: e.data.tags,
-    href: `/events/${e.id}/`,
-    badge: e.data.type,
-    orgIds: e.data.organizations.map((o) => o.id.id),
-  }))
-  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-
-// Build OrgOption list: only orgs that appear in at least one item
-const orgCounts = new Map<string, number>();
-for (const item of items) {
-  for (const orgId of item.orgIds) {
-    orgCounts.set(orgId, (orgCounts.get(orgId) ?? 0) + 1);
-  }
-}
-
-const orgs: OrgOption[] = [];
-for (const [orgId, count] of orgCounts.entries()) {
-  const org = orgMap.get(orgId);
-  if (!org) continue;
-  orgs.push({
-    id: orgId,
-    label: org.short_name ?? org.name,
-    count,
-  });
-}
-// Sort orgs by count descending, then label ascending
-orgs.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
 ---
 
 <BaseLayout
-  title="AI Safety Gov Tracker"
-  description="A Canadian AI governance and policy timeline tracking AI safety events, reports, and government action."
+  title="AI Governance Tracker"
+  description="Tracking Canadian AI governance and policy — Senate hearings, legislation, and government action."
 >
-  <h1 class="text-3xl font-bold tracking-tight">Timeline</h1>
-  <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
-    Canadian AI governance and policy events, reports, and government action.
-  </p>
+  <div class="py-8">
+    <h1 class="text-4xl font-bold tracking-tight">AI Governance Tracker</h1>
+    <p class="mt-3 text-lg text-slate-600 dark:text-slate-400">
+      Tracking Canadian AI governance and policy
+    </p>
 
-  <TimelineWithFilter client:load items={items} orgs={orgs} />
+    <p class="mt-6 max-w-2xl text-slate-700 dark:text-slate-300">
+      AI is one of the most consequential technologies in human history. AI safety in
+      particular deserves serious attention. This tracker follows Canada's policy
+      response — Senate hearings, legislation, and government action — so that anyone
+      who cares can stay informed.
+    </p>
+
+    <div class="mt-8 flex flex-wrap gap-3">
+      <a
+        href="/timeline/"
+        class="rounded-md bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      >
+        Browse the Timeline →
+      </a>
+      <a
+        href="https://github.com/jrhender/ai-governance-tracker/issues/new"
+        class="rounded-md border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-slate-100"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Contribute via GitHub
+      </a>
+    </div>
+
+    <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <a
+        href="/timeline/"
+        class="rounded-lg border border-slate-200 p-5 hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+      >
+        <h2 class="font-semibold">Timeline</h2>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Senate hearings, reports, and government announcements.
+        </p>
+      </a>
+      <a
+        href="/legislation/"
+        class="rounded-lg border border-slate-200 p-5 hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+      >
+        <h2 class="font-semibold">Legislation</h2>
+        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+          Bills and acts tracked through Parliament.
+        </p>
+      </a>
+    </div>
+  </div>
 </BaseLayout>

--- a/src/pages/orgs/[id].astro
+++ b/src/pages/orgs/[id].astro
@@ -26,7 +26,7 @@ const artifacts = allArtifacts.filter((a) =>
 
 <BaseLayout title={data.name} description={`Organization: ${data.name}`}>
   <p class="text-sm text-slate-500 dark:text-slate-400">
-    <a href="/" class="hover:underline">← Timeline</a>
+    <a href="/timeline/" class="hover:underline">← Timeline</a>
   </p>
   <h1 class="mt-4 text-3xl font-bold tracking-tight">{data.name}</h1>
   {data.short_name && (

--- a/src/pages/timeline/index.astro
+++ b/src/pages/timeline/index.astro
@@ -1,0 +1,59 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import TimelineWithFilter from "../../components/TimelineWithFilter";
+import type { TimelineItem, OrgOption } from "../../lib/timeline";
+
+const events = await getCollection("events");
+const organizations = await getCollection("organizations");
+
+const orgMap = new Map<string, { name: string; short_name?: string }>();
+for (const org of organizations) {
+  orgMap.set(org.id, { name: org.data.name, short_name: org.data.short_name });
+}
+
+const items: TimelineItem[] = events
+  .map((e) => ({
+    id: e.id,
+    kind: "event" as const,
+    title: e.data.title,
+    date: e.data.date.toISOString(),
+    description: e.data.description,
+    tags: e.data.tags,
+    href: `/events/${e.id}/`,
+    badge: e.data.type,
+    orgIds: e.data.organizations.map((o) => o.id.id),
+  }))
+  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+const orgCounts = new Map<string, number>();
+for (const item of items) {
+  for (const orgId of item.orgIds) {
+    orgCounts.set(orgId, (orgCounts.get(orgId) ?? 0) + 1);
+  }
+}
+
+const orgs: OrgOption[] = [];
+for (const [orgId, count] of orgCounts.entries()) {
+  const org = orgMap.get(orgId);
+  if (!org) continue;
+  orgs.push({
+    id: orgId,
+    label: org.short_name ?? org.name,
+    count,
+  });
+}
+orgs.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+---
+
+<BaseLayout
+  title="Timeline"
+  description="Canadian AI governance and policy events, reports, and government action."
+>
+  <h1 class="text-3xl font-bold tracking-tight">Timeline</h1>
+  <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+    Canadian AI governance and policy events, reports, and government action.
+  </p>
+
+  <TimelineWithFilter client:load items={items} orgs={orgs} />
+</BaseLayout>


### PR DESCRIPTION
## Summary

- Adds a homepage at `/` with a values statement, two CTAs (Browse Timeline, Contribute via GitHub), and section cards for Timeline and Legislation
- Moves the timeline from `/` to `/timeline/`
- Renames the site from "AI Safety Gov Tracker" to "AI Governance Tracker" throughout
- Updates nav to Home · Timeline · Legislation
- Fixes `← Timeline` backlinks in detail pages (`events/[id]`, `orgs/[id]`, `artifacts/[id]`)

**Spec:** `docs/superpowers/specs/2026-04-25-homepage-design.md`  
**Plan:** `docs/superpowers/plans/2026-04-25-homepage.md`

## Test plan

- [ ] `pnpm test` — unit tests pass
- [ ] `pnpm test:e2e` — all e2e tests pass (homepage, timeline, legislation, a11y, analytics)
- [ ] Homepage at `/` renders correctly with title, values statement, CTAs, and section cards
- [ ] Timeline at `/timeline/` renders correctly with org filter
- [ ] Nav shows Home · Timeline · Legislation with correct hrefs
- [ ] `← Timeline` backlinks on event/org/artifact detail pages navigate to `/timeline/`
- [ ] No remaining occurrences of "AI Safety Gov Tracker" in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)