### PR TITLE
Add Open Canada dataset links to ISED AI strategy summary of inputs

### DIFF
--- a/data/artifacts/2026-02-05-ai-strategy-summary-of-inputs.yaml
+++ b/data/artifacts/2026-02-05-ai-strategy-summary-of-inputs.yaml
@@ -33,6 +33,12 @@ links:
   - label: "PDF — Full Report"
     url: https://ised-isde.canada.ca/site/ised/sites/default/files/documents/AiStrategyReport_EN.pdf
     icon: document
+  - label: "Open Canada — ISED AI Engagement Task Force Reports"
+    url: https://open.canada.ca/data/en/dataset/df68c04c-c156-44b1-8cf7-cdf532a2ce9b
+    icon: document
+  - label: "Open Canada — ISED AI Engagement Dataset"
+    url: https://open.canada.ca/data/en/dataset/bc8cdd54-19cf-4f62-a3d3-fa4b7371d49a
+    icon: document
 
 tags:
   - ised


### PR DESCRIPTION
## Summary
- Adds two Open Canada dataset links to the ISED AI strategy summary of inputs artifact
- ISED AI Engagement Task Force Reports (32 task force reports from the consultation)
- ISED AI Engagement Dataset (qualitative public consultation response data)

## Test Plan
- [ ] Data-only change — no code modified
- [ ] CI unit and e2e checks pass