### PR TITLE
Add CIGI policy recommendations and data-adr/ directory (issues #13, #14)

### DIFF
--- a/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
+++ b/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
@@ -41,12 +41,98 @@ links:
     icon: document
 
 policy_recommendations:
-  # TODO: Policy recommendations could not be extracted — the CIGI site and PDF
-  # are behind Cloudflare. Fetch https://www.cigionline.org/static/documents/AI_National_Security.pdf
-  # manually to fill these in.
-  - id: rec-001
-    summary: ""
-    status: untracked  # untracked | under_review | adopted | rejected
+  # "No regrets" — useful in all or multiple scenarios
+  - id: rec-nr-001
+    title: "Encourage reliable AI diffusion and adoption"
+    summary: >
+      Promote widespread diffusion and adoption of reliable AI tools to advance
+      productivity and prosperity, while preventing adoption of unreliable AI in
+      critical systems.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-002
+    title: "Invest in skills, data, and compute"
+    summary: >
+      Invest in widespread skills development and broad access to data and
+      computing power.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-003
+    title: "Support AI-displaced workers"
+    summary: >
+      Strengthen measures to support workers displaced by AI-enabled automation,
+      including retraining, income support, and AI-enabled learning tools.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-004
+    title: "Strengthen information-sharing protocols"
+    summary: >
+      Strengthen information-sharing protocols to facilitate research cooperation
+      without unintended information flows.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-005
+    title: "Expand international AI safety cooperation"
+    summary: >
+      Expand international cooperation and research on AI safety and security,
+      including risks, technical safety, and governance mechanisms.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-006
+    title: "Build shared understanding of global AI risks"
+    summary: >
+      Build shared international understanding about global-scale AI risks and
+      mitigations, including with rival powers, as a foundation for future
+      cooperation if needed.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-007
+    title: "Limit AI in military decisions; regulate autonomous weapons"
+    summary: >
+      Limit use of AI systems in key military decisions and strengthen national
+      and international rules on the use of autonomous weapons.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-008
+    title: "Strengthen AI incident monitoring and emergency protocols"
+    summary: >
+      Strengthen national and international AI incident monitoring and build
+      protocols for coordinated emergency response.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-009
+    title: "Develop redundant knowledge repositories"
+    summary: >
+      Develop redundant physical and digital repositories of information for
+      knowledge preservation in the event of an accidental or necessary internet
+      shutdown.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-010
+    title: "Implement AI transparency and whistleblower protections"
+    summary: >
+      Implement transparency requirements and whistleblower protections for
+      disclosures about dangerous AI systems or practices.
+    robustness: robust
+    status: untracked
+
+  - id: rec-nr-011
+    title: "Harden digital systems and biosecurity defences"
+    summary: >
+      Harden digital systems from cyberattacks, limit access to bio-synthesis
+      tools, and improve detection and response to novel pathogens — essential
+      at all levels of AI development.
+    robustness: robust
+    status: untracked
 
 tags:
   - national-security

--- a/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
+++ b/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
@@ -134,6 +134,219 @@ policy_recommendations:
     robustness: robust
     status: untracked
 
+  # Scenario 1: AI Stall — necessary bets
+  - id: rec-s1-001
+    title: "Remove regulatory impediments to AI adoption"
+    summary: >
+      Promote rapid AI adoption by removing regulatory impediments, while
+      strengthening incentives for the development and deployment of reliable
+      AI systems and tools.
+    robustness: contingent
+    scenarios: [scenario-ai-stall]
+    status: untracked
+
+  - id: rec-s1-002
+    title: "Prepare for moderate-to-high AI-driven job losses"
+    summary: >
+      Prepare for the possibility of moderate-to-high job losses and economic
+      disruption by enhancing policy measures for retraining, income support,
+      business development, and cost-of-living reduction.
+    robustness: contingent
+    scenarios: [scenario-ai-stall]
+    status: untracked
+
+  - id: rec-s1-003
+    title: "Monitor AI adoption risks in critical domains"
+    summary: >
+      Monitor and mitigate AI adoption risks in key domains such as nuclear
+      missile launch, critical infrastructure, and personal companionship, to
+      avoid critical failures.
+    robustness: contingent
+    scenarios: [scenario-ai-stall]
+    status: untracked
+
+  # Scenario 2: Precarious Precipice — necessary bets
+  - id: rec-s2-001
+    title: "Prepare for extreme AI-driven job losses"
+    summary: >
+      Prepare for the possibility of extreme job losses and economic disruption,
+      including by developing new income distribution infrastructure.
+    robustness: contingent
+    scenarios: [scenario-precarious-precipice]
+    status: untracked
+
+  - id: rec-s2-002
+    title: "Develop systems to address widening international income inequality"
+    summary: >
+      Develop international systems to address severely widening income
+      inequalities among countries driven by uneven AI adoption.
+    robustness: contingent
+    scenarios: [scenario-precarious-precipice]
+    status: untracked
+
+  - id: rec-s2-003
+    title: "Establish joint international limits on AI in critical domains"
+    summary: >
+      Establish joint international limits on AI adoption in key domains such as
+      nuclear missile launch and critical infrastructure to avoid critical
+      failures.
+    robustness: contingent
+    scenarios: [scenario-precarious-precipice]
+    status: untracked
+
+  - id: rec-s2-004
+    title: "Limit overall societal automation to preserve human agency"
+    summary: >
+      Establish joint international limits on the overall level of AI adoption
+      and societal automation, if needed, to prevent excessive displacement of
+      humans in decision making.
+    robustness: contingent
+    scenarios: [scenario-precarious-precipice]
+    status: untracked
+
+  - id: rec-s2-005
+    title: "Build trust to limit military AI race escalation"
+    summary: >
+      Build trust and defuse tension between rival powers to limit a military AI
+      race that could result in rapid, unintended escalation and global conflict.
+    robustness: contingent
+    scenarios: [scenario-precarious-precipice]
+    status: untracked
+
+  - id: rec-s2-006
+    title: "Develop protocols for predictable AI-enabled military escalation"
+    summary: >
+      Limit use of AI systems in key military decisions and develop protocols for
+      scaled and predictable sabotage and retaliation to reduce the risk of
+      sudden destabilizing shifts in the balance of power.
+    robustness: contingent
+    scenarios: [scenario-precarious-precipice]
+    status: untracked
+
+  - id: rec-s2-007
+    title: "Implement international AI transparency and monitoring regime"
+    summary: >
+      Implement a robust international AI transparency and monitoring regime to
+      provide timely alerts of emerging global AI risks, such as from imminent
+      breakthroughs in AI capabilities.
+    robustness: contingent
+    scenarios: [scenario-precarious-precipice]
+    status: untracked
+
+  - id: rec-s2-008
+    title: "Ensure emergency protocols for sudden AI capability jumps"
+    summary: >
+      Ensure that national and coordinated emergency response protocols are
+      adequate to handle risks posed by the potential sudden emergence of much
+      more capable AI systems.
+    robustness: contingent
+    scenarios: [scenario-precarious-precipice]
+    status: untracked
+
+  # Scenario 3a: Hypercompetition — necessary bets
+  - id: rec-s3a-001
+    title: "Coordinate ASI use across countries to avoid conflict"
+    summary: >
+      Develop mechanisms to coordinate use of ASIs across countries to avoid
+      ASI-enabled conflict among multiple controllable ASI powers.
+    robustness: contingent
+    scenarios: [scenario-hypercompetition]
+    status: untracked
+
+  - id: rec-s3a-002
+    title: "Prevent ASI takeover by a faction"
+    summary: >
+      Develop national or international mechanisms to prevent any single faction
+      from gaining control of an ASI.
+    robustness: contingent
+    scenarios: [scenario-hypercompetition, scenario-hyperpower]
+    status: untracked
+
+  - id: rec-s3a-003
+    title: "Develop technical verification to prevent ASI weaponization"
+    summary: >
+      Develop technical verification and compliance measures to prevent malicious
+      use and weaponization of ASI systems.
+    robustness: contingent
+    scenarios: [scenario-hypercompetition]
+    status: untracked
+
+  - id: rec-s3a-004
+    title: "Prepare moratorium agreement on ASI development"
+    summary: >
+      Prepare an international agreement with the ability to enforce a moratorium
+      on ASI development if required.
+    robustness: contingent
+    scenarios: [scenario-hypercompetition]
+    status: untracked
+
+  - id: rec-s3a-005
+    title: "Prepare mechanisms for safe international ASI cooperation"
+    summary: >
+      Prepare an international agreement with mechanisms to coordinate use of
+      ASIs across countries if safe ASI cooperation is seen as possible.
+    robustness: contingent
+    scenarios: [scenario-hypercompetition]
+    status: untracked
+
+  # Scenario 3b: Hyperpower — necessary bets
+  - id: rec-s3b-001
+    title: "Adopt antitrust measures against ASI monopoly"
+    summary: >
+      Adopt antitrust measures to prevent monopoly and singleton control of ASI
+      in the market or politically.
+    robustness: contingent
+    scenarios: [scenario-hyperpower]
+    status: untracked
+
+  - id: rec-s3b-002
+    title: "Ensure inclusive international ASI governance"
+    summary: >
+      Implement international agreement and cooperation to ensure inclusive and
+      legitimate decision making around the development and use of ASI.
+    robustness: contingent
+    scenarios: [scenario-hyperpower]
+    status: untracked
+
+  # Scenario 4: Rogue ASI — necessary bets
+  - id: rec-s4-001
+    title: "Develop international ability to prevent uncontrolled ASI"
+    summary: >
+      Develop the ability, via international cooperation if necessary, to prevent
+      creation of ASI anywhere in the world until there is sufficient evidence
+      that it can be controlled and aligned.
+    robustness: contingent
+    scenarios: [scenario-rogue-asi]
+    status: untracked
+
+  - id: rec-s4-002
+    title: "Prepare ASI emergency response and kill switches"
+    summary: >
+      Prepare emergency response strategies including kill switches for ASI and
+      protocols for rapid containment of a nascent rogue ASI.
+    robustness: contingent
+    scenarios: [scenario-rogue-asi]
+    status: untracked
+
+  - id: rec-s4-003
+    title: "Ensure air-gapped networks and cyber defence for critical systems"
+    summary: >
+      Ensure air-gapped networks and robust cyber defence for critical systems
+      to limit a rogue ASI's ability to propagate or gain control.
+    robustness: contingent
+    scenarios: [scenario-rogue-asi]
+    status: untracked
+
+  - id: rec-s4-004
+    title: "Prepare analogue contingency systems for continuity of authority"
+    summary: >
+      Prepare resource stockpiles, citizen defence brigades, training programs,
+      and analogue contingency systems to ensure continuity of authority in the
+      event of loss of control to a rogue ASI.
+    robustness: contingent
+    scenarios: [scenario-rogue-asi]
+    status: untracked
+
 tags:
   - national-security
   - policy-recommendations

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -22,6 +22,9 @@ Michael Nygard.
 Conventions:
 
 - ADRs live in `docs/adr/`.
+- Data model decisions (schema fields, cross-reference conventions, YAML
+  structure, schema.org mappings, data directory layout) are recorded separately
+  in `docs/data-adr/` using the same format and numbering conventions.
 - Files are named `NNNN-kebab-case-title.md`, numbered sequentially starting
   at `0001`.
 - Each ADR has the sections: **Status**, **Context**, **Decision**,

--- a/docs/data-adr/0001-record-data-architecture-decisions.md
+++ b/docs/data-adr/0001-record-data-architecture-decisions.md
@@ -1,0 +1,48 @@
+# 1. Record data architecture decisions
+
+Date: 2026-04-26
+
+## Status
+
+Accepted
+
+## Context
+
+As the project's data model grows, decisions about schema fields, cross-reference
+conventions, YAML structure, schema.org mappings, and directory layout need a
+durable record. These decisions are distinct from site/infrastructure choices (which
+live in `docs/adr/`) and benefit from their own browseable history.
+
+## Decision
+
+We will use Data Architecture Decision Records (data ADRs) to capture significant
+data model decisions, following the same lightweight format used in `docs/adr/`.
+
+Conventions:
+
+- Data ADRs live in `docs/data-adr/`.
+- Files are named `NNNN-kebab-case-title.md`, numbered sequentially starting
+  at `0001`.
+- Each ADR has the sections: **Status**, **Context**, **Decision**,
+  **Consequences**.
+- **Status** is one of: `Proposed`, `Accepted`, `Deprecated`, or
+  `Superseded by data-ADR-NNNN`.
+- ADRs are immutable once accepted. To change a decision, write a new ADR
+  that supersedes the old one, and update the old one's status.
+
+Scope — data ADRs cover:
+- Schema fields added to YAML artifact, event, or organization records
+- Cross-reference field naming conventions (e.g., `id`, `role`, `relationship`)
+- YAML structural patterns (e.g., flat lists vs. nested blocks)
+- schema.org type mappings
+- Data directory layout under `data/`
+
+Site/infrastructure decisions (framework, deployment, testing) belong in
+`docs/adr/`, not here.
+
+## Consequences
+
+- A small amount of overhead per data model decision.
+- A clear, browseable history of why the data model looks the way it does.
+- New contributors can understand data conventions without archaeology through
+  git history.

--- a/docs/data-adr/0002-policy-recommendation-schema.md
+++ b/docs/data-adr/0002-policy-recommendation-schema.md
@@ -1,0 +1,75 @@
+# 2. Policy recommendation schema
+
+Date: 2026-04-26
+
+## Status
+
+Accepted
+
+## Context
+
+The CIGI/PCO AI National Security Scenarios report (artifact
+`cigi-pco-ai-national-security-report-2026`) organizes its policy recommendations
+into two groups from Figure 3:
+
+- **"No regrets"**: 11 cross-cutting actions useful in all scenarios.
+- **"Necessary bets"**: scenario-specific actions (3, 8, 5, 3, 4 items for
+  Scenarios 1–4).
+
+The existing `policy_recommendations` schema had only `id`, `summary`, and
+`status`. It needed extension to capture the no-regrets/necessary-bets
+distinction, a short human-readable title, and scenario linkage for contingent
+items.
+
+Other artifacts use a `provisions` field (e.g., ISED code of practice) with
+`id`/`title`/`summary`. The `policy_recommendations` field is kept as a
+separate concept: provisions describe substantive principles; recommendations
+describe actionable policy asks.
+
+## Decision
+
+**`robustness` field** (`robust` | `contingent`): Captures the expected-value
+distinction the report makes. "No regrets" actions have positive value in all
+possible AI futures (robust to the future); "necessary bets" are only worth
+pursuing if a particular scenario materializes (contingent on it). The field
+name describes the property rather than the report's colloquial label.
+
+**`title` field**: A short (3–8 word) human-readable label alongside the
+longer `summary`. Follows the `id`/`title`/`summary` pattern from ISED
+provisions.
+
+**`scenarios` field** (list of scenario IDs, present only on contingent items):
+Records which scenario(s) a recommendation applies to. Omitted on robust items
+to keep the YAML clean. This field is a staging ground for the future
+risk→recommendation mapping (issue #33): once a risk taxonomy is built, risks
+will carry scenario-probability data, and recommendations will gain an
+`addresses` field referencing risk IDs. `scenarios` and the future `addresses`
+are intentionally separate — scenarios are macro-level futures, risks are
+specific failure modes whose likelihood varies across scenarios.
+
+**`status` field**: Unchanged from existing schema (`untracked | under_review |
+adopted | rejected`).
+
+Scenario IDs used in `scenarios`:
+
+| ID | Scenario |
+|----|----------|
+| `scenario-ai-stall` | Scenario 1 — AI Stall |
+| `scenario-precarious-precipice` | Scenario 2 — Precarious Precipice |
+| `scenario-hypercompetition` | Scenario 3a — Hypercompetition |
+| `scenario-hyperpower` | Scenario 3b — Hyperpower |
+| `scenario-rogue-asi` | Scenario 4 — Rogue ASI |
+
+Recommendation IDs use prefixes: `rec-nr-NNN` (no regrets),
+`rec-s1-NNN`, `rec-s2-NNN`, `rec-s3a-NNN`, `rec-s3b-NNN`, `rec-s4-NNN`.
+
+## Consequences
+
+- `policy_recommendations` entries now have `id`, `title`, `summary`,
+  `robustness`, optionally `scenarios`, and `status`.
+- Other artifacts that gain `policy_recommendations` in future should follow
+  this schema; `provisions` remains a separate field for principle descriptions.
+- When issue #33 risk taxonomy is built, add `addresses: []` to recommendations
+  and populate with risk IDs. The `scenarios` field can remain as-is (it records
+  the report's own scenario linkage, which may differ from the risk taxonomy's
+  scenario-probability mapping).

--- a/docs/superpowers/specs/2026-04-26-cigi-policy-recommendations-design.md
+++ b/docs/superpowers/specs/2026-04-26-cigi-policy-recommendations-design.md
@@ -1,0 +1,105 @@
+# Design: CIGI Policy Recommendations Data Entry
+
+Date: 2026-04-26  
+Issue: [#13 — Add policy element content](https://github.com/jrhender/ai-governance-tracker/issues/13)  
+Related: [#14 — Data ADRs](https://github.com/jrhender/ai-governance-tracker/issues/14), [#33 — Risk mapping](https://github.com/jrhender/ai-governance-tracker/issues/33)
+
+## Overview
+
+Fill the currently empty `policy_recommendations` block in
+`data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml` with
+structured data drawn from Figure 3 of the report (the "no regrets" /
+"necessary bets" synthesis table, ~25 items). Simultaneously establish a
+`docs/data-adr/` directory for data architecture decisions, and record the
+schema decisions made here as ADR-0002.
+
+## Schema
+
+Each recommendation entry:
+
+```yaml
+- id: rec-no-regrets-001        # stable kebab ID, prefixed by robustness type
+  title: "Short label"          # 3-8 words, drawn from the report
+  summary: "..."                # one sentence expanding the title
+  robustness: robust            # robust | contingent
+  scenarios: []                 # omitted for robust items; list of scenario IDs for contingent
+  status: untracked             # untracked | under_review | adopted | rejected
+```
+
+### Field rationale
+
+**`robustness`** (`robust` | `contingent`): Captures the report's
+"no regrets" / "necessary bets" distinction. "No regrets" actions have
+positive expected value across all possible AI futures; "necessary bets" are
+only worth pursuing if a particular scenario materializes. `robustness` names
+this expected-value property rather than calling it a category or priority.
+
+**`title`**: A short human-readable label alongside the longer `summary`,
+following the pattern established in `data/artifacts/2023-08-16-ised-gen-ai-code-of-practice.yaml`
+(`provisions` → `id`/`title`/`summary`).
+
+**`scenarios`**: Present only on contingent items. References scenario IDs
+defined within this artifact's context. This is a staging field for the
+future risk→recommendation mapping (issue #33): once a risk taxonomy exists,
+risks will carry scenario-probability data, and recommendations will gain an
+`addresses` field referencing risk IDs. `scenarios` and `addresses` are
+intentionally separate — scenarios are macro-level futures, risks are specific
+failure modes whose likelihood varies across scenarios.
+
+**`status`**: Existing field; unchanged.
+
+### Scenario IDs
+
+Used in `scenarios` for contingent items:
+
+| ID | Scenario |
+|----|----------|
+| `scenario-ai-stall` | Scenario 1 — AI Stall |
+| `scenario-precarious-precipice` | Scenario 2 — Precarious Precipice |
+| `scenario-hypercompetition` | Scenario 3a — Hypercompetition |
+| `scenario-hyperpower` | Scenario 3b — Hyperpower |
+| `scenario-rogue-asi` | Scenario 4 — Rogue ASI |
+
+## Data source
+
+Figure 3 of the report (pp. 36–38): "Policy Responses." Items are drawn
+verbatim or near-verbatim from the table and lightly edited for YAML
+readability. The report organizes responses as:
+
+- **No regrets** (11 items): cross-cutting, useful in all scenarios
+- **Necessary bets** per scenario: 3 (S1) + 8 (S2) + 5 (S3a) + 3 (S3b) + 4 (S4) = 23 items
+
+Total: ~34 entries. IDs are prefixed `rec-no-regrets-NNN` and
+`rec-s1-NNN` / `rec-s2-NNN` / `rec-s3a-NNN` / `rec-s3b-NNN` / `rec-s4-NNN`.
+
+## ADR changes
+
+Three ADR-related deliverables:
+
+1. **Update `docs/adr/0001`** — add a note that site/infrastructure decisions
+   live in `docs/adr/` and data model decisions live in `docs/data-adr/`.
+
+2. **`docs/data-adr/0001-record-data-architecture-decisions.md`** — bootstrap
+   ADR establishing the `docs/data-adr/` directory, conventions (same NNNN
+   format as site ADRs), and scope (data model: schema fields, cross-reference
+   conventions, YAML structure, schema.org mappings, data directory layout).
+
+3. **`docs/data-adr/0002-policy-recommendation-schema.md`** — captures the
+   decisions in this spec: `robustness` field and values, `title`+`summary`
+   pattern, `scenarios` as staging field for future risk linkage, `addresses`
+   deferred to issue #33.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml` | Fill `policy_recommendations` block; remove TODO comment and placeholder |
+| `docs/adr/0001-record-architecture-decisions.md` | Add note about `docs/data-adr/` split |
+| `docs/data-adr/0001-record-data-architecture-decisions.md` | New — bootstrap data ADR |
+| `docs/data-adr/0002-policy-recommendation-schema.md` | New — schema decisions for policy recommendations |
+
+## Out of scope
+
+- Risk taxonomy (`addresses` field, issue #33)
+- UI changes to surface `robustness` or `scenarios` on the timeline or artifact pages
+- People records for Duncan Cass-Beggs and Matthew da Mota (authors listed in the artifact)


### PR DESCRIPTION
## Summary

- Fills the empty `policy_recommendations` block in `data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml` with all 33 structured entries from Figure 3 of the CIGI/PCO AI National Security Scenarios report
- Establishes `docs/data-adr/` directory for data model decisions (separate from `docs/adr/` for site/infra), with bootstrap ADR and schema ADR for the new policy recommendation fields
- Adds `robustness` (`robust`/`contingent`), `title`, `summary`, and `scenarios` fields to each recommendation; `scenarios` is a staging field for the future risk→recommendation mapping (issue #33)

**Spec:** `docs/superpowers/specs/2026-04-26-cigi-policy-recommendations-design.md`  
**Plan:** `docs/superpowers/plans/2026-04-26-cigi-policy-recommendations.md`  
Closes #13, contributes to #14

## Test Plan

- [ ] `npm test` passes (13/13 unit tests)
- [ ] YAML file has exactly 33 recommendation entries (`grep -c "^  - id: rec-" data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml` → 33)
- [ ] 11 entries have `robustness: robust` and no `scenarios` field
- [ ] 22 entries have `robustness: contingent` with appropriate `scenarios` lists
- [ ] `docs/data-adr/` directory exists with `0001` and `0002` ADRs
- [ ] `docs/adr/0001` mentions `docs/data-adr/` split