### PR TITLE
Add 30-day AI Sprint and Summary of Inputs

### DIFF
--- a/data/artifacts/2026-02-05-ai-strategy-summary-of-inputs.yaml
+++ b/data/artifacts/2026-02-05-ai-strategy-summary-of-inputs.yaml
@@ -1,0 +1,41 @@
+# artifacts/2026-02-05-ai-strategy-summary-of-inputs.yaml
+
+id: ai-strategy-summary-of-inputs-2026
+type: Report
+schema_type: CreativeWork
+
+title: "Engagements on Canada's next AI Strategy: Summary of inputs"
+published_date: 2026-02-05
+
+organizations:
+  - id: ised-canada
+    role: publisher
+
+derives_from:
+  - id: ai-strategy-sprint-launched-2025
+    relationship: summary_of
+
+description: >
+  Synthesizes feedback from Canada's largest public consultation on AI policy.
+  The report draws on over 11,300 responses from a 30-day online consultation
+  (October 1–31, 2025), 28 thematic reports from the AI Strategy Task Force,
+  and nearly 300 supplementary policy submissions from businesses, government
+  organizations, and NGOs. Eight priority areas emerged: talent attraction and
+  retention, industry and government AI adoption, commercialization,
+  scaling domestic champions, building public trust, education and skills
+  development, infrastructure sovereignty, and cybersecurity. ISED used these
+  inputs to inform a renewed national AI strategy expected in 2026.
+
+links:
+  - label: "ISED — Summary of Inputs"
+    url: https://ised-isde.canada.ca/site/ised/en/public-consultations/engagements-canadas-next-ai-strategy-summary-inputs
+    icon: document
+  - label: "PDF — Full Report"
+    url: https://ised-isde.canada.ca/site/ised/sites/default/files/documents/AiStrategyReport_EN.pdf
+    icon: document
+
+tags:
+  - ised
+  - public-consultation
+  - ai-strategy
+  - federal-government

--- a/data/events/2025-09-26-ai-strategy-sprint-launched.yaml
+++ b/data/events/2025-09-26-ai-strategy-sprint-launched.yaml
@@ -1,7 +1,7 @@
 # events/2025-09-26-ai-strategy-sprint-launched.yaml
 
 id: ai-strategy-sprint-launched-2025
-type: PublicConsultation
+type: GovernmentAnnouncement
 schema_type: Event
 
 title: "Government of Canada launches 30-day AI Sprint and AI Strategy Task Force"

--- a/data/events/2025-09-26-ai-strategy-sprint-launched.yaml
+++ b/data/events/2025-09-26-ai-strategy-sprint-launched.yaml
@@ -1,0 +1,44 @@
+# events/2025-09-26-ai-strategy-sprint-launched.yaml
+
+id: ai-strategy-sprint-launched-2025
+type: PublicConsultation
+schema_type: Event
+
+title: "Government of Canada launches 30-day AI Sprint and AI Strategy Task Force"
+date: 2025-09-26
+status: completed
+
+organizations:
+  - id: ised-canada
+    role: organizer
+
+description: >
+  Minister Evan Solomon (Minister of Artificial Intelligence and Digital
+  Innovation) announces a 30-day national sprint (October 1–31, 2025) inviting
+  Canadians to share views on Canada's next national AI strategy via the
+  Consulting Canadians portal. Simultaneously, an AI Strategy Task Force of
+  40 leaders from academia, industry, civil society, and government is
+  constituted to provide actionable insights and recommendations across nine
+  thematic areas. Over 11,300 Canadians participate and the Task Force
+  produces 28 reports.
+
+related_artifacts:
+  - id: ai-strategy-summary-of-inputs-2026
+
+tags:
+  - ised
+  - public-consultation
+  - ai-strategy
+  - federal-government
+  - evan-solomon
+
+links:
+  - label: "Canada.ca — Announcement"
+    url: https://www.canada.ca/en/innovation-science-economic-development/news/2025/09/government-of-canada-launches-ai-strategy-task-force-and-public-engagement-on-the-development-of-the-next-ai-strategy.html
+    icon: document
+  - label: "ISED — Consultation page"
+    url: https://ised-isde.canada.ca/site/ised/en/public-consultations/next-chapter-canadas-ai-leadership
+    icon: document
+  - label: "ISED — AI Strategy Task Force"
+    url: https://ised-isde.canada.ca/site/ised/en/advisory-council-artificial-intelligence/ai-strategy-task-force
+    icon: document

--- a/data/events/2026-02-05-ai-strategy-summary-of-inputs-published.yaml
+++ b/data/events/2026-02-05-ai-strategy-summary-of-inputs-published.yaml
@@ -1,0 +1,33 @@
+# events/2026-02-05-ai-strategy-summary-of-inputs-published.yaml
+
+id: ai-strategy-summary-of-inputs-published-2026
+type: Publication
+schema_type: Event
+
+title: "ISED publishes summary of inputs from 30-day AI Sprint"
+date: 2026-02-05
+status: completed
+
+organizations:
+  - id: ised-canada
+    role: publisher
+
+description: >
+  ISED publishes "Engagements on Canada's next AI Strategy: Summary of
+  inputs," synthesizing over 11,300 public responses, 28 AI Strategy Task
+  Force reports, and nearly 300 policy submissions gathered during the
+  October 2025 30-day national sprint.
+
+related_artifacts:
+  - id: ai-strategy-summary-of-inputs-2026
+
+tags:
+  - ised
+  - public-consultation
+  - ai-strategy
+  - federal-government
+
+links:
+  - label: "ISED — Summary of Inputs"
+    url: https://ised-isde.canada.ca/site/ised/en/public-consultations/engagements-canadas-next-ai-strategy-summary-inputs
+    icon: document


### PR DESCRIPTION
## Summary

- Adds event for the launch of Canada's 30-day AI Sprint and AI Strategy Task Force (Sept 26, 2025, announced by Minister Evan Solomon)
- Adds artifact for "Engagements on Canada's next AI Strategy: Summary of inputs" (Feb 5, 2026, ISED)
- Adds event for the publication of that report

Closes #17

## Data sources

- [Canada.ca announcement](https://www.canada.ca/en/innovation-science-economic-development/news/2025/09/government-of-canada-launches-ai-strategy-task-force-and-public-engagement-on-the-development-of-the-next-ai-strategy.html)
- [ISED consultation page](https://ised-isde.canada.ca/site/ised/en/public-consultations/next-chapter-canadas-ai-leadership)
- [ISED Summary of Inputs](https://ised-isde.canada.ca/site/ised/en/public-consultations/engagements-canadas-next-ai-strategy-summary-inputs)

## Test plan

- [ ] Event file `2025-09-26-ai-strategy-sprint-launched.yaml` has correct date, status, org ref, and links
- [ ] Artifact file `2026-02-05-ai-strategy-summary-of-inputs.yaml` has `derives_from` pointing to the sprint event
- [ ] Publication event `2026-02-05-ai-strategy-summary-of-inputs-published.yaml` references the artifact
- [ ] No orphaned cross-references (all `id` values resolve within the data set)