### PR TITLE
Improve site design with Deep Teal palette and typography (issue #42)

### DIFF
--- a/docs/superpowers/plans/2026-04-27-site-redesign.md
+++ b/docs/superpowers/plans/2026-04-27-site-redesign.md
@@ -1,0 +1,1399 @@
+# Site Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the monochromatic slate/grey design with a Deep Teal palette (petrol blue header, teal-mint accent, warm white body), DM Serif Display + Source Serif 4 + DM Sans typography, teal-accented timeline with inline org chips and source icon links, and an SVG favicon. Light mode only.
+
+**Architecture:** CSS custom properties defined via Tailwind v4's `@theme` block create new utility classes (`bg-header`, `text-accent`, `font-display`, etc.) used consistently across all Astro pages and TSX components. The `TimelineItem` type gains `orgs` and `links` fields, plumbed through from the Astro page, enabling org chips and source icon links in `TimelineList`. Dark mode is removed entirely.
+
+**Tech Stack:** Astro, Tailwind CSS v4 (`@import "tailwindcss"` / `@theme`), React TSX components, Vitest + Testing Library, Google Fonts (DM Serif Display, Source Serif 4, DM Sans).
+
+**Branch:** `feature/site-redesign`  
+**Spec:** `docs/superpowers/specs/2026-04-27-site-redesign-design.md`  
+**Issue:** #42
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/styles/global.css` | Modify | Tailwind v4 `@theme` color + font tokens, base body styles, chip component classes, remove dark variant |
+| `public/favicon.svg` | Create | SVG favicon mark |
+| `src/layouts/BaseLayout.astro` | Modify | Google Fonts, favicon link, petrol blue header with logo-mark + active nav, petrol blue footer, remove dark mode script |
+| `src/lib/timeline.ts` | Modify | Add `orgs` and `links` fields to `TimelineItem` type |
+| `src/pages/timeline/index.astro` | Modify | Pass `orgs` and `links` through when building `TimelineItem` array |
+| `src/components/TimelineList.tsx` | Modify | Full restyle — teal spine/dots, Source Serif 4 titles, org chips, source icon links |
+| `src/components/TimelineList.test.tsx` | Create | Tests for org chip rendering and source link rendering |
+| `src/components/OrgFilter.tsx` | Modify | Restyle filter chips (remove dark:, new active/inactive colours) |
+| `src/pages/index.astro` | Modify | Hero with eyebrow + DM Serif Display headline, teal-left-border feature cards |
+| `src/pages/policy/index.astro` | Modify | DM Serif Display headings, teal-left-border artifact cards, remove dark: |
+| `src/pages/orgs/index.astro` | Modify | Unified teal-left-border card treatment, remove dark: |
+| `src/pages/orgs/[id].astro` | Modify | New palette, accent-dk links, remove dark: |
+| `src/pages/events/[id].astro` | Modify | New palette, remove dark: |
+| `src/pages/artifacts/[id].astro` | Modify | New palette, remove dark: |
+
+---
+
+## Task 1: CSS Tokens + Favicon
+
+**Files:**
+- Modify: `src/styles/global.css`
+- Create: `public/favicon.svg`
+
+- [ ] **Step 1: Replace global.css contents**
+
+```css
+@import "tailwindcss";
+
+@theme {
+  /* Fonts */
+  --font-sans:    'DM Sans', system-ui, sans-serif;
+  --font-serif:   'Source Serif 4', Georgia, serif;
+  --font-display: 'DM Serif Display', Georgia, serif;
+
+  /* Colours */
+  --color-header:    #0f3040;
+  --color-accent:    #4ecdc4;
+  --color-accent-dk: #2aada4;
+  --color-body:      #f7f8f8;
+  --color-surface:   #ffffff;
+  --color-border:    #d0dce0;
+  --color-border-lt: #e8f0f4;
+  --color-ink:       #0f2a38;
+  --color-muted:     #5a7a88;
+  --color-faint:     #8aa0aa;
+}
+
+:root {
+  color-scheme: light;
+}
+
+@layer base {
+  body {
+    font-family: var(--font-sans);
+    background-color: var(--color-body);
+    color: var(--color-ink);
+  }
+}
+
+@layer components {
+  .chip-type {
+    @apply inline-block text-xs px-2 py-0.5 rounded-full font-semibold;
+    background: #e0f4f4;
+    color: #0a5858;
+    border: 1px solid #a8dcdc;
+  }
+
+  .chip-org {
+    @apply inline-block text-xs px-2 py-0.5 rounded-full font-semibold no-underline;
+    background: white;
+    color: #1a5878;
+    border: 1px solid #b0d4e4;
+  }
+
+  .chip-org:hover {
+    background: #e8f4f8;
+    border-color: #7ab8d0;
+  }
+}
+```
+
+- [ ] **Step 2: Create the public directory and favicon**
+
+Create `public/favicon.svg` (the `public/` directory doesn't exist yet — create it with the file):
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#0f3040"/>
+  <text
+    x="16" y="22"
+    font-family="Georgia, serif"
+    font-size="14"
+    font-weight="700"
+    fill="#4ecdc4"
+    text-anchor="middle"
+  >AI</text>
+</svg>
+```
+
+- [ ] **Step 3: Verify build succeeds**
+
+```bash
+npm run build
+```
+
+Expected: build completes with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/styles/global.css public/favicon.svg
+git commit -m "Add Deep Teal design tokens and SVG favicon (issue #42)"
+```
+
+---
+
+## Task 2: BaseLayout — Header, Footer, Fonts, Dark Mode Removal
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro`
+
+- [ ] **Step 1: Replace BaseLayout.astro contents**
+
+```astro
+---
+import "../styles/global.css";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+const siteTitle = "AI Governance Tracker";
+const fullTitle = title === siteTitle ? title : `${title} — ${siteTitle}`;
+
+const path = Astro.url.pathname;
+const navLinks = [
+  { href: "/timeline/", label: "Timeline" },
+  { href: "/orgs/", label: "Organizations" },
+  { href: "/policy/", label: "Policy" },
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{fullTitle}</title>
+    {description && <meta name="description" content={description} />}
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&family=DM+Serif+Display&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="min-h-screen antialiased">
+    <header class="bg-header">
+      <div class="mx-auto flex max-w-4xl items-stretch justify-between px-6">
+        <a
+          href="/"
+          class="flex items-center gap-2.5 py-4 font-display text-base text-white no-underline"
+        >
+          <span
+            class="flex h-7 w-7 shrink-0 items-center justify-center rounded bg-accent text-xs font-bold font-sans text-header"
+          >
+            AI
+          </span>
+          {siteTitle}
+        </a>
+        <nav class="flex" aria-label="Main navigation">
+          {navLinks.map(({ href, label }) => {
+            const active = path.startsWith(href);
+            return (
+              <a
+                href={href}
+                class={[
+                  "flex items-center px-4 text-sm font-medium border-b-[3px] transition-colors no-underline",
+                  active
+                    ? "text-white border-accent"
+                    : "text-[#8ab8c8] border-transparent hover:text-white",
+                ].join(" ")}
+                aria-current={active ? "page" : undefined}
+              >
+                {label}
+              </a>
+            );
+          })}
+        </nav>
+      </div>
+    </header>
+    <main class="mx-auto max-w-4xl px-6 py-10">
+      <slot />
+    </main>
+    <footer class="bg-header">
+      <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#5a8a9a]">
+        <p>
+          A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
+          <a
+            href="https://www.cloudflare.com/web-analytics/"
+            class="text-[#8ab8c8] hover:text-white underline"
+          >
+            Cloudflare Web Analytics
+          </a>
+        </p>
+      </div>
+    </footer>
+  </body>
+</html>
+```
+
+- [ ] **Step 2: Verify build succeeds**
+
+```bash
+npm run build
+```
+
+Expected: build completes. Site pages now have petrol blue header/footer.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro
+git commit -m "Restyle BaseLayout with Deep Teal header/footer and Google Fonts (issue #42)"
+```
+
+---
+
+## Task 3: TimelineItem Type — Add `orgs` and `links` Fields
+
+**Files:**
+- Modify: `src/lib/timeline.ts`
+- Modify: `src/pages/timeline/index.astro`
+
+- [ ] **Step 1: Update `TimelineItem` type in `src/lib/timeline.ts`**
+
+Replace the `TimelineItem` type (keep `OrgOption` and `filterByOrg` unchanged):
+
+```typescript
+export type TimelineItem = {
+  id: string;
+  kind: "event";
+  title: string;
+  date: string; // ISO string — sorted in Astro before passing
+  description?: string;
+  tags: string[];
+  href: string;
+  badge: string;
+  orgIds: string[]; // flattened org IDs for filtering
+  orgs: { id: string; label: string }[]; // for displaying org chips
+  links: { label: string; url: string; icon?: string }[]; // source links
+};
+```
+
+- [ ] **Step 2: Update `src/pages/timeline/index.astro` to populate the new fields**
+
+Replace the `items` mapping (keep all other logic — orgMap, orgCounts, orgs — unchanged):
+
+```typescript
+const items: TimelineItem[] = events
+  .map((e) => ({
+    id: e.id,
+    kind: "event" as const,
+    title: e.data.title,
+    date: e.data.date.toISOString(),
+    description: e.data.description,
+    tags: e.data.tags,
+    href: `/events/${e.id}/`,
+    badge: e.data.type,
+    orgIds: e.data.organizations.map((o) => o.id.id),
+    orgs: e.data.organizations.map((o) => {
+      const org = orgMap.get(o.id.id);
+      return { id: o.id.id, label: org?.short_name ?? org?.name ?? o.id.id };
+    }),
+    links: e.data.links,
+  }))
+  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+```
+
+- [ ] **Step 3: Verify TypeScript is happy**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/timeline.ts src/pages/timeline/index.astro
+git commit -m "Add orgs and links fields to TimelineItem (issue #42)"
+```
+
+---
+
+## Task 4: TimelineList — Restyle + Org Chips + Source Links
+
+**Files:**
+- Modify: `src/components/TimelineList.tsx`
+- Create: `src/components/TimelineList.test.tsx`
+
+- [ ] **Step 1: Write the failing tests first**
+
+Create `src/components/TimelineList.test.tsx`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TimelineList from "./TimelineList";
+import type { TimelineItem } from "../lib/timeline";
+
+const baseItem: TimelineItem = {
+  id: "test-1",
+  kind: "event",
+  title: "Senate Committee Hearing on AI Safety",
+  date: "2025-04-15T00:00:00.000Z",
+  tags: [],
+  href: "/events/test-1/",
+  badge: "CommitteeHearing",
+  orgIds: ["senate"],
+  orgs: [{ id: "senate", label: "Senate SOCI" }],
+  links: [],
+};
+
+describe("TimelineList", () => {
+  it("renders org chips as links to /orgs/<id>/", () => {
+    render(<TimelineList items={[baseItem]} />);
+    const chip = screen.getByRole("link", { name: "Senate SOCI" });
+    expect(chip).toHaveAttribute("href", "/orgs/senate/");
+  });
+
+  it("renders source links when item.links is non-empty", () => {
+    const item: TimelineItem = {
+      ...baseItem,
+      links: [
+        { label: "Hansard", url: "https://example.com/hansard", icon: "document" },
+        { label: "Video", url: "https://example.com/video", icon: "video" },
+      ],
+    };
+    render(<TimelineList items={[item]} />);
+    expect(screen.getByRole("link", { name: /Hansard/ })).toHaveAttribute(
+      "href",
+      "https://example.com/hansard",
+    );
+    expect(screen.getByRole("link", { name: /Video/ })).toHaveAttribute(
+      "href",
+      "https://example.com/video",
+    );
+  });
+
+  it("does not render a source-links row when item.links is empty", () => {
+    render(<TimelineList items={[baseItem]} />);
+    // The only links should be the title and the org chip
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((l) => l.getAttribute("href"));
+    expect(hrefs).not.toContain("https://example.com/hansard");
+  });
+
+  it("renders an empty-state message when items list is empty", () => {
+    render(<TimelineList items={[]} />);
+    expect(screen.getByText("No items match this filter.")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm test -- TimelineList
+```
+
+Expected: tests fail — `TimelineList` doesn't accept `orgs` or `links` yet.
+
+- [ ] **Step 3: Replace `src/components/TimelineList.tsx`**
+
+```typescript
+import type { TimelineItem } from "../lib/timeline";
+import { fmtDate } from "../lib/format";
+
+type Props = {
+  items: TimelineItem[];
+};
+
+function DocumentIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    >
+      <path d="M4 2h6l4 4v8H2V2h2z" />
+      <path d="M10 2v4h4" />
+    </svg>
+  );
+}
+
+function VideoIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    >
+      <circle cx="8" cy="8" r="6.5" />
+      <polygon points="6.5,5.5 11.5,8 6.5,10.5" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function ExternalIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    >
+      <path d="M7 3H3v10h10V9" />
+      <path d="M10 2h4v4" />
+      <path d="M13 3l-6 6" />
+    </svg>
+  );
+}
+
+function LinkIcon({ icon }: { icon?: string }) {
+  if (icon === "video") return <VideoIcon />;
+  if (icon === "document") return <DocumentIcon />;
+  return <ExternalIcon />;
+}
+
+export default function TimelineList({ items }: Props) {
+  if (items.length === 0) {
+    return (
+      <p className="mt-10 text-muted">No items match this filter.</p>
+    );
+  }
+
+  return (
+    <ol aria-label="Timeline" className="mt-8 border-l-2 border-accent">
+      {items.map((item) => (
+        <li key={item.id} className="relative pl-7 pb-8">
+          <span className="absolute -left-[5px] top-[7px] h-2.5 w-2.5 rounded-full bg-accent ring-2 ring-body" />
+          <time
+            dateTime={item.date}
+            className="block text-xs text-faint font-medium mb-1"
+          >
+            {fmtDate(item.date)}
+          </time>
+          <a
+            href={item.href}
+            className="block font-serif text-base font-semibold text-header leading-snug hover:text-accent-dk mb-2 no-underline"
+          >
+            {item.title}
+          </a>
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            <span className="chip-type">{item.badge}</span>
+            {item.orgs.map((org) => (
+              <a key={org.id} href={`/orgs/${org.id}/`} className="chip-org">
+                {org.label}
+              </a>
+            ))}
+          </div>
+          {item.description && (
+            <p className="text-sm text-muted leading-relaxed mb-2 max-w-2xl">
+              {item.description}
+            </p>
+          )}
+          {item.links.length > 0 && (
+            <div className="flex flex-wrap gap-4">
+              {item.links.map((link) => (
+                <a
+                  key={link.url}
+                  href={link.url}
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-xs text-accent-dk hover:text-header font-medium no-underline"
+                >
+                  <LinkIcon icon={link.icon} />
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```bash
+npm test -- TimelineList
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Full build check**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/TimelineList.tsx src/components/TimelineList.test.tsx
+git commit -m "Restyle TimelineList with org chips and source icon links (issue #42)"
+```
+
+---
+
+## Task 5: OrgFilter — Restyle Filter Chips
+
+**Files:**
+- Modify: `src/components/OrgFilter.tsx`
+
+- [ ] **Step 1: Confirm existing tests pass before touching anything**
+
+```bash
+npm test -- OrgFilter
+```
+
+Expected: 3 tests pass (they test behaviour, not styles — they will still pass after the restyle).
+
+- [ ] **Step 2: Replace the className strings in `src/components/OrgFilter.tsx`**
+
+Replace the three `const` declarations at the top of the component function and nothing else:
+
+```typescript
+  const pillBase =
+    "rounded-full px-3 py-1 text-sm font-medium transition-colors cursor-pointer border";
+  const active =
+    "bg-header text-white border-header";
+  const inactive =
+    "bg-body text-muted border-border hover:bg-surface hover:text-ink";
+```
+
+- [ ] **Step 3: Run tests to confirm they still pass**
+
+```bash
+npm test -- OrgFilter
+```
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/OrgFilter.tsx
+git commit -m "Restyle OrgFilter chips with Deep Teal palette (issue #42)"
+```
+
+---
+
+## Task 6: Homepage + Timeline Page
+
+**Files:**
+- Modify: `src/pages/index.astro`
+- Modify: `src/pages/timeline/index.astro`
+
+- [ ] **Step 1: Replace `src/pages/index.astro` contents**
+
+```astro
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+---
+
+<BaseLayout
+  title="AI Governance Tracker"
+  description="Tracking Canadian AI governance and policy — Senate hearings, legislation, and government action."
+>
+  <div class="py-8">
+    <p class="text-xs font-semibold uppercase tracking-widest text-accent-dk mb-3">
+      AI Policy · Governance · Safety
+    </p>
+    <h1 class="font-display text-5xl leading-tight text-header tracking-tight">
+      AI Governance Tracker
+    </h1>
+    <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
+      Tracking government responses to artificial intelligence — Senate hearings,
+      legislation, and policy action — so that anyone who cares can stay informed.
+    </p>
+
+    <div class="mt-8 flex flex-wrap gap-3">
+      <a
+        href="/timeline/"
+        class="inline-flex items-center rounded bg-header px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#1a4a60] no-underline transition-colors"
+      >
+        Browse the Timeline →
+      </a>
+      <a
+        href="https://github.com/jrhender/ai-governance-tracker/issues/new"
+        class="inline-flex items-center rounded border border-border px-5 py-2.5 text-sm font-semibold text-muted hover:border-[#aabbcc] hover:text-ink no-underline transition-colors"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Contribute via GitHub
+      </a>
+    </div>
+
+    <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <a
+        href="/timeline/"
+        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+      >
+        <h2 class="font-display text-lg text-header">Timeline</h2>
+        <p class="mt-1 text-sm text-muted">
+          Senate hearings, reports, and government announcements.
+        </p>
+      </a>
+      <a
+        href="/policy/"
+        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+      >
+        <h2 class="font-display text-lg text-header">Policy</h2>
+        <p class="mt-1 text-sm text-muted">
+          Legislation, reports, and policy documents.
+        </p>
+      </a>
+    </div>
+  </div>
+</BaseLayout>
+```
+
+- [ ] **Step 2: Update `src/pages/timeline/index.astro` heading styles**
+
+The page heading block (lines 49–58 in the original) currently reads:
+```astro
+<BaseLayout
+  title="Timeline"
+  description="..."
+>
+  <h1 class="text-3xl font-bold tracking-tight">Timeline</h1>
+  <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+    Canadian AI governance and policy events, reports, and government action.
+  </p>
+
+  <TimelineWithFilter client:load items={items} orgs={orgs} />
+</BaseLayout>
+```
+
+Replace it with:
+```astro
+<BaseLayout
+  title="Timeline"
+  description="Canadian AI governance and policy events, reports, and government action."
+>
+  <h1 class="font-display text-4xl text-header">Timeline</h1>
+  <p class="mt-2 max-w-2xl text-muted">
+    Canadian AI governance and policy events, reports, and government action.
+  </p>
+
+  <TimelineWithFilter client:load items={items} orgs={orgs} />
+</BaseLayout>
+```
+
+- [ ] **Step 3: Build check**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/index.astro src/pages/timeline/index.astro
+git commit -m "Restyle homepage and timeline page with Deep Teal design (issue #42)"
+```
+
+---
+
+## Task 7: Policy + Orgs Pages
+
+**Files:**
+- Modify: `src/pages/policy/index.astro`
+- Modify: `src/pages/orgs/index.astro`
+- Modify: `src/pages/orgs/[id].astro`
+
+- [ ] **Step 1: Replace `src/pages/policy/index.astro` contents**
+
+```astro
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { badgeClass, statusLabel } from "../../lib/legislation";
+import { fmtDate } from "../../lib/format";
+
+const artifacts = await getCollection("artifacts");
+
+function byDateDesc(a: { data: { published_date: Date } }, b: { data: { published_date: Date } }) {
+  return b.data.published_date.getTime() - a.data.published_date.getTime();
+}
+
+const legislation = artifacts.filter((a) => a.data.type === "Legislation").sort(byDateDesc);
+const reports     = artifacts.filter((a) => a.data.type === "Report").sort(byDateDesc);
+const policyDocs  = artifacts.filter((a) => a.data.type === "PolicyDocument").sort(byDateDesc);
+const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram").sort(byDateDesc);
+---
+
+<BaseLayout
+  title="Policy"
+  description="Canadian AI legislation, reports, policy documents, and government programs."
+>
+  <h1 class="font-display text-4xl text-header">Policy</h1>
+
+  {legislation.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">Legislation</h2>
+      <p class="mt-2 max-w-2xl text-muted">
+        Canadian federal bills and acts related to artificial intelligence. Each entry tracks
+        the bill's lifecycle — from introduction through readings, committee study, and royal
+        assent (or death on the order paper).
+      </p>
+      <div class="mt-6 space-y-4">
+        {legislation.map((bill) => (
+          <a
+            href={`/artifacts/${bill.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <h3 class="text-base font-semibold text-header">{bill.data.title}</h3>
+              {bill.data.lifecycle_status && (
+                <span
+                  class={`shrink-0 rounded-full px-3 py-0.5 text-xs font-semibold ${badgeClass(bill.data.lifecycle_status)}`}
+                >
+                  {statusLabel(bill.data.lifecycle_status)}
+                </span>
+              )}
+            </div>
+            {bill.data.current_stage && (
+              <p class="mt-2 text-sm text-muted">{bill.data.current_stage}</p>
+            )}
+            <p class="mt-2 text-xs text-faint">
+              Introduced: {fmtDate(bill.data.published_date)}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+
+  {reports.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">Reports</h2>
+      <p class="mt-2 max-w-2xl text-muted">
+        Research reports and analytical summaries published by think tanks, government
+        agencies, and advisory bodies.
+      </p>
+      <div class="mt-6 space-y-4">
+        {reports.map((r) => (
+          <a
+            href={`/artifacts/${r.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+          >
+            <h3 class="text-base font-semibold text-header">{r.data.title}</h3>
+            {r.data.description && (
+              <p class="mt-2 text-sm text-muted">{r.data.description}</p>
+            )}
+            <p class="mt-2 text-xs text-faint">
+              Published: {fmtDate(r.data.published_date)}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+
+  {policyDocs.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">Policy Documents</h2>
+      <p class="mt-2 max-w-2xl text-muted">
+        Voluntary codes of conduct, frameworks, and guidelines issued by government or
+        industry bodies.
+      </p>
+      <div class="mt-6 space-y-4">
+        {policyDocs.map((d) => (
+          <a
+            href={`/artifacts/${d.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+          >
+            <h3 class="text-base font-semibold text-header">{d.data.title}</h3>
+            {d.data.description && (
+              <p class="mt-2 text-sm text-muted">{d.data.description}</p>
+            )}
+            <p class="mt-2 text-xs text-faint">
+              Published: {fmtDate(d.data.published_date)}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+
+  {govPrograms.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">Government Programs</h2>
+      <p class="mt-2 max-w-2xl text-muted">
+        Ongoing federal programs and national strategies related to artificial intelligence.
+      </p>
+      <div class="mt-6 space-y-4">
+        {govPrograms.map((p) => (
+          <a
+            href={`/artifacts/${p.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+          >
+            <h3 class="text-base font-semibold text-header">{p.data.title}</h3>
+            {p.data.description && (
+              <p class="mt-2 text-sm text-muted">{p.data.description}</p>
+            )}
+            <p class="mt-2 text-xs text-faint">
+              Published: {fmtDate(p.data.published_date)}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+</BaseLayout>
+```
+
+- [ ] **Step 2: Replace `src/pages/orgs/index.astro` contents**
+
+```astro
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const orgs = await getCollection("organizations");
+const allEvents = await getCollection("events");
+const allArtifacts = await getCollection("artifacts");
+
+const eventCounts = new Map<string, number>();
+const artifactCounts = new Map<string, number>();
+for (const e of allEvents) {
+  for (const o of e.data.organizations) {
+    eventCounts.set(o.id.id, (eventCounts.get(o.id.id) ?? 0) + 1);
+  }
+}
+for (const a of allArtifacts) {
+  for (const o of a.data.organizations) {
+    artifactCounts.set(o.id.id, (artifactCounts.get(o.id.id) ?? 0) + 1);
+  }
+}
+
+const sorted = [...orgs].sort((a, b) => a.data.name.localeCompare(b.data.name));
+---
+
+<BaseLayout
+  title="Organizations"
+  description="Think tanks, government bodies, and advocacy groups tracked in this database."
+>
+  <h1 class="font-display text-4xl text-header">Organizations</h1>
+  <p class="mt-2 max-w-2xl text-muted">
+    Think tanks, government bodies, and advocacy groups tracked in this database.
+  </p>
+
+  {sorted.length === 0 ? (
+    <p class="mt-10 text-faint">No organizations tracked yet.</p>
+  ) : (
+    <div class="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {sorted.map((org) => {
+        const events = eventCounts.get(org.id) ?? 0;
+        const artifacts = artifactCounts.get(org.id) ?? 0;
+        return (
+          <a
+            href={`/orgs/${org.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+          >
+            {org.data.short_name && (
+              <div class="text-base font-bold text-header">{org.data.short_name}</div>
+            )}
+            <div class={`text-sm text-muted ${org.data.short_name ? "mt-0.5" : "font-semibold text-base text-header"}`}>
+              {org.data.name}
+            </div>
+            <div class="mt-3 text-xs text-faint">
+              {[
+                events > 0 && `${events} event${events === 1 ? "" : "s"}`,
+                artifacts > 0 && `${artifacts} artifact${artifacts === 1 ? "" : "s"}`,
+              ]
+                .filter(Boolean)
+                .join(" · ") || "No events yet"}
+            </div>
+            {org.data.tags.length > 0 && (
+              <div class="mt-3 flex flex-wrap gap-1">
+                {org.data.tags.map((t) => (
+                  <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+                    #{t}
+                  </span>
+                ))}
+              </div>
+            )}
+          </a>
+        );
+      })}
+    </div>
+  )}
+</BaseLayout>
+```
+
+- [ ] **Step 3: Replace `src/pages/orgs/[id].astro` contents**
+
+```astro
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+export async function getStaticPaths() {
+  const orgs = await getCollection("organizations");
+  return orgs.map((org) => ({
+    params: { id: org.id },
+    props: { org },
+  }));
+}
+
+const { org } = Astro.props;
+const { data } = org;
+
+const allEvents = await getCollection("events");
+const allArtifacts = await getCollection("artifacts");
+
+const events = allEvents.filter((e) =>
+  e.data.organizations.some((o) => o.id.id === org.id),
+);
+const artifacts = allArtifacts.filter((a) =>
+  a.data.organizations.some((o) => o.id.id === org.id),
+);
+---
+
+<BaseLayout title={data.name} description={`Organization: ${data.name}`}>
+  <p class="text-sm text-faint">
+    <a href="/orgs/" class="hover:underline text-accent-dk">← Organizations</a>
+  </p>
+  <h1 class="mt-4 font-display text-3xl text-header">{data.name}</h1>
+  {data.short_name && (
+    <p class="mt-1 text-faint">{data.short_name}</p>
+  )}
+
+  <div class="mt-4 flex flex-wrap gap-4 text-sm">
+    {data.url && (
+      <a
+        href={data.url}
+        class="text-accent-dk hover:underline"
+        rel="noopener noreferrer"
+      >
+        Website ↗
+      </a>
+    )}
+    {data.wikipedia && (
+      <a
+        href={data.wikipedia}
+        class="text-accent-dk hover:underline"
+        rel="noopener noreferrer"
+      >
+        Wikipedia ↗
+      </a>
+    )}
+  </div>
+
+  {events.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Events
+      </h2>
+      <ul class="space-y-1">
+        {events.map((e) => (
+          <li>
+            <a href={`/events/${e.id}/`} class="text-sm text-ink hover:text-accent-dk hover:underline">
+              {e.data.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  {artifacts.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Artifacts
+      </h2>
+      <ul class="space-y-1">
+        {artifacts.map((a) => (
+          <li>
+            <a href={`/artifacts/${a.id}/`} class="text-sm text-ink hover:text-accent-dk hover:underline">
+              {a.data.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  {data.tags.length > 0 && (
+    <section class="mt-8 flex flex-wrap gap-2">
+      {data.tags.map((t) => (
+        <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+          #{t}
+        </span>
+      ))}
+    </section>
+  )}
+</BaseLayout>
+```
+
+- [ ] **Step 4: Build check**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/policy/index.astro src/pages/orgs/index.astro src/pages/orgs/\[id\].astro
+git commit -m "Restyle policy and orgs pages with Deep Teal design (issue #42)"
+```
+
+---
+
+## Task 8: Detail Pages — Events and Artifacts
+
+**Files:**
+- Modify: `src/pages/events/[id].astro`
+- Modify: `src/pages/artifacts/[id].astro`
+
+- [ ] **Step 1: Replace `src/pages/events/[id].astro` contents**
+
+```astro
+---
+import { getCollection, getEntry } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { fmtDate } from "../../lib/format";
+
+export async function getStaticPaths() {
+  const events = await getCollection("events");
+  return events.map((event) => ({
+    params: { id: event.id },
+    props: { event },
+  }));
+}
+
+const { event } = Astro.props;
+const { data } = event;
+
+const orgs = await Promise.all(
+  data.organizations.map(async (o) => {
+    const org = await getEntry("organizations", o.id.id);
+    return { role: o.role, org };
+  }),
+);
+
+const relatedArtifacts = await Promise.all(
+  data.related_artifacts.map((a) => getEntry("artifacts", a.id.id)),
+);
+---
+
+<BaseLayout title={data.title} description={data.description}>
+  <p class="text-sm text-faint">
+    <a href="/timeline/" class="text-accent-dk hover:underline">← Timeline</a>
+  </p>
+  <h1 class="mt-4 font-display text-3xl text-header">{data.title}</h1>
+  <div class="mt-2 flex flex-wrap gap-3 text-sm text-faint">
+    <time datetime={data.date.toISOString()}>{fmtDate(data.date)}</time>
+    <span>·</span>
+    <span>{data.type}</span>
+    {data.location && (
+      <>
+        <span>·</span>
+        <span>{data.location.name}</span>
+      </>
+    )}
+    {data.status && (
+      <>
+        <span>·</span>
+        <span>{data.status}</span>
+      </>
+    )}
+  </div>
+
+  {data.description && (
+    <p class="mt-6 text-ink leading-relaxed">{data.description}</p>
+  )}
+
+  {orgs.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Organizations
+      </h2>
+      <ul class="space-y-1">
+        {orgs.map(({ role, org }) =>
+          org ? (
+            <li>
+              <a href={`/orgs/${org.id}/`} class="font-medium text-ink hover:text-accent-dk hover:underline">
+                {org.data.short_name ?? org.data.name}
+              </a>
+              <span class="text-faint"> — {role}</span>
+            </li>
+          ) : null,
+        )}
+      </ul>
+    </section>
+  )}
+
+  {data.links.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Links
+      </h2>
+      <ul class="space-y-1">
+        {data.links.map((l) => (
+          <li>
+            <a
+              href={l.url}
+              class="text-accent-dk hover:underline"
+              rel="noopener noreferrer"
+            >
+              {l.label} ↗
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  {relatedArtifacts.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Related artifacts
+      </h2>
+      <ul class="space-y-1">
+        {relatedArtifacts.map((a) =>
+          a ? (
+            <li>
+              <a href={`/artifacts/${a.id}/`} class="text-ink hover:text-accent-dk hover:underline">
+                {a.data.title}
+              </a>
+            </li>
+          ) : null,
+        )}
+      </ul>
+    </section>
+  )}
+
+  {data.tags.length > 0 && (
+    <section class="mt-8 flex flex-wrap gap-2">
+      {data.tags.map((t) => (
+        <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+          #{t}
+        </span>
+      ))}
+    </section>
+  )}
+</BaseLayout>
+```
+
+- [ ] **Step 2: Replace `src/pages/artifacts/[id].astro` contents**
+
+```astro
+---
+import { getCollection, getEntry } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { fmtDate } from "../../lib/format";
+
+export async function getStaticPaths() {
+  const artifacts = await getCollection("artifacts");
+  return artifacts.map((artifact) => ({
+    params: { id: artifact.id },
+    props: { artifact },
+  }));
+}
+
+const { artifact } = Astro.props;
+const { data } = artifact;
+
+const orgs = await Promise.all(
+  data.organizations.map(async (o) => {
+    const org = await getEntry("organizations", o.id.id);
+    return { role: o.role, org };
+  }),
+);
+
+const sources = await Promise.all(
+  data.derives_from.map(async (d) => {
+    const event = await getEntry("events", d.id.id);
+    return { relationship: d.relationship, event };
+  }),
+);
+
+const statusLabels: Record<string, string> = {
+  untracked: "Untracked",
+  under_review: "Under review",
+  adopted: "Adopted",
+  rejected: "Rejected",
+};
+---
+
+<BaseLayout title={data.title} description={data.description}>
+  <p class="text-sm text-faint">
+    <a href="/policy/" class="text-accent-dk hover:underline">← Policy</a>
+  </p>
+  <h1 class="mt-4 font-display text-3xl text-header">{data.title}</h1>
+  <div class="mt-2 flex flex-wrap gap-3 text-sm text-faint">
+    <time datetime={data.published_date.toISOString()}>
+      Published {fmtDate(data.published_date)}
+    </time>
+    <span>·</span>
+    <span>{data.type}</span>
+  </div>
+
+  {data.description && (
+    <p class="mt-6 text-ink leading-relaxed">{data.description}</p>
+  )}
+
+  {orgs.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Organizations
+      </h2>
+      <ul class="space-y-1">
+        {orgs.map(({ role, org }) =>
+          org ? (
+            <li>
+              <a href={`/orgs/${org.id}/`} class="font-medium text-ink hover:text-accent-dk hover:underline">
+                {org.data.short_name ?? org.data.name}
+              </a>
+              <span class="text-faint"> — {role}</span>
+            </li>
+          ) : null,
+        )}
+      </ul>
+    </section>
+  )}
+
+  {sources.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Derives from
+      </h2>
+      <ul class="space-y-1">
+        {sources.map(({ relationship, event }) =>
+          event ? (
+            <li>
+              <a href={`/events/${event.id}/`} class="text-ink hover:text-accent-dk hover:underline">
+                {event.data.title}
+              </a>
+              <span class="text-faint"> — {relationship}</span>
+            </li>
+          ) : null,
+        )}
+      </ul>
+    </section>
+  )}
+
+  {data.links.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Links
+      </h2>
+      <ul class="space-y-1">
+        {data.links.map((l) => (
+          <li>
+            <a
+              href={l.url}
+              class="text-accent-dk hover:underline"
+              rel="noopener noreferrer"
+            >
+              {l.label} ↗
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  {data.policy_recommendations.length > 0 && (
+    <section class="mt-8">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
+        Policy recommendations
+      </h2>
+      <ul class="space-y-2">
+        {data.policy_recommendations.map((r) => (
+          <li class="rounded border border-border bg-surface p-3">
+            <div class="flex items-center justify-between gap-3">
+              <span class="font-mono text-xs text-faint">{r.id}</span>
+              <span class="rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+                {statusLabels[r.status] ?? r.status}
+              </span>
+            </div>
+            {r.summary && (
+              <p class="mt-2 text-sm text-ink">{r.summary}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  {data.tags.length > 0 && (
+    <section class="mt-8 flex flex-wrap gap-2">
+      {data.tags.map((t) => (
+        <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+          #{t}
+        </span>
+      ))}
+    </section>
+  )}
+</BaseLayout>
+```
+
+- [ ] **Step 3: Run full test suite and build**
+
+```bash
+npm test && npm run build
+```
+
+Expected: all tests pass, build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/events/\[id\].astro src/pages/artifacts/\[id\].astro
+git commit -m "Restyle event and artifact detail pages with Deep Teal design (issue #42)"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run all tests**
+
+```bash
+npm test
+```
+
+Expected: all tests pass (OrgFilter × 3, TimelineList × 4).
+
+- [ ] **Run build**
+
+```bash
+npm run build
+```
+
+Expected: clean build, no type errors or warnings.
+
+- [ ] **Check `.gitignore` for `.superpowers/`**
+
+```bash
+grep superpowers .gitignore
+```
+
+If not present, add it:
+
+```bash
+echo '.superpowers/' >> .gitignore
+git add .gitignore
+git commit -m "Ignore .superpowers/ brainstorm session files"
+```

--- a/docs/superpowers/plans/2026-04-27-site-redesign.md
+++ b/docs/superpowers/plans/2026-04-27-site-redesign.md
@@ -29,7 +29,7 @@
 | `src/pages/index.astro` | Modify | Hero with eyebrow + DM Serif Display headline, teal-left-border feature cards |
 | `src/pages/policy/index.astro` | Modify | DM Serif Display headings, teal-left-border artifact cards, remove dark: |
 | `src/pages/orgs/index.astro` | Modify | Unified teal-left-border card treatment, remove dark: |
-| `src/pages/orgs/[id].astro` | Modify | New palette, accent-dk links, remove dark: |
+| `src/pages/orgs/[id].astro` | Modify | New palette, accent-dark links, remove dark: |
 | `src/pages/events/[id].astro` | Modify | New palette, remove dark: |
 | `src/pages/artifacts/[id].astro` | Modify | New palette, remove dark: |
 
@@ -55,7 +55,7 @@
   /* Colours */
   --color-header:    #0f3040;
   --color-accent:    #4ecdc4;
-  --color-accent-dk: #2aada4;
+  --color-accent-dark: #2aada4;
   --color-body:      #f7f8f8;
   --color-surface:   #ffffff;
   --color-border:    #d0dce0;
@@ -483,7 +483,7 @@ export default function TimelineList({ items }: Props) {
           </time>
           <a
             href={item.href}
-            className="block font-serif text-base font-semibold text-header leading-snug hover:text-accent-dk mb-2 no-underline"
+            className="block font-serif text-base font-semibold text-header leading-snug hover:text-accent-dark mb-2 no-underline"
           >
             {item.title}
           </a>
@@ -507,7 +507,7 @@ export default function TimelineList({ items }: Props) {
                   key={link.url}
                   href={link.url}
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-xs text-accent-dk hover:text-header font-medium no-underline"
+                  className="inline-flex items-center gap-1.5 text-xs text-accent-dark hover:text-header font-medium no-underline"
                 >
                   <LinkIcon icon={link.icon} />
                   {link.label}
@@ -608,7 +608,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   description="Tracking Canadian AI governance and policy — Senate hearings, legislation, and government action."
 >
   <div class="py-8">
-    <p class="text-xs font-semibold uppercase tracking-widest text-accent-dk mb-3">
+    <p class="text-xs font-semibold uppercase tracking-widest text-accent-dark mb-3">
       AI Policy · Governance · Safety
     </p>
     <h1 class="font-display text-5xl leading-tight text-header tracking-tight">
@@ -639,7 +639,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
       <a
         href="/timeline/"
-        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
       >
         <h2 class="font-display text-lg text-header">Timeline</h2>
         <p class="mt-1 text-sm text-muted">
@@ -648,7 +648,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       </a>
       <a
         href="/policy/"
-        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
       >
         <h2 class="font-display text-lg text-header">Policy</h2>
         <p class="mt-1 text-sm text-muted">
@@ -755,7 +755,7 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
         {legislation.map((bill) => (
           <a
             href={`/artifacts/${bill.id}/`}
-            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
             <div class="flex items-start justify-between gap-3">
               <h3 class="text-base font-semibold text-header">{bill.data.title}</h3>
@@ -790,7 +790,7 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
         {reports.map((r) => (
           <a
             href={`/artifacts/${r.id}/`}
-            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
             <h3 class="text-base font-semibold text-header">{r.data.title}</h3>
             {r.data.description && (
@@ -816,7 +816,7 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
         {policyDocs.map((d) => (
           <a
             href={`/artifacts/${d.id}/`}
-            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
             <h3 class="text-base font-semibold text-header">{d.data.title}</h3>
             {d.data.description && (
@@ -841,7 +841,7 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
         {govPrograms.map((p) => (
           <a
             href={`/artifacts/${p.id}/`}
-            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
             <h3 class="text-base font-semibold text-header">{p.data.title}</h3>
             {p.data.description && (
@@ -904,7 +904,7 @@ const sorted = [...orgs].sort((a, b) => a.data.name.localeCompare(b.data.name));
         return (
           <a
             href={`/orgs/${org.id}/`}
-            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dk hover:shadow-sm transition-all no-underline"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
             {org.data.short_name && (
               <div class="text-base font-bold text-header">{org.data.short_name}</div>
@@ -968,7 +968,7 @@ const artifacts = allArtifacts.filter((a) =>
 
 <BaseLayout title={data.name} description={`Organization: ${data.name}`}>
   <p class="text-sm text-faint">
-    <a href="/orgs/" class="hover:underline text-accent-dk">← Organizations</a>
+    <a href="/orgs/" class="hover:underline text-accent-dark">← Organizations</a>
   </p>
   <h1 class="mt-4 font-display text-3xl text-header">{data.name}</h1>
   {data.short_name && (
@@ -979,7 +979,7 @@ const artifacts = allArtifacts.filter((a) =>
     {data.url && (
       <a
         href={data.url}
-        class="text-accent-dk hover:underline"
+        class="text-accent-dark hover:underline"
         rel="noopener noreferrer"
       >
         Website ↗
@@ -988,7 +988,7 @@ const artifacts = allArtifacts.filter((a) =>
     {data.wikipedia && (
       <a
         href={data.wikipedia}
-        class="text-accent-dk hover:underline"
+        class="text-accent-dark hover:underline"
         rel="noopener noreferrer"
       >
         Wikipedia ↗
@@ -1004,7 +1004,7 @@ const artifacts = allArtifacts.filter((a) =>
       <ul class="space-y-1">
         {events.map((e) => (
           <li>
-            <a href={`/events/${e.id}/`} class="text-sm text-ink hover:text-accent-dk hover:underline">
+            <a href={`/events/${e.id}/`} class="text-sm text-ink hover:text-accent-dark hover:underline">
               {e.data.title}
             </a>
           </li>
@@ -1021,7 +1021,7 @@ const artifacts = allArtifacts.filter((a) =>
       <ul class="space-y-1">
         {artifacts.map((a) => (
           <li>
-            <a href={`/artifacts/${a.id}/`} class="text-sm text-ink hover:text-accent-dk hover:underline">
+            <a href={`/artifacts/${a.id}/`} class="text-sm text-ink hover:text-accent-dark hover:underline">
               {a.data.title}
             </a>
           </li>
@@ -1098,7 +1098,7 @@ const relatedArtifacts = await Promise.all(
 
 <BaseLayout title={data.title} description={data.description}>
   <p class="text-sm text-faint">
-    <a href="/timeline/" class="text-accent-dk hover:underline">← Timeline</a>
+    <a href="/timeline/" class="text-accent-dark hover:underline">← Timeline</a>
   </p>
   <h1 class="mt-4 font-display text-3xl text-header">{data.title}</h1>
   <div class="mt-2 flex flex-wrap gap-3 text-sm text-faint">
@@ -1132,7 +1132,7 @@ const relatedArtifacts = await Promise.all(
         {orgs.map(({ role, org }) =>
           org ? (
             <li>
-              <a href={`/orgs/${org.id}/`} class="font-medium text-ink hover:text-accent-dk hover:underline">
+              <a href={`/orgs/${org.id}/`} class="font-medium text-ink hover:text-accent-dark hover:underline">
                 {org.data.short_name ?? org.data.name}
               </a>
               <span class="text-faint"> — {role}</span>
@@ -1153,7 +1153,7 @@ const relatedArtifacts = await Promise.all(
           <li>
             <a
               href={l.url}
-              class="text-accent-dk hover:underline"
+              class="text-accent-dark hover:underline"
               rel="noopener noreferrer"
             >
               {l.label} ↗
@@ -1173,7 +1173,7 @@ const relatedArtifacts = await Promise.all(
         {relatedArtifacts.map((a) =>
           a ? (
             <li>
-              <a href={`/artifacts/${a.id}/`} class="text-ink hover:text-accent-dk hover:underline">
+              <a href={`/artifacts/${a.id}/`} class="text-ink hover:text-accent-dark hover:underline">
                 {a.data.title}
               </a>
             </li>
@@ -1238,7 +1238,7 @@ const statusLabels: Record<string, string> = {
 
 <BaseLayout title={data.title} description={data.description}>
   <p class="text-sm text-faint">
-    <a href="/policy/" class="text-accent-dk hover:underline">← Policy</a>
+    <a href="/policy/" class="text-accent-dark hover:underline">← Policy</a>
   </p>
   <h1 class="mt-4 font-display text-3xl text-header">{data.title}</h1>
   <div class="mt-2 flex flex-wrap gap-3 text-sm text-faint">
@@ -1262,7 +1262,7 @@ const statusLabels: Record<string, string> = {
         {orgs.map(({ role, org }) =>
           org ? (
             <li>
-              <a href={`/orgs/${org.id}/`} class="font-medium text-ink hover:text-accent-dk hover:underline">
+              <a href={`/orgs/${org.id}/`} class="font-medium text-ink hover:text-accent-dark hover:underline">
                 {org.data.short_name ?? org.data.name}
               </a>
               <span class="text-faint"> — {role}</span>
@@ -1282,7 +1282,7 @@ const statusLabels: Record<string, string> = {
         {sources.map(({ relationship, event }) =>
           event ? (
             <li>
-              <a href={`/events/${event.id}/`} class="text-ink hover:text-accent-dk hover:underline">
+              <a href={`/events/${event.id}/`} class="text-ink hover:text-accent-dark hover:underline">
                 {event.data.title}
               </a>
               <span class="text-faint"> — {relationship}</span>
@@ -1303,7 +1303,7 @@ const statusLabels: Record<string, string> = {
           <li>
             <a
               href={l.url}
-              class="text-accent-dk hover:underline"
+              class="text-accent-dark hover:underline"
               rel="noopener noreferrer"
             >
               {l.label} ↗

--- a/docs/superpowers/specs/2026-04-27-site-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-27-site-redesign-design.md
@@ -1,0 +1,146 @@
+# Site Redesign — Design Spec
+
+**Issue:** #42  
+**Date:** 2026-04-27  
+**Status:** Approved
+
+## Goal
+
+Replace the current monochromatic slate/grey design with a polished, internationally credible aesthetic. The redesign targets credibility, engagement, and clarity — with no national colour associations. Light mode only (dark mode support removed).
+
+## Design Decisions
+
+### Aesthetic Direction
+"Deep Teal" — an internationally neutral policy/think-tank register (Oxford Internet Institute, Brookings). Serious and editorial without feeling like a government department or any particular country.
+
+### Colour Palette (CSS custom properties)
+
+| Token             | Value     | Usage                                      |
+|-------------------|-----------|--------------------------------------------|
+| `--col-header`    | `#0f3040` | Site header and footer background          |
+| `--col-accent`    | `#4ecdc4` | Timeline spine, dots, active states        |
+| `--col-accent-dk` | `#2aada4` | Hover states, source link text             |
+| `--col-body`      | `#f7f8f8` | Page background                            |
+| `--col-surface`   | `#ffffff` | Cards, filter bar                          |
+| `--col-border`    | `#d0dce0` | Borders on cards and inputs                |
+| `--col-border-lt` | `#e8f0f4` | Lighter dividers                           |
+| `--col-text`      | `#0f2a38` | Body text                                  |
+| `--col-muted`     | `#5a7a88` | Secondary text, descriptions               |
+| `--col-faint`     | `#8aa0aa` | Timestamps, section labels                 |
+
+All tokens defined in `src/styles/global.css`.
+
+### Typography
+
+| Role              | Font               | Usage                                      |
+|-------------------|--------------------|--------------------------------------------|
+| Display / logo    | DM Serif Display   | Site logo, page headings (h1)              |
+| Serif body        | Source Serif 4     | Timeline event titles                      |
+| UI / body         | DM Sans            | Nav, descriptions, tags, all UI text       |
+
+Loaded via Google Fonts in `BaseLayout.astro`.
+
+### Dark Mode
+Removed entirely. The `dark:` variant classes are stripped from all components. The inline `<script>` that reads `localStorage("theme")` and the `@variant dark` in `global.css` are removed.
+
+---
+
+## Components
+
+### `BaseLayout.astro`
+
+**Header:**
+- Background `--col-header` (petrol blue), full width
+- Logo: `<span class="logo-mark">AI</span>` teal rounded-square mark + "AI Governance Tracker" in DM Serif Display
+- Nav links: muted teal (`#8ab8c8`), hover white, active state = white text + 3px teal bottom border
+- No dark mode toggle
+
+**Footer:**
+- Background `--col-header`
+- Centred text, muted teal colour
+
+**Body:**
+- `background: var(--col-body)` — replaces `bg-white`
+- `color: var(--col-text)`
+- No `dark:` variants anywhere
+
+### `src/pages/index.astro` (Homepage)
+
+- **Eyebrow:** small caps, `--col-accent-dk`, text "AI Policy · Governance · Safety"
+- **H1:** DM Serif Display, 42px, `--col-header`
+- **Body copy:** DM Sans, `--col-muted`
+- **CTA buttons:** primary = petrol blue fill; secondary = ghost with `--col-border`
+- **Feature cards:** white surface, `--col-border` border, 4px left border in `--col-accent`, rounded right corners only. On hover: darker accent left border + subtle shadow.
+
+### `TimelineList.tsx`
+
+**Spine:** `border-left: 2px solid var(--col-accent)` (teal line, not slate)
+
+**Timeline dot:** `--col-accent` filled circle, white border ring, `--col-body` outer ring — replaces grey dot
+
+**Each event item:**
+1. **Date:** `--col-faint`, 11px, DM Sans
+2. **Title:** Source Serif 4, 16px, `--col-header`, links to detail page
+3. **Chips row:**
+   - Type badge: `chip-type` — teal-tinted background, dark teal text
+   - Org chips: `chip-org` — white surface, blue-teal border, link to `/orgs/<id>/`
+4. **Description:** DM Sans 13px, `--col-muted`
+5. **Source links:** rendered from `event.links[]`. Each link = small SVG icon + label text in `--col-accent-dk`. Icon is chosen by `link.icon` field: `document` → document SVG, `video` → play-circle SVG, anything else → external-link SVG.
+
+**Data plumbing:** `TimelineItem` type gains a `links` field (`{label: string; url: string; icon?: string}[]`). The Astro page passes `e.data.links` through. Events with no links render no source-link row.
+
+### `OrgFilter.tsx` / `TimelineWithFilter.tsx`
+
+Filter chips restyled: `--col-body` background, `--col-border` border. Active chip: `--col-header` background, white text. No functional changes.
+
+### `src/pages/timeline/index.astro`
+
+No logic changes. Style updates inherited from `TimelineList` and `BaseLayout`.
+
+### `src/pages/policy/index.astro`
+
+- Section headings: DM Serif Display
+- Artifact cards: white surface, `--col-border` border, 4px teal left border (matching homepage feature cards)
+- Lifecycle status badges: keep existing colour logic, adjust to match new palette (remove dark: variants)
+
+### `src/pages/orgs/index.astro` and `[id].astro`
+
+- Org list: consistent card treatment with the rest of the site
+- Org detail: links ("Website", "Wikipedia") use `--col-accent-dk` with underline on hover
+
+### Event and artifact detail pages (`src/pages/events/[id].astro`, `src/pages/artifacts/[id].astro`)
+
+- Consistent header/footer from BaseLayout
+- Remove all `dark:` variants
+- Section headings use DM Serif Display
+
+---
+
+## Favicon
+
+An SVG favicon: the letters "AI" in a system serif (`Georgia, serif` — Google Fonts are unavailable inside SVG favicons without embedding), teal (`#4ecdc4`) on petrol blue (`#0f3040`) background, with a `rx="22%"` rounded rectangle. Delivered as `public/favicon.svg` referenced in `BaseLayout.astro` via `<link rel="icon" type="image/svg+xml" href="/favicon.svg">`.
+
+No `favicon.ico` is needed — all modern browsers support SVG favicons. The `public/` directory is created as part of this work.
+
+---
+
+## Scope
+
+All pages and components in one PR:
+
+1. `src/styles/global.css` — add CSS tokens, remove dark variant, import Google Fonts
+2. `src/layouts/BaseLayout.astro` — new header/footer, remove dark mode script, add favicon link
+3. `src/components/TimelineList.tsx` — new timeline styles, org chips, source links
+4. `src/components/OrgFilter.tsx` — restyled filter chips
+5. `src/pages/index.astro` — hero, feature cards
+6. `src/pages/timeline/index.astro` — minor style cleanup
+7. `src/pages/policy/index.astro` — card and heading styles
+8. `src/pages/orgs/index.astro` and `[id].astro` — palette update
+9. `src/pages/events/[id].astro` and `src/pages/artifacts/[id].astro` — dark mode removal, palette
+10. `public/favicon.svg` — new SVG favicon (no .ico needed)
+
+## Out of Scope
+
+- Data entry for new Hansard/video links on existing events (separate issue)
+- Dark mode toggle UI (removed, not deferred)
+- Any new pages or data model changes

--- a/docs/superpowers/specs/2026-04-27-site-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-27-site-redesign-design.md
@@ -19,7 +19,7 @@ Replace the current monochromatic slate/grey design with a polished, internation
 |-------------------|-----------|--------------------------------------------|
 | `--col-header`    | `#0f3040` | Site header and footer background          |
 | `--col-accent`    | `#4ecdc4` | Timeline spine, dots, active states        |
-| `--col-accent-dk` | `#2aada4` | Hover states, source link text             |
+| `--color-accent-dark` | `#2aada4` | Hover states, source link text             |
 | `--col-body`      | `#f7f8f8` | Page background                            |
 | `--col-surface`   | `#ffffff` | Cards, filter bar                          |
 | `--col-border`    | `#d0dce0` | Borders on cards and inputs                |
@@ -66,7 +66,7 @@ Removed entirely. The `dark:` variant classes are stripped from all components. 
 
 ### `src/pages/index.astro` (Homepage)
 
-- **Eyebrow:** small caps, `--col-accent-dk`, text "AI Policy · Governance · Safety"
+- **Eyebrow:** small caps, `--color-accent-dark`, text "AI Policy · Governance · Safety"
 - **H1:** DM Serif Display, 42px, `--col-header`
 - **Body copy:** DM Sans, `--col-muted`
 - **CTA buttons:** primary = petrol blue fill; secondary = ghost with `--col-border`
@@ -85,7 +85,7 @@ Removed entirely. The `dark:` variant classes are stripped from all components. 
    - Type badge: `chip-type` — teal-tinted background, dark teal text
    - Org chips: `chip-org` — white surface, blue-teal border, link to `/orgs/<id>/`
 4. **Description:** DM Sans 13px, `--col-muted`
-5. **Source links:** rendered from `event.links[]`. Each link = small SVG icon + label text in `--col-accent-dk`. Icon is chosen by `link.icon` field: `document` → document SVG, `video` → play-circle SVG, anything else → external-link SVG.
+5. **Source links:** rendered from `event.links[]`. Each link = small SVG icon + label text in `--color-accent-dark`. Icon is chosen by `link.icon` field: `document` → document SVG, `video` → play-circle SVG, anything else → external-link SVG.
 
 **Data plumbing:** `TimelineItem` type gains a `links` field (`{label: string; url: string; icon?: string}[]`). The Astro page passes `e.data.links` through. Events with no links render no source-link row.
 
@@ -106,7 +106,7 @@ No logic changes. Style updates inherited from `TimelineList` and `BaseLayout`.
 ### `src/pages/orgs/index.astro` and `[id].astro`
 
 - Org list: consistent card treatment with the rest of the site
-- Org detail: links ("Website", "Wikipedia") use `--col-accent-dk` with underline on hover
+- Org detail: links ("Website", "Wikipedia") use `--color-accent-dark` with underline on hover
 
 ### Event and artifact detail pages (`src/pages/events/[id].astro`, `src/pages/artifacts/[id].astro`)
 

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <title>AI Governance Tracker</title>
   <rect width="32" height="32" rx="7" fill="#0f3040"/>
   <text
     x="16" y="22"

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#0f3040"/>
+  <text
+    x="16" y="22"
+    font-family="Georgia, serif"
+    font-size="14"
+    font-weight="700"
+    fill="#4ecdc4"
+    text-anchor="middle"
+  >AI</text>
+</svg>

--- a/src/components/OrgFilter.tsx
+++ b/src/components/OrgFilter.tsx
@@ -8,11 +8,11 @@ type Props = {
 
 export default function OrgFilter({ orgs, selected, onSelect }: Props) {
   const pillBase =
-    "rounded-full px-3 py-1 text-sm font-medium transition-colors cursor-pointer";
+    "rounded-full px-3 py-1 text-sm font-medium transition-colors cursor-pointer border";
   const active =
-    "bg-slate-700 text-white dark:bg-slate-300 dark:text-slate-900";
+    "bg-header text-white border-header";
   const inactive =
-    "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700";
+    "bg-body text-muted border-border hover:bg-surface hover:text-ink";
 
   return (
     <div

--- a/src/components/TimelineList.test.tsx
+++ b/src/components/TimelineList.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TimelineList from "./TimelineList";
+import type { TimelineItem } from "../lib/timeline";
+
+const baseItem: TimelineItem = {
+  id: "test-1",
+  kind: "event",
+  title: "Senate Committee Hearing on AI Safety",
+  date: "2025-04-15T00:00:00.000Z",
+  tags: [],
+  href: "/events/test-1/",
+  badge: "CommitteeHearing",
+  orgIds: ["senate"],
+  orgs: [{ id: "senate", label: "Senate SOCI" }],
+  links: [],
+};
+
+describe("TimelineList", () => {
+  it("renders org chips as links to /orgs/<id>/", () => {
+    render(<TimelineList items={[baseItem]} />);
+    const chip = screen.getByRole("link", { name: "Senate SOCI" });
+    expect(chip).toHaveAttribute("href", "/orgs/senate/");
+  });
+
+  it("renders source links when item.links is non-empty", () => {
+    const item: TimelineItem = {
+      ...baseItem,
+      links: [
+        { label: "Hansard", url: "https://example.com/hansard", icon: "document" },
+        { label: "Video", url: "https://example.com/video", icon: "video" },
+      ],
+    };
+    render(<TimelineList items={[item]} />);
+    expect(screen.getByRole("link", { name: /Hansard/ })).toHaveAttribute(
+      "href",
+      "https://example.com/hansard",
+    );
+    expect(screen.getByRole("link", { name: /Video/ })).toHaveAttribute(
+      "href",
+      "https://example.com/video",
+    );
+  });
+
+  it("does not render a source-links row when item.links is empty", () => {
+    render(<TimelineList items={[baseItem]} />);
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((l) => l.getAttribute("href"));
+    expect(hrefs).not.toContain("https://example.com/hansard");
+  });
+
+  it("renders an empty-state message when items list is empty", () => {
+    render(<TimelineList items={[]} />);
+    expect(screen.getByText("No items match this filter.")).toBeInTheDocument();
+  });
+});

--- a/src/components/TimelineList.tsx
+++ b/src/components/TimelineList.tsx
@@ -104,7 +104,7 @@ export default function TimelineList({ items }: Props) {
             <div className="flex flex-wrap gap-4">
               {item.links.map((link) => (
                 <a
-                  key={link.url}
+                  key={`${link.url}-${link.label}`}
                   href={link.url}
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1.5 text-xs text-accent-dark hover:text-header font-medium no-underline"

--- a/src/components/TimelineList.tsx
+++ b/src/components/TimelineList.tsx
@@ -81,12 +81,11 @@ export default function TimelineList({ items }: Props) {
           >
             {fmtDate(item.date)}
           </time>
-          <a
-            href={item.href}
-            className="block font-serif text-base font-semibold text-header leading-snug hover:text-accent-dark mb-2 no-underline"
-          >
-            {item.title}
-          </a>
+          <h3 className="font-serif text-base font-semibold text-header leading-snug mb-2">
+            <a href={item.href} className="hover:text-accent-dark no-underline">
+              {item.title}
+            </a>
+          </h3>
           <div className="flex flex-wrap gap-1.5 mb-2">
             <span className="chip-type">{item.badge}</span>
             {item.orgs.map((org) => (

--- a/src/components/TimelineList.tsx
+++ b/src/components/TimelineList.tsx
@@ -5,51 +5,115 @@ type Props = {
   items: TimelineItem[];
 };
 
+function DocumentIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    >
+      <path d="M4 2h6l4 4v8H2V2h2z" />
+      <path d="M10 2v4h4" />
+    </svg>
+  );
+}
+
+function VideoIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    >
+      <circle cx="8" cy="8" r="6.5" />
+      <polygon points="6.5,5.5 11.5,8 6.5,10.5" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
+function ExternalIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="12"
+      height="12"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    >
+      <path d="M7 3H3v10h10V9" />
+      <path d="M10 2h4v4" />
+      <path d="M13 3l-6 6" />
+    </svg>
+  );
+}
+
+function LinkIcon({ icon }: { icon?: string }) {
+  if (icon === "video") return <VideoIcon />;
+  if (icon === "document") return <DocumentIcon />;
+  return <ExternalIcon />;
+}
+
 export default function TimelineList({ items }: Props) {
   if (items.length === 0) {
     return (
-      <p className="mt-10 text-slate-500 dark:text-slate-400">
-        No items match this filter.
-      </p>
+      <p className="mt-10 text-muted">No items match this filter.</p>
     );
   }
 
   return (
-    <ol
-      aria-label="Timeline"
-      className="mt-10 space-y-8 border-l border-slate-200 dark:border-slate-800"
-    >
+    <ol aria-label="Timeline" className="mt-8 border-l-2 border-accent">
       {items.map((item) => (
-        <li key={item.id} className="relative pl-6">
-          <span className="absolute -left-[5px] top-2 h-2.5 w-2.5 rounded-full bg-slate-400 dark:bg-slate-600" />
+        <li key={item.id} className="relative pl-7 pb-8">
+          <span className="absolute -left-[5px] top-[7px] h-2.5 w-2.5 rounded-full bg-accent ring-2 ring-body" />
           <time
             dateTime={item.date}
-            className="text-sm text-slate-500 dark:text-slate-400"
+            className="block text-xs text-faint font-medium mb-1"
           >
             {fmtDate(item.date)}
           </time>
-          <h2 className="mt-1 text-lg font-semibold">
-            <a href={item.href} className="hover:underline">
-              {item.title}
-            </a>
-          </h2>
-          <div className="mt-1 flex flex-wrap gap-2 text-xs">
-            <span className="rounded bg-slate-100 px-2 py-0.5 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
-              {item.badge}
-            </span>
-            {item.tags.map((t) => (
-              <span
-                key={t}
-                className="rounded bg-slate-50 px-2 py-0.5 text-slate-600 dark:bg-slate-900 dark:text-slate-400"
-              >
-                #{t}
-              </span>
+          <a
+            href={item.href}
+            className="block font-serif text-base font-semibold text-header leading-snug hover:text-accent-dark mb-2 no-underline"
+          >
+            {item.title}
+          </a>
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            <span className="chip-type">{item.badge}</span>
+            {item.orgs.map((org) => (
+              <a key={org.id} href={`/orgs/${org.id}/`} className="chip-org">
+                {org.label}
+              </a>
             ))}
           </div>
           {item.description && (
-            <p className="mt-2 text-slate-700 dark:text-slate-300">
+            <p className="text-sm text-muted leading-relaxed mb-2 max-w-2xl">
               {item.description}
             </p>
+          )}
+          {item.links.length > 0 && (
+            <div className="flex flex-wrap gap-4">
+              {item.links.map((link) => (
+                <a
+                  key={link.url}
+                  href={link.url}
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-xs text-accent-dark hover:text-header font-medium no-underline"
+                >
+                  <LinkIcon icon={link.icon} />
+                  {link.label}
+                </a>
+              ))}
+            </div>
           )}
         </li>
       ))}

--- a/src/components/TimelineList.tsx
+++ b/src/components/TimelineList.tsx
@@ -81,11 +81,11 @@ export default function TimelineList({ items }: Props) {
           >
             {fmtDate(item.date)}
           </time>
-          <h3 className="font-serif text-base font-semibold text-header leading-snug mb-2">
+          <h2 className="font-serif text-base font-semibold text-header leading-snug mb-2">
             <a href={item.href} className="hover:text-accent-dark no-underline">
               {item.title}
             </a>
-          </h3>
+          </h2>
           <div className="flex flex-wrap gap-1.5 mb-2">
             <span className="chip-type">{item.badge}</span>
             {item.orgs.map((org) => (

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -72,7 +72,7 @@ const navLinks = [
       <slot />
     </main>
     <footer class="bg-header">
-      <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#5a8a9a]">
+      <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#8ab8c8]">
         <p>
           A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
           <a

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -75,6 +75,7 @@ const navLinks = [
       <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#8ab8c8]">
         <p>
           A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
+          Anonymous usage statistics via&nbsp;
           <a
             href="https://www.cloudflare.com/web-analytics/"
             class="text-[#8ab8c8] hover:text-white underline"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,6 +9,13 @@ interface Props {
 const { title, description } = Astro.props;
 const siteTitle = "AI Governance Tracker";
 const fullTitle = title === siteTitle ? title : `${title} — ${siteTitle}`;
+
+const path = Astro.url.pathname;
+const navLinks = [
+  { href: "/timeline/", label: "Timeline" },
+  { href: "/orgs/", label: "Organizations" },
+  { href: "/policy/", label: "Policy" },
+];
 ---
 
 <!doctype html>
@@ -18,54 +25,64 @@ const fullTitle = title === siteTitle ? title : `${title} — ${siteTitle}`;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{fullTitle}</title>
     {description && <meta name="description" content={description} />}
-    <script is:inline>
-      const t =
-        localStorage.getItem("theme") ??
-        (matchMedia("(prefers-color-scheme: dark)").matches
-          ? "dark"
-          : "light");
-      document.documentElement.classList.toggle("dark", t === "dark");
-    </script>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&family=DM+Serif+Display&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap"
+      rel="stylesheet"
+    />
   </head>
-  <body
-    class="min-h-screen bg-white text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100"
-  >
-    <header class="border-b border-slate-200 dark:border-slate-800">
-      <div
-        class="mx-auto flex max-w-4xl flex-wrap items-center justify-between gap-y-2 px-6 py-4"
-      >
-        <a href="/" class="text-lg font-semibold tracking-tight">
+  <body class="min-h-screen antialiased">
+    <header class="bg-header">
+      <div class="mx-auto flex max-w-4xl items-stretch justify-between px-6">
+        <a
+          href="/"
+          class="flex items-center gap-2.5 py-4 font-display text-base text-white no-underline"
+        >
+          <span
+            class="flex h-7 w-7 shrink-0 items-center justify-center rounded bg-accent text-xs font-bold font-sans text-header"
+          >
+            AI
+          </span>
           {siteTitle}
         </a>
-        <nav class="flex gap-4 text-sm text-slate-600 dark:text-slate-400">
-          <a href="/timeline/" class="hover:text-slate-900 dark:hover:text-slate-100">
-            Timeline
-          </a>
-          <a href="/orgs/" class="hover:text-slate-900 dark:hover:text-slate-100">
-            Organizations
-          </a>
-          <a href="/policy/" class="hover:text-slate-900 dark:hover:text-slate-100">
-            Policy
-          </a>
+        <nav class="flex" aria-label="Main navigation">
+          {navLinks.map(({ href, label }) => {
+            const active = path.startsWith(href);
+            return (
+              <a
+                href={href}
+                class={[
+                  "flex items-center px-4 text-sm font-medium border-b-[3px] transition-colors no-underline",
+                  active
+                    ? "text-white border-accent"
+                    : "text-[#8ab8c8] border-transparent hover:text-white",
+                ].join(" ")}
+                aria-current={active ? "page" : undefined}
+              >
+                {label}
+              </a>
+            );
+          })}
         </nav>
       </div>
     </header>
     <main class="mx-auto max-w-4xl px-6 py-10">
       <slot />
     </main>
-    <footer
-      class="mx-auto max-w-4xl space-y-2 px-6 py-10 text-sm text-slate-500 dark:text-slate-400"
-    >
-      <p>A Canadian AI governance and policy timeline.</p>
-      <p>
-        Anonymous usage statistics via{" "}
-        <a
-          href="https://www.cloudflare.com/web-analytics/"
-          class="underline hover:text-slate-900 dark:hover:text-slate-100"
-        >
-          Cloudflare Web Analytics
-        </a>.
-      </p>
+    <footer class="bg-header">
+      <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#5a8a9a]">
+        <p>
+          A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
+          <a
+            href="https://www.cloudflare.com/web-analytics/"
+            class="text-[#8ab8c8] hover:text-white underline"
+          >
+            Cloudflare Web Analytics
+          </a>
+        </p>
+      </div>
     </footer>
   </body>
 </html>

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -8,6 +8,8 @@ export type TimelineItem = {
   href: string;
   badge: string;
   orgIds: string[]; // flattened org IDs for filtering
+  orgs: { id: string; label: string }[]; // for displaying org chips
+  links: { label: string; url: string; icon?: string }[]; // source links
 };
 
 export type OrgOption = {

--- a/src/pages/artifacts/[id].astro
+++ b/src/pages/artifacts/[id].astro
@@ -104,6 +104,7 @@ const statusLabels: Record<string, string> = {
             <a
               href={l.url}
               class="text-accent-dark hover:underline"
+              target="_blank"
               rel="noopener noreferrer"
             >
               {l.label} ↗

--- a/src/pages/artifacts/[id].astro
+++ b/src/pages/artifacts/[id].astro
@@ -34,19 +34,14 @@ const statusLabels: Record<string, string> = {
   adopted: "Adopted",
   rejected: "Rejected",
 };
-
 ---
 
 <BaseLayout title={data.title} description={data.description}>
-  <p class="text-sm text-slate-500 dark:text-slate-400">
-    {data.type === "Legislation" ? (
-      <a href="/legislation/" class="hover:underline">← Legislation</a>
-    ) : (
-      <a href="/timeline/" class="hover:underline">← Timeline</a>
-    )}
+  <p class="text-sm text-faint">
+    <a href="/policy/" class="text-accent-dark hover:underline">← Policy</a>
   </p>
-  <h1 class="mt-4 text-3xl font-bold tracking-tight">{data.title}</h1>
-  <div class="mt-2 flex flex-wrap gap-3 text-sm text-slate-600 dark:text-slate-400">
+  <h1 class="mt-4 font-display text-3xl text-header">{data.title}</h1>
+  <div class="mt-2 flex flex-wrap gap-3 text-sm text-faint">
     <time datetime={data.published_date.toISOString()}>
       Published {fmtDate(data.published_date)}
     </time>
@@ -55,22 +50,22 @@ const statusLabels: Record<string, string> = {
   </div>
 
   {data.description && (
-    <p class="mt-6 text-slate-800 dark:text-slate-200">{data.description}</p>
+    <p class="mt-6 text-ink leading-relaxed">{data.description}</p>
   )}
 
   {orgs.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Organizations
       </h2>
-      <ul class="mt-2 space-y-1">
+      <ul class="space-y-1">
         {orgs.map(({ role, org }) =>
           org ? (
             <li>
-              <a href={`/orgs/${org.id}/`} class="font-medium hover:underline">
+              <a href={`/orgs/${org.id}/`} class="font-medium text-ink hover:text-accent-dark hover:underline">
                 {org.data.short_name ?? org.data.name}
               </a>
-              <span class="text-slate-500 dark:text-slate-400"> — {role}</span>
+              <span class="text-faint"> — {role}</span>
             </li>
           ) : null,
         )}
@@ -80,20 +75,17 @@ const statusLabels: Record<string, string> = {
 
   {sources.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Derives from
       </h2>
-      <ul class="mt-2 space-y-1">
+      <ul class="space-y-1">
         {sources.map(({ relationship, event }) =>
           event ? (
             <li>
-              <a href={`/events/${event.id}/`} class="hover:underline">
+              <a href={`/events/${event.id}/`} class="text-ink hover:text-accent-dark hover:underline">
                 {event.data.title}
               </a>
-              <span class="text-slate-500 dark:text-slate-400">
-                {" "}
-                — {relationship}
-              </span>
+              <span class="text-faint"> — {relationship}</span>
             </li>
           ) : null,
         )}
@@ -103,18 +95,18 @@ const statusLabels: Record<string, string> = {
 
   {data.links.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Links
       </h2>
-      <ul class="mt-2 space-y-1">
+      <ul class="space-y-1">
         {data.links.map((l) => (
           <li>
             <a
               href={l.url}
-              class="text-blue-700 hover:underline dark:text-blue-400"
+              class="text-accent-dark hover:underline"
               rel="noopener noreferrer"
             >
-              {l.label}
+              {l.label} ↗
             </a>
           </li>
         ))}
@@ -124,24 +116,20 @@ const statusLabels: Record<string, string> = {
 
   {data.policy_recommendations.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Policy recommendations
       </h2>
-      <ul class="mt-2 space-y-2">
+      <ul class="space-y-2">
         {data.policy_recommendations.map((r) => (
-          <li class="rounded border border-slate-200 p-3 dark:border-slate-800">
+          <li class="rounded border border-border bg-surface p-3">
             <div class="flex items-center justify-between gap-3">
-              <span class="font-mono text-xs text-slate-500 dark:text-slate-400">
-                {r.id}
-              </span>
-              <span class="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+              <span class="font-mono text-xs text-faint">{r.id}</span>
+              <span class="rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
                 {statusLabels[r.status] ?? r.status}
               </span>
             </div>
             {r.summary && (
-              <p class="mt-2 text-sm text-slate-700 dark:text-slate-300">
-                {r.summary}
-              </p>
+              <p class="mt-2 text-sm text-ink">{r.summary}</p>
             )}
           </li>
         ))}
@@ -150,9 +138,9 @@ const statusLabels: Record<string, string> = {
   )}
 
   {data.tags.length > 0 && (
-    <section class="mt-8 flex flex-wrap gap-2 text-xs">
+    <section class="mt-8 flex flex-wrap gap-2">
       {data.tags.map((t) => (
-        <span class="rounded bg-slate-100 px-2 py-0.5 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
           #{t}
         </span>
       ))}

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -24,15 +24,14 @@ const orgs = await Promise.all(
 const relatedArtifacts = await Promise.all(
   data.related_artifacts.map((a) => getEntry("artifacts", a.id.id)),
 );
-
 ---
 
 <BaseLayout title={data.title} description={data.description}>
-  <p class="text-sm text-slate-500 dark:text-slate-400">
-    <a href="/timeline/" class="hover:underline">← Timeline</a>
+  <p class="text-sm text-faint">
+    <a href="/timeline/" class="text-accent-dark hover:underline">← Timeline</a>
   </p>
-  <h1 class="mt-4 text-3xl font-bold tracking-tight">{data.title}</h1>
-  <div class="mt-2 flex flex-wrap gap-3 text-sm text-slate-600 dark:text-slate-400">
+  <h1 class="mt-4 font-display text-3xl text-header">{data.title}</h1>
+  <div class="mt-2 flex flex-wrap gap-3 text-sm text-faint">
     <time datetime={data.date.toISOString()}>{fmtDate(data.date)}</time>
     <span>·</span>
     <span>{data.type}</span>
@@ -51,22 +50,22 @@ const relatedArtifacts = await Promise.all(
   </div>
 
   {data.description && (
-    <p class="mt-6 text-slate-800 dark:text-slate-200">{data.description}</p>
+    <p class="mt-6 text-ink leading-relaxed">{data.description}</p>
   )}
 
   {orgs.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Organizations
       </h2>
-      <ul class="mt-2 space-y-1">
+      <ul class="space-y-1">
         {orgs.map(({ role, org }) =>
           org ? (
             <li>
-              <a href={`/orgs/${org.id}/`} class="font-medium hover:underline">
+              <a href={`/orgs/${org.id}/`} class="font-medium text-ink hover:text-accent-dark hover:underline">
                 {org.data.short_name ?? org.data.name}
               </a>
-              <span class="text-slate-500 dark:text-slate-400"> — {role}</span>
+              <span class="text-faint"> — {role}</span>
             </li>
           ) : null,
         )}
@@ -76,18 +75,18 @@ const relatedArtifacts = await Promise.all(
 
   {data.links.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Links
       </h2>
-      <ul class="mt-2 space-y-1">
+      <ul class="space-y-1">
         {data.links.map((l) => (
           <li>
             <a
               href={l.url}
-              class="text-blue-700 hover:underline dark:text-blue-400"
+              class="text-accent-dark hover:underline"
               rel="noopener noreferrer"
             >
-              {l.label}
+              {l.label} ↗
             </a>
           </li>
         ))}
@@ -97,14 +96,14 @@ const relatedArtifacts = await Promise.all(
 
   {relatedArtifacts.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Related artifacts
       </h2>
-      <ul class="mt-2 space-y-1">
+      <ul class="space-y-1">
         {relatedArtifacts.map((a) =>
           a ? (
             <li>
-              <a href={`/artifacts/${a.id}/`} class="hover:underline">
+              <a href={`/artifacts/${a.id}/`} class="text-ink hover:text-accent-dark hover:underline">
                 {a.data.title}
               </a>
             </li>
@@ -115,9 +114,9 @@ const relatedArtifacts = await Promise.all(
   )}
 
   {data.tags.length > 0 && (
-    <section class="mt-8 flex flex-wrap gap-2 text-xs">
+    <section class="mt-8 flex flex-wrap gap-2">
       {data.tags.map((t) => (
-        <span class="rounded bg-slate-100 px-2 py-0.5 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
           #{t}
         </span>
       ))}

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -84,6 +84,7 @@ const relatedArtifacts = await Promise.all(
             <a
               href={l.url}
               class="text-accent-dark hover:underline"
+              target="_blank"
               rel="noopener noreferrer"
             >
               {l.label} ↗

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <div class="mt-8 flex flex-wrap gap-3">
       <a
         href="/timeline/"
-        class="inline-flex items-center rounded bg-header px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#1a4a60] no-underline transition-colors"
+        class="inline-flex items-center rounded bg-header px-5 py-2.5 text-sm font-semibold text-white hover:bg-header-hover no-underline transition-colors"
       >
         Browse the Timeline →
       </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,8 +14,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       AI Governance Tracker
     </h1>
     <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
-      Tracking government responses to artificial intelligence — Senate hearings,
-      legislation, and policy action — so that anyone who cares can stay informed.
+      Tracking Canadian AI safety and governance — Senate hearings, legislation,
+      and policy action — so that anyone who cares can stay informed.
     </p>
 
     <div class="mt-8 flex flex-wrap gap-3">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,28 +7,27 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   description="Tracking Canadian AI governance and policy — Senate hearings, legislation, and government action."
 >
   <div class="py-8">
-    <h1 class="text-4xl font-bold tracking-tight">AI Governance Tracker</h1>
-    <p class="mt-3 text-lg text-slate-600 dark:text-slate-400">
-      Tracking Canadian AI governance and policy
+    <p class="text-xs font-semibold uppercase tracking-widest text-accent-dark mb-3">
+      AI Policy · Governance · Safety
     </p>
-
-    <p class="mt-6 max-w-2xl text-slate-700 dark:text-slate-300">
-      AI is one of the most consequential technologies in human history. AI safety in
-      particular deserves serious attention. This tracker follows Canada's policy
-      response — Senate hearings, legislation, and government action — so that anyone
-      who cares can stay informed.
+    <h1 class="font-display text-5xl leading-tight text-header tracking-tight">
+      AI Governance Tracker
+    </h1>
+    <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
+      Tracking government responses to artificial intelligence — Senate hearings,
+      legislation, and policy action — so that anyone who cares can stay informed.
     </p>
 
     <div class="mt-8 flex flex-wrap gap-3">
       <a
         href="/timeline/"
-        class="rounded-md bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+        class="inline-flex items-center rounded bg-header px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#1a4a60] no-underline transition-colors"
       >
         Browse the Timeline →
       </a>
       <a
         href="https://github.com/jrhender/ai-governance-tracker/issues/new"
-        class="rounded-md border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-slate-100"
+        class="inline-flex items-center rounded border border-border px-5 py-2.5 text-sm font-semibold text-muted hover:border-[#aabbcc] hover:text-ink no-underline transition-colors"
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -39,19 +38,19 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
       <a
         href="/timeline/"
-        class="rounded-lg border border-slate-200 p-5 hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
       >
-        <h2 class="font-semibold">Timeline</h2>
-        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        <h2 class="font-display text-lg text-header">Timeline</h2>
+        <p class="mt-1 text-sm text-muted">
           Senate hearings, reports, and government announcements.
         </p>
       </a>
       <a
         href="/policy/"
-        class="rounded-lg border border-slate-200 p-5 hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
       >
-        <h2 class="font-semibold">Policy</h2>
-        <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        <h2 class="font-display text-lg text-header">Policy</h2>
+        <p class="mt-1 text-sm text-muted">
           Legislation, reports, and policy documents.
         </p>
       </a>

--- a/src/pages/orgs/[id].astro
+++ b/src/pages/orgs/[id].astro
@@ -38,6 +38,7 @@ const artifacts = allArtifacts.filter((a) =>
       <a
         href={data.url}
         class="text-accent-dark hover:underline"
+        target="_blank"
         rel="noopener noreferrer"
       >
         Website ↗
@@ -47,6 +48,7 @@ const artifacts = allArtifacts.filter((a) =>
       <a
         href={data.wikipedia}
         class="text-accent-dark hover:underline"
+        target="_blank"
         rel="noopener noreferrer"
       >
         Wikipedia ↗

--- a/src/pages/orgs/[id].astro
+++ b/src/pages/orgs/[id].astro
@@ -25,44 +25,44 @@ const artifacts = allArtifacts.filter((a) =>
 ---
 
 <BaseLayout title={data.name} description={`Organization: ${data.name}`}>
-  <p class="text-sm text-slate-500 dark:text-slate-400">
-    <a href="/orgs/" class="hover:underline">← Organizations</a>
+  <p class="text-sm text-faint">
+    <a href="/orgs/" class="hover:underline text-accent-dark">← Organizations</a>
   </p>
-  <h1 class="mt-4 text-3xl font-bold tracking-tight">{data.name}</h1>
+  <h1 class="mt-4 font-display text-3xl text-header">{data.name}</h1>
   {data.short_name && (
-    <p class="mt-1 text-slate-500 dark:text-slate-400">{data.short_name}</p>
+    <p class="mt-1 text-faint">{data.short_name}</p>
   )}
 
   <div class="mt-4 flex flex-wrap gap-4 text-sm">
     {data.url && (
       <a
         href={data.url}
-        class="text-blue-700 hover:underline dark:text-blue-400"
+        class="text-accent-dark hover:underline"
         rel="noopener noreferrer"
       >
-        Website
+        Website ↗
       </a>
     )}
     {data.wikipedia && (
       <a
         href={data.wikipedia}
-        class="text-blue-700 hover:underline dark:text-blue-400"
+        class="text-accent-dark hover:underline"
         rel="noopener noreferrer"
       >
-        Wikipedia
+        Wikipedia ↗
       </a>
     )}
   </div>
 
   {events.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Events
       </h2>
-      <ul class="mt-2 space-y-1">
+      <ul class="space-y-1">
         {events.map((e) => (
           <li>
-            <a href={`/events/${e.id}/`} class="hover:underline">
+            <a href={`/events/${e.id}/`} class="text-sm text-ink hover:text-accent-dark hover:underline">
               {e.data.title}
             </a>
           </li>
@@ -73,13 +73,13 @@ const artifacts = allArtifacts.filter((a) =>
 
   {artifacts.length > 0 && (
     <section class="mt-8">
-      <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
         Artifacts
       </h2>
-      <ul class="mt-2 space-y-1">
+      <ul class="space-y-1">
         {artifacts.map((a) => (
           <li>
-            <a href={`/artifacts/${a.id}/`} class="hover:underline">
+            <a href={`/artifacts/${a.id}/`} class="text-sm text-ink hover:text-accent-dark hover:underline">
               {a.data.title}
             </a>
           </li>
@@ -89,9 +89,9 @@ const artifacts = allArtifacts.filter((a) =>
   )}
 
   {data.tags.length > 0 && (
-    <section class="mt-8 flex flex-wrap gap-2 text-xs">
+    <section class="mt-8 flex flex-wrap gap-2">
       {data.tags.map((t) => (
-        <span class="rounded bg-slate-100 px-2 py-0.5 text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
           #{t}
         </span>
       ))}

--- a/src/pages/orgs/index.astro
+++ b/src/pages/orgs/index.astro
@@ -6,7 +6,6 @@ const orgs = await getCollection("organizations");
 const allEvents = await getCollection("events");
 const allArtifacts = await getCollection("artifacts");
 
-// Count events and artifacts per org
 const eventCounts = new Map<string, number>();
 const artifactCounts = new Map<string, number>();
 for (const e of allEvents) {
@@ -20,30 +19,20 @@ for (const a of allArtifacts) {
   }
 }
 
-// Sort orgs alphabetically by name
 const sorted = [...orgs].sort((a, b) => a.data.name.localeCompare(b.data.name));
-
-// Accent colour by schema_type
-function accentClass(schemaType: string): string {
-  return schemaType === "GovernmentOrganization"
-    ? "border-l-4 border-emerald-500"
-    : "border-l-4 border-blue-500";
-}
 ---
 
 <BaseLayout
   title="Organizations"
   description="Think tanks, government bodies, and advocacy groups tracked in this database."
 >
-  <h1 class="text-3xl font-bold tracking-tight">Organizations</h1>
-  <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+  <h1 class="font-display text-4xl text-header">Organizations</h1>
+  <p class="mt-2 max-w-2xl text-muted">
     Think tanks, government bodies, and advocacy groups tracked in this database.
   </p>
 
   {sorted.length === 0 ? (
-    <p class="mt-10 text-slate-500 dark:text-slate-400">
-      No organizations tracked yet.
-    </p>
+    <p class="mt-10 text-faint">No organizations tracked yet.</p>
   ) : (
     <div class="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2">
       {sorted.map((org) => {
@@ -52,15 +41,15 @@ function accentClass(schemaType: string): string {
         return (
           <a
             href={`/orgs/${org.id}/`}
-            class={`block rounded-lg border border-slate-200 p-5 transition-colors hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700 ${accentClass(org.data.schema_type)}`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
             {org.data.short_name && (
-              <div class="text-lg font-bold">{org.data.short_name}</div>
+              <div class="text-base font-bold text-header">{org.data.short_name}</div>
             )}
-            <div class={`text-sm text-slate-600 dark:text-slate-400 ${org.data.short_name ? "mt-0.5" : "font-semibold text-base text-slate-900 dark:text-slate-100"}`}>
+            <div class={`text-sm text-muted ${org.data.short_name ? "mt-0.5" : "font-semibold text-base text-header"}`}>
               {org.data.name}
             </div>
-            <div class="mt-3 text-xs text-slate-500 dark:text-slate-500">
+            <div class="mt-3 text-xs text-faint">
               {[
                 events > 0 && `${events} event${events === 1 ? "" : "s"}`,
                 artifacts > 0 && `${artifacts} artifact${artifacts === 1 ? "" : "s"}`,
@@ -71,7 +60,7 @@ function accentClass(schemaType: string): string {
             {org.data.tags.length > 0 && (
               <div class="mt-3 flex flex-wrap gap-1">
                 {org.data.tags.map((t) => (
-                  <span class="rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                  <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
                     #{t}
                   </span>
                 ))}

--- a/src/pages/policy/index.astro
+++ b/src/pages/policy/index.astro
@@ -20,12 +20,12 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
   title="Policy"
   description="Canadian AI legislation, reports, policy documents, and government programs."
 >
-  <h1 class="text-3xl font-bold tracking-tight">Policy</h1>
+  <h1 class="font-display text-4xl text-header">Policy</h1>
 
   {legislation.length > 0 && (
     <section class="mt-10">
-      <h2 class="text-xl font-semibold">Legislation</h2>
-      <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+      <h2 class="font-display text-2xl text-header">Legislation</h2>
+      <p class="mt-2 max-w-2xl text-muted">
         Canadian federal bills and acts related to artificial intelligence. Each entry tracks
         the bill's lifecycle — from introduction through readings, committee study, and royal
         assent (or death on the order paper).
@@ -34,10 +34,10 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
         {legislation.map((bill) => (
           <a
             href={`/artifacts/${bill.id}/`}
-            class="block rounded-lg border border-slate-200 p-5 transition-colors hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
             <div class="flex items-start justify-between gap-3">
-              <h3 class="text-lg font-semibold">{bill.data.title}</h3>
+              <h3 class="text-base font-semibold text-header">{bill.data.title}</h3>
               {bill.data.lifecycle_status && (
                 <span
                   class={`shrink-0 rounded-full px-3 py-0.5 text-xs font-semibold ${badgeClass(bill.data.lifecycle_status)}`}
@@ -47,11 +47,9 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
               )}
             </div>
             {bill.data.current_stage && (
-              <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-                {bill.data.current_stage}
-              </p>
+              <p class="mt-2 text-sm text-muted">{bill.data.current_stage}</p>
             )}
-            <p class="mt-2 text-xs text-slate-500 dark:text-slate-500">
+            <p class="mt-2 text-xs text-faint">
               Introduced: {fmtDate(bill.data.published_date)}
             </p>
           </a>
@@ -62,25 +60,22 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
 
   {reports.length > 0 && (
     <section class="mt-10">
-      <h2 class="text-xl font-semibold">Reports</h2>
-      <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+      <h2 class="font-display text-2xl text-header">Reports</h2>
+      <p class="mt-2 max-w-2xl text-muted">
         Research reports and analytical summaries published by think tanks, government
-        agencies, and advisory bodies. These documents examine AI risks, policy options,
-        and strategic considerations for Canada.
+        agencies, and advisory bodies.
       </p>
       <div class="mt-6 space-y-4">
         {reports.map((r) => (
           <a
             href={`/artifacts/${r.id}/`}
-            class="block rounded-lg border border-slate-200 p-5 transition-colors hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
-            <h3 class="text-lg font-semibold">{r.data.title}</h3>
+            <h3 class="text-base font-semibold text-header">{r.data.title}</h3>
             {r.data.description && (
-              <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-                {r.data.description}
-              </p>
+              <p class="mt-2 text-sm text-muted">{r.data.description}</p>
             )}
-            <p class="mt-2 text-xs text-slate-500 dark:text-slate-500">
+            <p class="mt-2 text-xs text-faint">
               Published: {fmtDate(r.data.published_date)}
             </p>
           </a>
@@ -91,25 +86,22 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
 
   {policyDocs.length > 0 && (
     <section class="mt-10">
-      <h2 class="text-xl font-semibold">Policy Documents</h2>
-      <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+      <h2 class="font-display text-2xl text-header">Policy Documents</h2>
+      <p class="mt-2 max-w-2xl text-muted">
         Voluntary codes of conduct, frameworks, and guidelines issued by government or
-        industry bodies. These set expectations for responsible AI development and
-        deployment without carrying the force of law.
+        industry bodies.
       </p>
       <div class="mt-6 space-y-4">
         {policyDocs.map((d) => (
           <a
             href={`/artifacts/${d.id}/`}
-            class="block rounded-lg border border-slate-200 p-5 transition-colors hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
-            <h3 class="text-lg font-semibold">{d.data.title}</h3>
+            <h3 class="text-base font-semibold text-header">{d.data.title}</h3>
             {d.data.description && (
-              <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-                {d.data.description}
-              </p>
+              <p class="mt-2 text-sm text-muted">{d.data.description}</p>
             )}
-            <p class="mt-2 text-xs text-slate-500 dark:text-slate-500">
+            <p class="mt-2 text-xs text-faint">
               Published: {fmtDate(d.data.published_date)}
             </p>
           </a>
@@ -120,25 +112,21 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
 
   {govPrograms.length > 0 && (
     <section class="mt-10">
-      <h2 class="text-xl font-semibold">Government Programs</h2>
-      <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+      <h2 class="font-display text-2xl text-header">Government Programs</h2>
+      <p class="mt-2 max-w-2xl text-muted">
         Ongoing federal programs and national strategies related to artificial intelligence.
-        These represent long-term government commitments and investments rather than
-        one-off publications.
       </p>
       <div class="mt-6 space-y-4">
         {govPrograms.map((p) => (
           <a
             href={`/artifacts/${p.id}/`}
-            class="block rounded-lg border border-slate-200 p-5 transition-colors hover:border-slate-300 dark:border-slate-800 dark:hover:border-slate-700"
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
-            <h3 class="text-lg font-semibold">{p.data.title}</h3>
+            <h3 class="text-base font-semibold text-header">{p.data.title}</h3>
             {p.data.description && (
-              <p class="mt-2 text-sm text-slate-600 dark:text-slate-400">
-                {p.data.description}
-              </p>
+              <p class="mt-2 text-sm text-muted">{p.data.description}</p>
             )}
-            <p class="mt-2 text-xs text-slate-500 dark:text-slate-500">
+            <p class="mt-2 text-xs text-faint">
               Published: {fmtDate(p.data.published_date)}
             </p>
           </a>

--- a/src/pages/timeline/index.astro
+++ b/src/pages/timeline/index.astro
@@ -55,8 +55,8 @@ orgs.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
   title="Timeline"
   description="Canadian AI governance and policy events, reports, and government action."
 >
-  <h1 class="text-3xl font-bold tracking-tight">Timeline</h1>
-  <p class="mt-2 max-w-2xl text-slate-600 dark:text-slate-400">
+  <h1 class="font-display text-4xl text-header">Timeline</h1>
+  <p class="mt-2 max-w-2xl text-muted">
     Canadian AI governance and policy events, reports, and government action.
   </p>
 

--- a/src/pages/timeline/index.astro
+++ b/src/pages/timeline/index.astro
@@ -23,6 +23,11 @@ const items: TimelineItem[] = events
     href: `/events/${e.id}/`,
     badge: e.data.type,
     orgIds: e.data.organizations.map((o) => o.id.id),
+    orgs: e.data.organizations.map((o) => {
+      const org = orgMap.get(o.id.id);
+      return { id: o.id.id, label: org?.short_name ?? org?.name ?? o.id.id };
+    }),
+    links: e.data.links,
   }))
   .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,9 +7,10 @@
   --font-display: 'DM Serif Display', Georgia, serif;
 
   /* Colours */
-  --color-header:    #0f3040;
-  --color-accent:    #4ecdc4;
-  --color-accent-dark: #2aada4;
+  --color-header:       #0f3040;
+  --color-header-hover: #1a4a60;
+  --color-accent:       #4ecdc4;
+  --color-accent-dark:  #2aada4;
   --color-body:      #f7f8f8;
   --color-surface:   #ffffff;
   --color-border:    #d0dce0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,7 +9,7 @@
   /* Colours */
   --color-header:    #0f3040;
   --color-accent:    #4ecdc4;
-  --color-accent-dk: #2aada4;
+  --color-accent-dark: #2aada4;
   --color-body:      #f7f8f8;
   --color-surface:   #ffffff;
   --color-border:    #d0dce0;
@@ -17,6 +17,14 @@
   --color-ink:       #0f2a38;
   --color-muted:     #5a7a88;
   --color-faint:     #8aa0aa;
+
+  --color-chip-type-bg:          #e0f4f4;
+  --color-chip-type-fg:          #0a5858;
+  --color-chip-type-border:      #a8dcdc;
+  --color-chip-org-fg:           #1a5878;
+  --color-chip-org-border:       #b0d4e4;
+  --color-chip-org-hover-bg:     #e8f4f8;
+  --color-chip-org-hover-border: #7ab8d0;
 }
 
 :root {
@@ -34,20 +42,20 @@
 @layer components {
   .chip-type {
     @apply inline-block text-xs px-2 py-0.5 rounded-full font-semibold;
-    background: #e0f4f4;
-    color: #0a5858;
-    border: 1px solid #a8dcdc;
+    background: var(--color-chip-type-bg);
+    color: var(--color-chip-type-fg);
+    border: 1px solid var(--color-chip-type-border);
   }
 
   .chip-org {
     @apply inline-block text-xs px-2 py-0.5 rounded-full font-semibold no-underline;
     background: white;
-    color: #1a5878;
-    border: 1px solid #b0d4e4;
+    color: var(--color-chip-org-fg);
+    border: 1px solid var(--color-chip-org-border);
   }
 
   .chip-org:hover {
-    background: #e8f4f8;
-    border-color: #7ab8d0;
+    background: var(--color-chip-org-hover-bg);
+    border-color: var(--color-chip-org-hover-border);
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,14 +10,14 @@
   --color-header:       #0f3040;
   --color-header-hover: #1a4a60;
   --color-accent:       #4ecdc4;
-  --color-accent-dark:  #2aada4;
+  --color-accent-dark:  #0a6e6a;
   --color-body:      #f7f8f8;
   --color-surface:   #ffffff;
   --color-border:    #d0dce0;
   --color-border-lt: #e8f0f4;
   --color-ink:       #0f2a38;
-  --color-muted:     #5a7a88;
-  --color-faint:     #8aa0aa;
+  --color-muted:     #4a5f6e;
+  --color-faint:     #5a6e78;
 
   --color-chip-type-bg:          #e0f4f4;
   --color-chip-type-fg:          #0a5858;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,11 +1,53 @@
 @import "tailwindcss";
 
-@variant dark (&:where(.dark, .dark *));
+@theme {
+  /* Fonts */
+  --font-sans:    'DM Sans', system-ui, sans-serif;
+  --font-serif:   'Source Serif 4', Georgia, serif;
+  --font-display: 'DM Serif Display', Georgia, serif;
+
+  /* Colours */
+  --color-header:    #0f3040;
+  --color-accent:    #4ecdc4;
+  --color-accent-dk: #2aada4;
+  --color-body:      #f7f8f8;
+  --color-surface:   #ffffff;
+  --color-border:    #d0dce0;
+  --color-border-lt: #e8f0f4;
+  --color-ink:       #0f2a38;
+  --color-muted:     #5a7a88;
+  --color-faint:     #8aa0aa;
+}
 
 :root {
   color-scheme: light;
 }
 
-:root.dark {
-  color-scheme: dark;
+@layer base {
+  body {
+    font-family: var(--font-sans);
+    background-color: var(--color-body);
+    color: var(--color-ink);
+  }
+}
+
+@layer components {
+  .chip-type {
+    @apply inline-block text-xs px-2 py-0.5 rounded-full font-semibold;
+    background: #e0f4f4;
+    color: #0a5858;
+    border: 1px solid #a8dcdc;
+  }
+
+  .chip-org {
+    @apply inline-block text-xs px-2 py-0.5 rounded-full font-semibold no-underline;
+    background: white;
+    color: #1a5878;
+    border: 1px solid #b0d4e4;
+  }
+
+  .chip-org:hover {
+    background: #e8f4f8;
+    border-color: #7ab8d0;
+  }
 }


### PR DESCRIPTION
## Summary

- Replace monochromatic slate/grey design with a Deep Teal palette (petrol blue header `#0f3040`, teal-mint accent `#4ecdc4`, warm white body) and light mode only (dark mode removed)
- Add DM Serif Display + Source Serif 4 + DM Sans typography via Google Fonts, and an SVG favicon
- Extend `TimelineItem` with `orgs` and `links` fields; restyle timeline with teal spine/dots, inline org chips as `/orgs/<id>/` links, and source icon links (document, video, external) from event data

## Files Changed

- `src/styles/global.css` — Tailwind v4 `@theme` colour + font tokens; chip component classes; light-mode-only
- `public/favicon.svg` — New SVG favicon (petrol square, teal "AI" wordmark)
- `src/layouts/BaseLayout.astro` — Google Fonts, petrol blue header with logo-mark + active nav, remove dark mode
- `src/lib/timeline.ts` — Add `orgs` and `links` fields to `TimelineItem` type
- `src/pages/timeline/index.astro` — Populate new fields when building `TimelineItem` array
- `src/components/TimelineList.tsx` — Full restyle: teal spine, org chips, source icon links
- `src/components/TimelineList.test.tsx` — 4 new tests for org chip and source link rendering
- `src/components/OrgFilter.tsx` — Restyle filter chips (remove dark:, new active/inactive colours)
- `src/pages/index.astro` — Hero with DM Serif Display headline, teal-left-border feature cards
- `src/pages/policy/index.astro` — DM Serif Display headings, teal-left-border artifact cards
- `src/pages/orgs/index.astro` — Unified teal-left-border card treatment
- `src/pages/orgs/[id].astro`, `events/[id].astro`, `artifacts/[id].astro` — New palette, accent-dark links

## Spec and Plan

- Spec: `docs/superpowers/specs/2026-04-27-site-redesign-design.md`
- Plan: `docs/superpowers/plans/2026-04-27-site-redesign.md`

Closes #42

## Test Plan

- [ ] `npm test` — 17 tests pass (4 TimelineList, 3 OrgFilter, others)
- [ ] `npm run build` — 36 pages build with no errors
- [ ] No `dark:` classes remain in `src/`
- [ ] Timeline page: org chips link to `/orgs/<id>/`, source icon links open in new tab
- [ ] Homepage: teal eyebrow, DM Serif Display H1, teal-left-border feature cards
- [ ] Favicon appears in browser tab
- [ ] Nav active state highlights current page with teal underline
- [ ] All external links (`target="_blank"`) open in new tab with `rel="noopener noreferrer"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)