### PR TITLE
Add WhitePaper and JointStatement sections to policy page

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -48,11 +48,21 @@ const events = defineCollection({
   }),
 });
 
+export const artifactTypeSchema = z.enum([
+  "GovernmentProgram",
+  "JointStatement",
+  "Legislation",
+  "PolicyDocument",
+  "Report",
+  "WhitePaper",
+]);
+export type ArtifactType = z.infer<typeof artifactTypeSchema>;
+
 const artifacts = defineCollection({
   loader: yamlGlob({ pattern: "*.yaml", base: dataDir("artifacts") }),
   schema: z.object({
     id: z.string(),
-    type: z.string(),
+    type: artifactTypeSchema,
     schema_type: z.literal("CreativeWork"),
     title: z.string(),
     published_date: z.coerce.date(),

--- a/src/pages/policy/index.astro
+++ b/src/pages/policy/index.astro
@@ -10,10 +10,12 @@ function byDateDesc(a: { data: { published_date: Date } }, b: { data: { publishe
   return b.data.published_date.getTime() - a.data.published_date.getTime();
 }
 
-const legislation = artifacts.filter((a) => a.data.type === "Legislation").sort(byDateDesc);
-const reports     = artifacts.filter((a) => a.data.type === "Report").sort(byDateDesc);
-const policyDocs  = artifacts.filter((a) => a.data.type === "PolicyDocument").sort(byDateDesc);
-const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram").sort(byDateDesc);
+const legislation   = artifacts.filter((a) => a.data.type === "Legislation").sort(byDateDesc);
+const reports       = artifacts.filter((a) => a.data.type === "Report").sort(byDateDesc);
+const whitePapers   = artifacts.filter((a) => a.data.type === "WhitePaper").sort(byDateDesc);
+const policyDocs    = artifacts.filter((a) => a.data.type === "PolicyDocument").sort(byDateDesc);
+const govPrograms   = artifacts.filter((a) => a.data.type === "GovernmentProgram").sort(byDateDesc);
+const jointStatements = artifacts.filter((a) => a.data.type === "JointStatement").sort(byDateDesc);
 ---
 
 <BaseLayout
@@ -84,6 +86,32 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
     </section>
   )}
 
+  {whitePapers.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">White Papers</h2>
+      <p class="mt-2 max-w-2xl text-muted">
+        Position and advocacy papers published by think tanks and civil society organizations
+        making the case for specific AI policy approaches.
+      </p>
+      <div class="mt-6 space-y-4">
+        {whitePapers.map((w) => (
+          <a
+            href={`/artifacts/${w.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
+          >
+            <h3 class="text-base font-semibold text-header">{w.data.title}</h3>
+            {w.data.description && (
+              <p class="mt-2 text-sm text-muted">{w.data.description}</p>
+            )}
+            <p class="mt-2 text-xs text-faint">
+              Published: {fmtDate(w.data.published_date)}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+
   {policyDocs.length > 0 && (
     <section class="mt-10">
       <h2 class="font-display text-2xl text-header">Policy Documents</h2>
@@ -128,6 +156,31 @@ const govPrograms = artifacts.filter((a) => a.data.type === "GovernmentProgram")
             )}
             <p class="mt-2 text-xs text-faint">
               Published: {fmtDate(p.data.published_date)}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+  {jointStatements.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">Joint Statements</h2>
+      <p class="mt-2 max-w-2xl text-muted">
+        Bilateral and multilateral statements on AI governance issued jointly by Canada and
+        partner governments.
+      </p>
+      <div class="mt-6 space-y-4">
+        {jointStatements.map((j) => (
+          <a
+            href={`/artifacts/${j.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
+          >
+            <h3 class="text-base font-semibold text-header">{j.data.title}</h3>
+            {j.data.description && (
+              <p class="mt-2 text-sm text-muted">{j.data.description}</p>
+            )}
+            <p class="mt-2 text-xs text-faint">
+              Published: {fmtDate(j.data.published_date)}
             </p>
           </a>
         ))}

--- a/src/pages/policy/index.astro
+++ b/src/pages/policy/index.astro
@@ -3,6 +3,19 @@ import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { badgeClass, statusLabel } from "../../lib/legislation";
 import { fmtDate } from "../../lib/format";
+import type { ArtifactType } from "../../content.config";
+
+// Exhaustiveness guard: every ArtifactType must appear here.
+// Set to true (shown on this page) or false (intentionally omitted).
+// Adding a new type to the schema without updating this will be a compile error.
+const _policyVisibility: Record<ArtifactType, boolean> = {
+  GovernmentProgram: true,
+  JointStatement: true,
+  Legislation: true,
+  PolicyDocument: true,
+  Report: true,
+  WhitePaper: true,
+};
 
 const artifacts = await getCollection("artifacts");
 

--- a/src/pages/policy/index.astro
+++ b/src/pages/policy/index.astro
@@ -73,58 +73,6 @@ const jointStatements = artifacts.filter((a) => a.data.type === "JointStatement"
     </section>
   )}
 
-  {reports.length > 0 && (
-    <section class="mt-10">
-      <h2 class="font-display text-2xl text-header">Reports</h2>
-      <p class="mt-2 max-w-2xl text-muted">
-        Research reports and analytical summaries published by think tanks, government
-        agencies, and advisory bodies.
-      </p>
-      <div class="mt-6 space-y-4">
-        {reports.map((r) => (
-          <a
-            href={`/artifacts/${r.id}/`}
-            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
-          >
-            <h3 class="text-base font-semibold text-header">{r.data.title}</h3>
-            {r.data.description && (
-              <p class="mt-2 text-sm text-muted">{r.data.description}</p>
-            )}
-            <p class="mt-2 text-xs text-faint">
-              Published: {fmtDate(r.data.published_date)}
-            </p>
-          </a>
-        ))}
-      </div>
-    </section>
-  )}
-
-  {whitePapers.length > 0 && (
-    <section class="mt-10">
-      <h2 class="font-display text-2xl text-header">White Papers</h2>
-      <p class="mt-2 max-w-2xl text-muted">
-        Position and advocacy papers published by think tanks and civil society organizations
-        making the case for specific AI policy approaches.
-      </p>
-      <div class="mt-6 space-y-4">
-        {whitePapers.map((w) => (
-          <a
-            href={`/artifacts/${w.id}/`}
-            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
-          >
-            <h3 class="text-base font-semibold text-header">{w.data.title}</h3>
-            {w.data.description && (
-              <p class="mt-2 text-sm text-muted">{w.data.description}</p>
-            )}
-            <p class="mt-2 text-xs text-faint">
-              Published: {fmtDate(w.data.published_date)}
-            </p>
-          </a>
-        ))}
-      </div>
-    </section>
-  )}
-
   {policyDocs.length > 0 && (
     <section class="mt-10">
       <h2 class="font-display text-2xl text-header">Policy Documents</h2>
@@ -194,6 +142,57 @@ const jointStatements = artifacts.filter((a) => a.data.type === "JointStatement"
             )}
             <p class="mt-2 text-xs text-faint">
               Published: {fmtDate(j.data.published_date)}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+  {reports.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">Reports</h2>
+      <p class="mt-2 max-w-2xl text-muted">
+        Research reports and analytical summaries published by think tanks, government
+        agencies, and advisory bodies.
+      </p>
+      <div class="mt-6 space-y-4">
+        {reports.map((r) => (
+          <a
+            href={`/artifacts/${r.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
+          >
+            <h3 class="text-base font-semibold text-header">{r.data.title}</h3>
+            {r.data.description && (
+              <p class="mt-2 text-sm text-muted">{r.data.description}</p>
+            )}
+            <p class="mt-2 text-xs text-faint">
+              Published: {fmtDate(r.data.published_date)}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
+
+  {whitePapers.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">White Papers</h2>
+      <p class="mt-2 max-w-2xl text-muted">
+        Position and advocacy papers published by think tanks and civil society organizations
+        making the case for specific AI policy approaches.
+      </p>
+      <div class="mt-6 space-y-4">
+        {whitePapers.map((w) => (
+          <a
+            href={`/artifacts/${w.id}/`}
+            class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
+          >
+            <h3 class="text-base font-semibold text-header">{w.data.title}</h3>
+            {w.data.description && (
+              <p class="mt-2 text-sm text-muted">{w.data.description}</p>
+            )}
+            <p class="mt-2 text-xs text-faint">
+              Published: {fmtDate(w.data.published_date)}
             </p>
           </a>
         ))}


### PR DESCRIPTION
The policy page hardcoded four artifact types and silently dropped anything else. Two WhitePaper artifacts and one JointStatement were invisible as a result. Add dedicated sections for both types.