### PR TITLE
Add canonical URLs to all pages (issue #50)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ const siteTitle = "AI Governance Tracker";
 const fullTitle = title === siteTitle ? title : `${title} — ${siteTitle}`;
 
 const path = Astro.url.pathname;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const navLinks = [
   { href: "/timeline/", label: "Timeline" },
   { href: "/orgs/", label: "Organizations" },
@@ -25,6 +26,7 @@ const navLinks = [
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{fullTitle}</title>
     {description && <meta name="description" content={description} />}
+    <link rel="canonical" href={canonicalURL} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

- Adds `<link rel="canonical">` to `BaseLayout.astro` so every page automatically gets the correct canonical URL
- Uses `Astro.site` (already set to `https://ai-governance-tracker.com` in `astro.config.mjs`) + `Astro.url.pathname`
- Because the tag lives in `BaseLayout.astro`, all new pages inherit it automatically — no per-page work needed

Fixes #50

## Test plan

- [x] `npm run build` succeeds with 36 pages built
- [x] `dist/index.html` contains `<link rel="canonical" href="https://ai-governance-tracker.com/">`
- [ ] Spot-check a few other built pages (e.g. `/timeline/`, `/policy/`, an org page) for correct canonical hrefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)