### PR TITLE
Add AIGS org and white papers with policy recommendations (issue #27)

### DIFF
--- a/data/artifacts/2023-10-18-aigs-governing-ai-2023.yaml
+++ b/data/artifacts/2023-10-18-aigs-governing-ai-2023.yaml
@@ -1,0 +1,88 @@
+# artifacts/2023-10-18-aigs-governing-ai-2023.yaml
+
+id: aigs-governing-ai-2023
+type: WhitePaper
+schema_type: CreativeWork
+
+title: "Governing AI: A Plan for Canada"
+subtitle: "Five high-impact actions needed in 2023/2024"
+published_date: 2023-10-18
+
+authors:
+  - name: "Wyatt Tessari L'Allié"
+    role: author
+  - name: "Gabrielle Tran"
+    role: author
+
+organizations:
+  - id: aigs-canada
+    role: publisher
+
+description: >
+  White paper by AI Governance and Safety Canada (AIGS) outlining five
+  high-impact actions for the Canadian government to significantly advance
+  AI governance by end of Q2 2024. The paper covers the evolving AI risk
+  landscape from narrow AI through to potential AGI, key considerations for
+  AI governance, and concrete recommendations for Canada.
+
+links:
+  - label: "White Paper (PDF)"
+    url: https://aigs.ca/2023-white-paper.pdf
+    icon: document
+  - label: "Announcement"
+    url: https://aigs.ca/news/231018-aigs-unveils-governing-ai-a-plan-for-canada/
+    icon: document
+
+policy_recommendations:
+  - id: rec-2023-001
+    title: "Establish a central AI agency for the Government of Canada"
+    summary: >
+      Create an expert team based within the Privy Council Office to monitor
+      and inform leadership about AI developments, communicate with the
+      provinces, and coordinate federal action. ISED and other departments
+      lack the institutional incentives or mandate to navigate and balance
+      the full range of issues.
+    status: untracked
+
+  - id: rec-2023-002
+    title: "Invest >$500M in AI governance and safety research"
+    summary: >
+      More than double the existing CIFAR Pan-Canadian AI Strategy funding,
+      earmarking the extra funds to developing better policy and technical AI
+      safety solutions. Governance and safety research must rapidly catch up
+      to the hundreds of billions invested annually in capabilities.
+    status: untracked
+
+  - id: rec-2023-003
+    title: "Champion and fund global AI governance efforts"
+    summary: >
+      Support global initiatives such as at the UN, G7, UK safety summit,
+      and OECD. Lead the conversation about CERN, IPCC, and IAEA models for
+      global AI governance. Without global coordination, domestic regulation
+      will simply push AI development to other jurisdictions.
+    status: untracked
+
+  - id: rec-2023-004
+    title: "Improve and pass the AI & Data Act"
+    summary: >
+      Accelerate consultations and drafting of legislation as the best
+      mechanism for enacting policies on audits, transparency, and liability.
+      Establish a Canadian AI Commission to regulate high-risk models.
+    status: untracked
+
+  - id: rec-2023-005
+    title: "Launch a national conversation on AI"
+    summary: >
+      Hold nationwide open public consultations to inform policy decisions
+      on AI in relation to the jobs transition, wealth concentration, and
+      the right balance between pursuing rewards and limiting risks. Canada's
+      relative stability and strong AI ecosystem make it well placed to lead
+      this conversation.
+    status: untracked
+
+tags:
+  - ai-governance
+  - ai-safety
+  - policy-recommendations
+  - aigs
+  - white-paper

--- a/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
+++ b/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
@@ -1,0 +1,98 @@
+# artifacts/2024-06-26-aigs-governing-ai-2024.yaml
+
+id: aigs-governing-ai-2024
+type: WhitePaper
+schema_type: CreativeWork
+
+title: "Governing AI: A Plan for Canada"
+subtitle: "Five high-impact actions needed in 2024/2025"
+published_date: 2024-06-26
+
+authors:
+  - name: "Wyatt Tessari L'Allié"
+    role: author
+    affiliation: "Founder, AIGS Canada"
+  - name: "Kathrin Gardhouse"
+    role: author
+    affiliation: "Policy Lead, AIGS Canada"
+
+organizations:
+  - id: aigs-canada
+    role: publisher
+
+description: >
+  Updated white paper by AI Governance and Safety Canada (AIGS) outlining
+  five high-impact actions for the Canadian government to significantly advance
+  AI governance by end of Q2 2025. The paper updates the 2023 edition with
+  the latest developments in AI capabilities and governance, including Canada's
+  $2.4B budget investment in compute access and the creation of the AI Safety
+  Institute (AISI). Recommends a Ministry of AI, improved legislation, and
+  increased safety research investment.
+
+links:
+  - label: "White Paper (PDF)"
+    url: https://aigs.ca/2024-white-paper.pdf
+    icon: document
+  - label: "Announcement"
+    url: https://aigs.ca/news/240626-aigs-unveils-2024-white-paper/
+    icon: document
+
+policy_recommendations:
+  - id: rec-2024-001
+    title: "Establish a Ministry of AI"
+    summary: >
+      Create a dedicated Ministry of AI to ensure a direct voice at Cabinet
+      and awareness of AI's impact on other top portfolios. The ministry
+      would house AI regulatory bodies, monitor and inform leadership about
+      AI developments, communicate with the provinces, and coordinate federal
+      action. Avoids ISED's conflicting mandate of boosting development while
+      also regulating it.
+    status: untracked
+
+  - id: rec-2024-002
+    title: "Champion and fund global AI governance efforts"
+    summary: >
+      Support global efforts addressing frontier AI race dynamics and host
+      talks on global AI governance during Canada's 2025 G7 leadership.
+      Without global coordination, domestic regulation will simply push AI
+      development to other jurisdictions, and frontier AI development is
+      mostly happening abroad.
+    status: untracked
+
+  - id: rec-2024-003
+    title: "Improve and pass the AI & Data Act and supporting regulations"
+    summary: >
+      Provide a legal framework to address a range of ethics and safety
+      concerns. Improve the Canadian AI Data Commissioner's (AIDC) independence
+      by moving its administration to the new Ministry of AI to avoid
+      conflict with ISED's mandate. There is no time to drop the AIDA and
+      reintroduce it later.
+    status: untracked
+
+  - id: rec-2024-004
+    title: "Increase and focus Budget 2024 investments on safety and governance"
+    summary: >
+      Dedicate more than $500M for research on technical AI and governance
+      policy research, coordinated by Canada's new AI Safety Institute. Allocate
+      more than 20% of the proposed AI Compute Access Fund for research on
+      frontier AI safety. The AISI's $50M in funding is insufficient given
+      the scale of AI safety needs.
+    status: untracked
+
+  - id: rec-2024-005
+    title: "Launch a national conversation on AI"
+    summary: >
+      Hold nationwide open public consultations to inform policy decisions
+      on AI in relation to the jobs transition, wealth concentration, and
+      the right balance between pursuing rewards and limiting risks. AI will
+      radically transform society, and managing this transition needs to start
+      early with Canada's relative stability and strong AI ecosystem making
+      it well placed to lead.
+    status: untracked
+
+tags:
+  - ai-governance
+  - ai-safety
+  - policy-recommendations
+  - aigs
+  - white-paper

--- a/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
+++ b/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
@@ -4,7 +4,7 @@ id: aigs-governing-ai-2024
 type: WhitePaper
 schema_type: CreativeWork
 
-title: "Governing AI: A Plan for Canada"
+title: "Governing AI: A Plan for Canada (2024 Update)"
 subtitle: "Five high-impact actions needed in 2024/2025"
 published_date: 2024-06-26
 

--- a/data/artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
+++ b/data/artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
@@ -1,0 +1,82 @@
+# artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
+
+id: aigs-preparing-for-ai-crisis-2025
+type: WhitePaper
+schema_type: CreativeWork
+
+title: "Preparing for the AI Crisis: A Plan for Canada"
+published_date: 2025-10-21
+
+authors:
+  - name: "Wyatt Tessari L'Allié"
+    role: author
+    affiliation: "Founder and Executive Director, AIGS Canada"
+
+organizations:
+  - id: aigs-canada
+    role: publisher
+
+description: >
+  White paper by AI Governance and Safety Canada (AIGS) warning that leading
+  AI labs may develop smarter-than-human AI within 18 months and urging
+  urgent federal action to prepare for the resulting crises. The paper offers
+  a concise overview of where AI is headed, the likely crisis points, and
+  why Canada is well placed to lead a global solution. Argues that Canada's
+  best contribution is leadership — to spearhead global talks while building
+  resilience at home.
+
+links:
+  - label: "White Paper (PDF)"
+    url: https://aigs.ca/preparing-for-the-ai-crisis.pdf
+    icon: document
+  - label: "Announcement"
+    url: https://aigs.ca/news/251021-aigs-canada-releases-2025-white-paper/
+    icon: document
+
+policy_recommendations:
+  - id: rec-2025-001
+    title: "Pivot to meet the AI crisis"
+    summary: >
+      The federal government should act urgently, as leading AI labs may
+      develop smarter-than-human AI within 18 months. This could trigger
+      multiple crises including accidents, geopolitical tensions, employment
+      disruption, economic shocks, and social unrest. Government must treat
+      AI development as a strategic emergency.
+    status: untracked
+
+  - id: rec-2025-002
+    title: "Spearhead the global response"
+    summary: >
+      Establish international agreements to minimize conflict, enhance safety
+      protocols, and distribute AI benefits equitably across nations. Canada
+      is well placed to lead global talks given its stable society, educated
+      population, and reputation on the world stage.
+    status: untracked
+
+  - id: rec-2025-003
+    title: "Build Canada's resilience"
+    summary: >
+      Implement domestic measures to address the secondary impacts of the AI
+      crisis, including AI-powered cyberattacks on critical infrastructure,
+      supply chain disruptions from accidents or conflict, fiscal shocks from
+      sustained job losses, and potential loss of access to foreign compute.
+    status: untracked
+
+  - id: rec-2025-004
+    title: "Engage Canadians in a national conversation on AI"
+    summary: >
+      Foster informed public dialogue about AI's transformative impact on
+      Canadian society. Canadians deserve to be informed and consulted on a
+      technology that will reshape their lives. Canada's relative stability
+      and strong AI ecosystem make it a good position to pilot such a
+      conversation.
+    status: untracked
+
+tags:
+  - ai-governance
+  - ai-safety
+  - policy-recommendations
+  - aigs
+  - white-paper
+  - agi
+  - national-security

--- a/data/events/2023-10-18-aigs-governing-ai-2023-published.yaml
+++ b/data/events/2023-10-18-aigs-governing-ai-2023-published.yaml
@@ -1,0 +1,31 @@
+# data/events/2023-10-18-aigs-governing-ai-2023-published.yaml
+
+id: aigs-governing-ai-2023-published
+type: Publication
+schema_type: Event
+title: "AIGS publishes \"Governing AI: A Plan for Canada\" (2023)"
+date: 2023-10-18
+
+organizations:
+  - id: aigs-canada
+    role: publisher
+
+description: >
+  AI Governance and Safety Canada (AIGS) publishes its inaugural white paper
+  outlining five high-impact actions for the Canadian government to advance
+  AI governance by end of Q2 2024.
+
+related_artifacts:
+  - id: aigs-governing-ai-2023
+
+tags:
+  - ai-governance
+  - ai-safety
+  - policy-recommendations
+  - aigs
+  - white-paper
+
+links:
+  - label: "Announcement"
+    url: https://aigs.ca/news/231018-aigs-unveils-governing-ai-a-plan-for-canada/
+    icon: document

--- a/data/events/2024-06-26-aigs-governing-ai-2024-published.yaml
+++ b/data/events/2024-06-26-aigs-governing-ai-2024-published.yaml
@@ -1,0 +1,31 @@
+# data/events/2024-06-26-aigs-governing-ai-2024-published.yaml
+
+id: aigs-governing-ai-2024-published
+type: Publication
+schema_type: Event
+title: "AIGS publishes \"Governing AI: A Plan for Canada\" (2024 update)"
+date: 2024-06-26
+
+organizations:
+  - id: aigs-canada
+    role: publisher
+
+description: >
+  AI Governance and Safety Canada (AIGS) publishes the 2024 update to its
+  annual white paper, outlining five high-impact actions for the Canadian
+  government to advance AI governance by end of Q2 2025.
+
+related_artifacts:
+  - id: aigs-governing-ai-2024
+
+tags:
+  - ai-governance
+  - ai-safety
+  - policy-recommendations
+  - aigs
+  - white-paper
+
+links:
+  - label: "Announcement"
+    url: https://aigs.ca/news/240626-aigs-unveils-2024-white-paper/
+    icon: document

--- a/data/events/2024-06-26-aigs-governing-ai-2024-published.yaml
+++ b/data/events/2024-06-26-aigs-governing-ai-2024-published.yaml
@@ -3,7 +3,7 @@
 id: aigs-governing-ai-2024-published
 type: Publication
 schema_type: Event
-title: "AIGS publishes \"Governing AI: A Plan for Canada\" (2024 update)"
+title: "AIGS publishes \"Governing AI: A Plan for Canada (2024 Update)\""
 date: 2024-06-26
 
 organizations:

--- a/data/events/2025-10-21-aigs-preparing-for-ai-crisis-2025-published.yaml
+++ b/data/events/2025-10-21-aigs-preparing-for-ai-crisis-2025-published.yaml
@@ -1,0 +1,35 @@
+# data/events/2025-10-21-aigs-preparing-for-ai-crisis-2025-published.yaml
+
+id: aigs-preparing-for-ai-crisis-2025-published
+type: Publication
+schema_type: Event
+title: "AIGS publishes \"Preparing for the AI Crisis: A Plan for Canada\" (2025)"
+date: 2025-10-21
+
+organizations:
+  - id: aigs-canada
+    role: publisher
+
+description: >
+  AI Governance and Safety Canada (AIGS) publishes its 2025 white paper,
+  warning that leading AI labs may develop smarter-than-human AI within
+  18 months and urging urgent federal action. Canada's G7 position and stable
+  society make it well placed to lead global talks while building resilience
+  at home.
+
+related_artifacts:
+  - id: aigs-preparing-for-ai-crisis-2025
+
+tags:
+  - ai-governance
+  - ai-safety
+  - policy-recommendations
+  - aigs
+  - white-paper
+  - agi
+  - national-security
+
+links:
+  - label: "Announcement"
+    url: https://aigs.ca/news/251021-aigs-canada-releases-2025-white-paper/
+    icon: document

--- a/data/organizations/aigs-canada.yaml
+++ b/data/organizations/aigs-canada.yaml
@@ -1,0 +1,17 @@
+# organizations/aigs-canada.yaml
+
+id: aigs-canada
+type: Organization
+schema_type: Organization
+
+name: "AI Governance and Safety Canada"
+short_name: "AIGS"
+url: https://aigs.ca/
+founded: 2022
+
+tags:
+  - think-tank
+  - canadian
+  - ai-safety
+  - ai-governance
+  - non-profit


### PR DESCRIPTION
## Summary

- Adds **AI Governance and Safety Canada (AIGS)** as an organization (`data/organizations/aigs-canada.yaml`)
- Adds three annual white papers as artifacts with policy recommendations broken down in the CIGI style:
  - **"Governing AI: A Plan for Canada"** — Oct 2023 (5 recs), Jun 2024 update (5 recs)
  - **"Preparing for the AI Crisis: A Plan for Canada"** — Oct 2025 (4 recs)
- Adds three corresponding publication events

Note: the issue mentioned "a couple" of white papers, but there are three — one per year 2023–2025. All included.

Closes #27

## Test plan

- [ ] Verify org file `aigs-canada` has correct `id`, `url`, and tags
- [ ] Verify artifact files reference `aigs-canada` org by ID
- [ ] Verify policy recommendation IDs are unique across all three artifacts
- [ ] Verify event files cross-reference correct artifact IDs
- [ ] Verify PDF links in artifacts resolve to correct documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)