### PR TITLE
Expand homepage intro with site purpose and scope

### DIFF
--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -4,7 +4,7 @@ test.describe("homepage", () => {
   test("renders site title and values statement", async ({ page }) => {
     await page.goto("/");
     await expect(page.getByRole("heading", { level: 1, name: /AI Governance Tracker/i })).toBeVisible();
-    await expect(page.getByText(/AI safety/i)).toBeVisible();
+    await expect(page.getByText(/transformational impact/i)).toBeVisible();
   });
 
   test("primary CTA links to /timeline/", async ({ page }) => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,8 +14,11 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       AI Governance Tracker
     </h1>
     <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
-      Tracking Canadian AI safety and governance — Senate hearings, legislation,
-      and policy action — so that anyone who cares can stay informed.
+      AI is likely to have a transformational impact on human society, and governance of AI is important to ensure that this transformation goes well.
+      The goal of this site is to be a resource for Canadians to understand the status of AI governance in Canada so that they can provide their own input into the ecosystem.
+    </p>
+    <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
+      Policy on the full range of AI risks and benefits is given space here, but emphasis is on the scenarios with the largest potential impacts — including widespread deployment of advanced AI across the economy, increased bio and cyber risk, and the implications of highly capable systems. Within that scope, the site reports on government action and civil society inputs neutrally, without editorial comment.
     </p>
 
     <div class="mt-8 flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary
- Replace the one-line homepage tagline with a two-paragraph intro
- Paragraph 1 frames why AI governance matters and the site's purpose for Canadians
- Paragraph 2 makes scope explicit: full range of AI risks/benefits welcome, with emphasis on the highest-impact scenarios (advanced AI deployment, bio/cyber risk, highly capable systems), while preserving the neutral-reporting stance within that scope

## Test plan
- [ ] Visually verify both paragraphs render correctly on the homepage
- [ ] Confirm CTA buttons and grid below are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)