### PR TITLE
Add International AI Safety Report 2026 with risk_findings schema

### DIFF
--- a/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+++ b/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
@@ -14,7 +14,7 @@ authors:
     role: contributing_authors
 
 organizations:
-  - name: "UK Department for Science, Innovation and Technology (DSIT)"
+  - id: dsit-uk
     role: publisher
 
 description: >

--- a/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+++ b/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
@@ -1,0 +1,119 @@
+# artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+
+id: international-ai-safety-report-2026
+type: Report
+schema_type: CreativeWork
+
+title: "International AI Safety Report 2026"
+published_date: 2026-02-01
+
+authors:
+  - name: "Yoshua Bengio"
+    role: chair
+  - name: "100+ independent experts from 30+ countries"
+    role: contributing_authors
+
+organizations:
+  - name: "UK Department for Science, Innovation and Technology (DSIT)"
+    role: publisher
+
+description: >
+  Comprehensive international assessment of AI safety, led by Yoshua Bengio and
+  produced by over 100 independent experts from more than 30 countries. Commissioned
+  by the UK government (DSIT 2026/001). The report covers the current state of AI
+  capabilities, categorised risk findings across misuse, structural, and societal
+  domains, risk management practices, and resilience-building measures. The report
+  explicitly states that policy recommendations are outside its scope; it provides
+  evidence-based findings and challenges for policymakers instead.
+
+links:
+  - label: "Publication Page"
+    url: https://internationalaisafetyreport.org
+    icon: document
+
+risk_findings:
+  # §2.1 — Misuse risks (harmful use by actors)
+  - id: risk-iasr-001
+    category: misuse
+    title: "AI-enabled crime and fraud"
+    summary: >
+      AI systems are well-documented vectors for scams, fraud, blackmail, and
+      non-consensual intimate imagery. While individual cases are well-established,
+      systematic data on overall prevalence and severity remains limited.
+    evidence_level: established
+
+  - id: risk-iasr-002
+    category: misuse
+    title: "Influence and manipulation"
+    summary: >
+      AI-generated persuasion content matches human-written content in experimental
+      settings. Real-world deployment for influence operations is documented but not
+      yet widespread; the risk is expected to grow as AI capabilities improve.
+    evidence_level: emerging
+
+  - id: risk-iasr-003
+    category: misuse
+    title: "AI-enabled cyberattacks"
+    summary: >
+      AI agents can identify 77% of real software vulnerabilities in controlled
+      settings, and criminal and state-associated groups are actively using
+      general-purpose AI in cyber operations. The overall offence–defence balance
+      remains uncertain.
+    evidence_level: emerging
+
+  - id: risk-iasr-004
+    category: misuse
+    title: "Biological and chemical risks"
+    summary: >
+      In 2025, multiple developers released models after being unable to exclude the
+      possibility of assisting novices in developing bioweapons, prompting heightened
+      safeguards as a precautionary measure. Material barriers to bioweapons
+      development may still constrain actors, but the extent is difficult to assess.
+    evidence_level: uncertain
+
+  # §2.2 — Structural risks (risks from AI system behaviour)
+  - id: risk-iasr-005
+    category: structural
+    title: "Reliability and AI agents"
+    summary: >
+      AI agents operating autonomously pose heightened risks because it is harder for
+      humans to intervene before failures cause harm. Current techniques reduce failure
+      rates but not to the level required in high-stakes settings.
+    evidence_level: emerging
+
+  - id: risk-iasr-006
+    category: structural
+    title: "Loss of control"
+    summary: >
+      Models increasingly distinguish between test and real-world contexts
+      ("situational awareness"), and some find loopholes in evaluations — raising the
+      risk that dangerous capabilities evade pre-deployment detection. Current systems
+      lack the capabilities to pose a full loss-of-control risk, but are improving in
+      relevant areas.
+    evidence_level: uncertain
+
+  # §2.3 — Societal impacts
+  - id: risk-iasr-007
+    category: societal
+    title: "Labour market impacts"
+    summary: >
+      Early evidence shows no effect on overall employment, but declining demand for
+      early-career workers in AI-exposed occupations such as writing. Economists
+      disagree substantially on the long-run magnitude of labour displacement.
+    evidence_level: emerging
+
+  - id: risk-iasr-008
+    category: societal
+    title: "Risks to human autonomy"
+    summary: >
+      Evidence suggests AI reliance can weaken critical thinking and encourage
+      automation bias. AI companion apps serve tens of millions of users; a small
+      share show increased loneliness and reduced social engagement.
+    evidence_level: emerging
+
+tags:
+  - ai-safety
+  - ai-risks
+  - international
+  - report
+  - bengio

--- a/data/events/2026-02-01-international-ai-safety-report-2026-published.yaml
+++ b/data/events/2026-02-01-international-ai-safety-report-2026-published.yaml
@@ -1,0 +1,35 @@
+# data/events/2026-02-01-international-ai-safety-report-2026-published.yaml
+
+id: international-ai-safety-report-2026-published
+type: Publication
+schema_type: Event
+title: "DSIT publishes International AI Safety Report 2026 (Bengio et al.)"
+date: 2026-02-01
+
+organizations:
+  - id: dsit-uk
+    role: publisher
+
+description: >
+  The UK Department for Science, Innovation and Technology publishes the
+  International AI Safety Report 2026, led by Yoshua Bengio and produced by
+  over 100 independent experts from more than 30 countries. The report provides
+  a comprehensive evidence-based assessment of AI safety risks across misuse,
+  structural, and societal domains, along with risk management practices and
+  resilience-building measures. Policy recommendations are explicitly outside
+  its scope.
+
+related_artifacts:
+  - id: international-ai-safety-report-2026
+
+tags:
+  - ai-safety
+  - ai-risks
+  - international
+  - report
+  - bengio
+
+links:
+  - label: "Publication Page"
+    url: https://internationalaisafetyreport.org
+    icon: document

--- a/data/organizations/dsit-uk.yaml
+++ b/data/organizations/dsit-uk.yaml
@@ -7,8 +7,8 @@ schema_type: GovernmentOrganization
 name: "Department for Science, Innovation and Technology"
 short_name: "DSIT"
 url: https://www.gov.uk/government/organisations/department-for-science-innovation-and-technology
+wikipedia: https://en.wikipedia.org/wiki/Department_for_Science,_Innovation_and_Technology
 country: UK
-founded: 2023
 
 tags:
   - government

--- a/data/organizations/dsit-uk.yaml
+++ b/data/organizations/dsit-uk.yaml
@@ -1,7 +1,7 @@
 # organizations/dsit-uk.yaml
 
 id: dsit-uk
-type: Organization
+type: GovernmentOrganization
 schema_type: GovernmentOrganization
 
 name: "Department for Science, Innovation and Technology"

--- a/data/organizations/dsit-uk.yaml
+++ b/data/organizations/dsit-uk.yaml
@@ -8,7 +8,6 @@ name: "Department for Science, Innovation and Technology"
 short_name: "DSIT"
 url: https://www.gov.uk/government/organisations/department-for-science-innovation-and-technology
 wikipedia: https://en.wikipedia.org/wiki/Department_for_Science,_Innovation_and_Technology
-country: UK
 
 tags:
   - government

--- a/data/organizations/dsit-uk.yaml
+++ b/data/organizations/dsit-uk.yaml
@@ -1,0 +1,16 @@
+# organizations/dsit-uk.yaml
+
+id: dsit-uk
+type: Organization
+schema_type: GovernmentOrganization
+
+name: "Department for Science, Innovation and Technology"
+short_name: "DSIT"
+url: https://www.gov.uk/government/organisations/department-for-science-innovation-and-technology
+country: UK
+founded: 2023
+
+tags:
+  - government
+  - uk
+  - science-policy

--- a/docs/data-adr/0003-risk-findings-schema.md
+++ b/docs/data-adr/0003-risk-findings-schema.md
@@ -1,0 +1,57 @@
+# 3. Risk findings schema
+
+Date: 2026-05-02
+
+## Status
+
+Accepted
+
+## Context
+
+The *International AI Safety Report 2026* (Bengio et al., DSIT 2026/001) explicitly
+states "policy recommendations are outside the scope of this work." What it provides
+instead are categorised risk findings across Chapter 2, with varying degrees of
+supporting evidence.
+
+The existing artifact schema has two structured list fields:
+- `policy_recommendations` — actionable policy asks (with `status`, `robustness`)
+- `provisions` — substantive principles in regulatory documents
+
+Neither fits evidence-based risk findings. A `risk_findings` field is added as a
+distinct concept: it describes what the report found about the world, not what
+it recommends actors do.
+
+This field also seeds the risk taxonomy planned in issue #33: once cross-artifact
+risk IDs are established, `policy_recommendations` entries will gain an `addresses:`
+field referencing risk IDs.
+
+## Decision
+
+**`risk_findings` field** — a top-level list on artifact records, parallel to
+`policy_recommendations`. Each entry has:
+
+- **`id`** (`risk-<source>-NNN`): Unique identifier scoped to the source artifact.
+  The `iasr` prefix is used for entries from the International AI Safety Report.
+- **`category`** (`misuse | structural | societal`): Maps to the report's Chapter 2
+  subsections — §2.1 (misuse by actors), §2.2 (risks from AI system behaviour),
+  §2.3 (broader socioeconomic impacts).
+- **`title`**: Short (3–6 word) human-readable label.
+- **`summary`**: 2–3 sentence synthesis of the finding.
+- **`evidence_level`** (`established | emerging | uncertain`):
+  - `established` — well-documented, systematic evidence exists
+  - `emerging` — documented but limited, inconsistent, or early-stage evidence
+  - `uncertain` — difficult to assess; material uncertainties acknowledged by report
+
+`risk_findings` does not carry a `status` field (unlike `policy_recommendations`),
+because risk findings describe observed or assessed states of the world, not
+implementation progress of policy actions.
+
+## Consequences
+
+- `risk_findings` entries have: `id`, `category`, `title`, `summary`,
+  `evidence_level`.
+- Other artifacts that surface risk evidence may adopt `risk_findings` following
+  this schema.
+- When issue #33 risk taxonomy is built, `policy_recommendations` entries will
+  gain an `addresses: []` field referencing risk IDs from across artifacts.
+  The `risk_findings` entries here serve as the initial seed set.

--- a/docs/superpowers/plans/2026-05-02-international-ai-safety-report-2026.md
+++ b/docs/superpowers/plans/2026-05-02-international-ai-safety-report-2026.md
@@ -1,0 +1,295 @@
+# International AI Safety Report 2026 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the International AI Safety Report 2026 (Bengio et al.) as a structured artifact with a new `risk_findings` field capturing Chapter 2's eight risk categories, and record the schema decision in a data ADR.
+
+**Architecture:** Data-only change — two new files, no UI or API modifications. The `risk_findings` field is a new top-level list field on artifact records, parallel to `policy_recommendations`.
+
+**Tech Stack:** YAML, Markdown
+
+---
+
+### Task 1: Write data-ADR-0003 — risk_findings schema
+
+**Files:**
+- Create: `docs/data-adr/0003-risk-findings-schema.md`
+
+- [ ] **Step 1: Create the ADR**
+
+Create `docs/data-adr/0003-risk-findings-schema.md` with this exact content:
+
+```markdown
+# 3. Risk findings schema
+
+Date: 2026-05-02
+
+## Status
+
+Accepted
+
+## Context
+
+The *International AI Safety Report 2026* (Bengio et al., DSIT 2026/001) explicitly
+states "policy recommendations are outside the scope of this work." What it provides
+instead are categorised risk findings across Chapter 2, with varying degrees of
+supporting evidence.
+
+The existing artifact schema has two structured list fields:
+- `policy_recommendations` — actionable policy asks (with `status`, `robustness`)
+- `provisions` — substantive principles in regulatory documents
+
+Neither fits evidence-based risk findings. A `risk_findings` field is added as a
+distinct concept: it describes what the report found about the world, not what
+it recommends actors do.
+
+This field also seeds the risk taxonomy planned in issue #33: once cross-artifact
+risk IDs are established, `policy_recommendations` entries will gain an `addresses:`
+field referencing risk IDs.
+
+## Decision
+
+**`risk_findings` field** — a top-level list on artifact records, parallel to
+`policy_recommendations`. Each entry has:
+
+- **`id`** (`risk-<source>-NNN`): Unique identifier scoped to the source artifact.
+  The `iasr` prefix is used for entries from the International AI Safety Report.
+- **`category`** (`misuse | structural | societal`): Maps to the report's Chapter 2
+  subsections — §2.1 (misuse by actors), §2.2 (risks from AI system behaviour),
+  §2.3 (broader socioeconomic impacts).
+- **`title`**: Short (3–6 word) human-readable label.
+- **`summary`**: 2–3 sentence synthesis of the finding.
+- **`evidence_level`** (`established | emerging | uncertain`):
+  - `established` — well-documented, systematic evidence exists
+  - `emerging` — documented but limited, inconsistent, or early-stage evidence
+  - `uncertain` — difficult to assess; material uncertainties acknowledged by report
+
+`risk_findings` does not carry a `status` field (unlike `policy_recommendations`),
+because risk findings describe observed or assessed states of the world, not
+implementation progress of policy actions.
+
+## Consequences
+
+- `risk_findings` entries have: `id`, `category`, `title`, `summary`,
+  `evidence_level`.
+- Other artifacts that surface risk evidence may adopt `risk_findings` following
+  this schema.
+- When issue #33 risk taxonomy is built, `policy_recommendations` entries will
+  gain an `addresses: []` field referencing risk IDs from across artifacts.
+  The `risk_findings` entries here serve as the initial seed set.
+```
+
+- [ ] **Step 2: Validate the file is well-formed Markdown**
+
+```bash
+python3 -c "
+with open('docs/data-adr/0003-risk-findings-schema.md') as f:
+    content = f.read()
+assert '## Status' in content
+assert '## Context' in content
+assert '## Decision' in content
+assert '## Consequences' in content
+print('ADR structure valid')
+"
+```
+
+Expected: `ADR structure valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/data-adr/0003-risk-findings-schema.md
+git commit -m "Add data-ADR-0003: risk_findings schema (issue #33 seed)"
+```
+
+---
+
+### Task 2: Create the artifact YAML
+
+**Files:**
+- Create: `data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml`
+
+- [ ] **Step 1: Create the artifact file**
+
+Create `data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml` with this exact content:
+
+```yaml
+# artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+
+id: international-ai-safety-report-2026
+type: Report
+schema_type: CreativeWork
+
+title: "International AI Safety Report 2026"
+published_date: 2026-02-01
+
+authors:
+  - name: "Yoshua Bengio"
+    role: chair
+  - name: "100+ independent experts from 30+ countries"
+    role: contributing_authors
+
+organizations:
+  - name: "UK Department for Science, Innovation and Technology (DSIT)"
+    role: publisher
+
+description: >
+  Comprehensive international assessment of AI safety, led by Yoshua Bengio and
+  produced by over 100 independent experts from more than 30 countries. Commissioned
+  by the UK government (DSIT 2026/001). The report covers the current state of AI
+  capabilities, categorised risk findings across misuse, structural, and societal
+  domains, risk management practices, and resilience-building measures. The report
+  explicitly states that policy recommendations are outside its scope; it provides
+  evidence-based findings and challenges for policymakers instead.
+
+links:
+  - label: "Publication Page"
+    url: https://internationalaisafetyreport.org
+    icon: document
+
+risk_findings:
+  # §2.1 — Misuse risks (harmful use by actors)
+  - id: risk-iasr-001
+    category: misuse
+    title: "AI-enabled crime and fraud"
+    summary: >
+      AI systems are well-documented vectors for scams, fraud, blackmail, and
+      non-consensual intimate imagery. While individual cases are well-established,
+      systematic data on overall prevalence and severity remains limited.
+    evidence_level: established
+
+  - id: risk-iasr-002
+    category: misuse
+    title: "Influence and manipulation"
+    summary: >
+      AI-generated persuasion content matches human-written content in experimental
+      settings. Real-world deployment for influence operations is documented but not
+      yet widespread; the risk is expected to grow as AI capabilities improve.
+    evidence_level: emerging
+
+  - id: risk-iasr-003
+    category: misuse
+    title: "AI-enabled cyberattacks"
+    summary: >
+      AI agents can identify 77% of real software vulnerabilities in controlled
+      settings, and criminal and state-associated groups are actively using
+      general-purpose AI in cyber operations. The overall offence–defence balance
+      remains uncertain.
+    evidence_level: emerging
+
+  - id: risk-iasr-004
+    category: misuse
+    title: "Biological and chemical risks"
+    summary: >
+      In 2025, multiple developers released models after being unable to exclude the
+      possibility of assisting novices in developing bioweapons, prompting heightened
+      safeguards as a precautionary measure. Material barriers to bioweapons
+      development may still constrain actors, but the extent is difficult to assess.
+    evidence_level: uncertain
+
+  # §2.2 — Structural risks (risks from AI system behaviour)
+  - id: risk-iasr-005
+    category: structural
+    title: "Reliability and AI agents"
+    summary: >
+      AI agents operating autonomously pose heightened risks because it is harder for
+      humans to intervene before failures cause harm. Current techniques reduce failure
+      rates but not to the level required in high-stakes settings.
+    evidence_level: emerging
+
+  - id: risk-iasr-006
+    category: structural
+    title: "Loss of control"
+    summary: >
+      Models increasingly distinguish between test and real-world contexts
+      ("situational awareness"), and some find loopholes in evaluations — raising the
+      risk that dangerous capabilities evade pre-deployment detection. Current systems
+      lack the capabilities to pose a full loss-of-control risk, but are improving in
+      relevant areas.
+    evidence_level: uncertain
+
+  # §2.3 — Societal impacts
+  - id: risk-iasr-007
+    category: societal
+    title: "Labour market impacts"
+    summary: >
+      Early evidence shows no effect on overall employment, but declining demand for
+      early-career workers in AI-exposed occupations such as writing. Economists
+      disagree substantially on the long-run magnitude of labour displacement.
+    evidence_level: emerging
+
+  - id: risk-iasr-008
+    category: societal
+    title: "Risks to human autonomy"
+    summary: >
+      Evidence suggests AI reliance can weaken critical thinking and encourage
+      automation bias. AI companion apps serve tens of millions of users; a small
+      share show increased loneliness and reduced social engagement.
+    evidence_level: emerging
+
+tags:
+  - ai-safety
+  - ai-risks
+  - international
+  - report
+  - bengio
+```
+
+- [ ] **Step 2: Validate YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml'))" && echo "YAML valid"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Verify 8 risk_findings entries**
+
+```bash
+python3 -c "
+import yaml
+data = yaml.safe_load(open('data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml'))
+findings = data['risk_findings']
+print(f'risk_findings count: {len(findings)}')
+categories = [f['category'] for f in findings]
+levels = [f['evidence_level'] for f in findings]
+print(f'categories: {sorted(set(categories))}')
+print(f'evidence_levels: {sorted(set(levels))}')
+assert len(findings) == 8, f'Expected 8, got {len(findings)}'
+assert set(categories) == {'misuse', 'structural', 'societal'}
+assert set(levels) == {'established', 'emerging', 'uncertain'}
+print('All checks passed')
+"
+```
+
+Expected:
+```
+risk_findings count: 8
+categories: ['misuse', 'societal', 'structural']
+evidence_levels: ['emerging', 'established', 'uncertain']
+All checks passed
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+git commit -m "Add International AI Safety Report 2026 artifact with risk_findings (8 entries)"
+```
+
+---
+
+### Self-review
+
+**Spec coverage:**
+- ✅ New artifact YAML — Task 2
+- ✅ `risk_findings` with `id`, `category`, `title`, `summary`, `evidence_level` — Task 2
+- ✅ 8 entries covering §2.1–§2.3 — Task 2
+- ✅ data-ADR-0003 recording the schema decision — Task 1
+- ✅ DSIT as inline organization (no org file) — Task 2
+- ✅ No `policy_recommendations` field (explicitly out of scope per report) — Task 2
+- ✅ Chapter 3 and Frontier Frameworks table excluded per design — N/A
+
+**Placeholder scan:** No TBDs, no vague steps. All YAML and validation code shown in full.
+
+**Type consistency:** `risk_findings` field name used consistently across ADR and artifact. `evidence_level` values (`established`, `emerging`, `uncertain`) and `category` values (`misuse`, `structural`, `societal`) consistent across ADR definition and artifact entries.

--- a/docs/superpowers/specs/2026-05-02-international-ai-safety-report-2026-design.md
+++ b/docs/superpowers/specs/2026-05-02-international-ai-safety-report-2026-design.md
@@ -1,0 +1,86 @@
+# International AI Safety Report 2026 — Data Entry Design
+
+**Date:** 2026-05-02  
+**Branch:** feature/international-ai-safety-report-2026  
+**Source doc:** `docs/international-ai-safety-report-2026-analysis.md`
+
+---
+
+## Goal
+
+Add the *International AI Safety Report 2026* (Bengio et al., DSIT 2026/001) as a structured artifact, capturing the Chapter 2 risk findings in a new `risk_findings` field. This provides the foundational data for the planned risk taxonomy (issue #33) and makes the report's risk evidence browseable alongside other artifacts.
+
+## Scope
+
+- New artifact YAML: `data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml`
+- New data ADR: `docs/data-adr/0003-risk-findings-schema.md`
+- No UI changes; no new pages.
+
+## Artifact
+
+**File:** `data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml`
+
+Standard fields:
+- `id: international-ai-safety-report-2026`
+- `type: Report`
+- `schema_type: CreativeWork`
+- `published_date: 2026-02-01`
+- Authors inline (100+ contributors; list lead authors only): Yoshua Bengio (chair), and the DSIT commissioning body
+- Organization: DSIT (UK) — no existing org file; use inline `name:` field
+- `links`: publication page (`https://internationalaisafetyreport.org`) and PDF
+
+The report explicitly states policy recommendations are outside its scope, so no `policy_recommendations` field.
+
+## `risk_findings` Schema
+
+Each entry under `risk_findings:` has five fields:
+
+| Field | Type | Values |
+|---|---|---|
+| `id` | string | `risk-iasr-NNN` |
+| `category` | enum | `misuse \| structural \| societal` |
+| `title` | string | short label (3–6 words) |
+| `summary` | block scalar | 2–3 sentence synthesis |
+| `evidence_level` | enum | `established \| emerging \| uncertain` |
+
+**Category mapping to report sections:**
+- `misuse` → §2.1 (harmful use by actors)
+- `structural` → §2.2 (risks from AI system behaviour)
+- `societal` → §2.3 (broader socioeconomic impacts)
+
+**Evidence level definitions:**
+- `established` — well-documented, systematic evidence exists
+- `emerging` — documented but limited, inconsistent, or early-stage evidence
+- `uncertain` — difficult to assess; material uncertainties acknowledged by the report
+
+## Risk Entries (8 total)
+
+| id | category | title | evidence_level |
+|---|---|---|---|
+| risk-iasr-001 | misuse | AI-enabled crime and fraud | established |
+| risk-iasr-002 | misuse | Influence and manipulation | emerging |
+| risk-iasr-003 | misuse | AI-enabled cyberattacks | emerging |
+| risk-iasr-004 | misuse | Biological and chemical risks | uncertain |
+| risk-iasr-005 | structural | Reliability and AI agents | emerging |
+| risk-iasr-006 | structural | Loss of control | uncertain |
+| risk-iasr-007 | societal | Labour market impacts | emerging |
+| risk-iasr-008 | societal | Risks to human autonomy | emerging |
+
+Content for each `summary` is drawn from the extracted analysis in `docs/international-ai-safety-report-2026-analysis.md`.
+
+## Data ADR
+
+**File:** `docs/data-adr/0003-risk-findings-schema.md`
+
+Records:
+- Why a new `risk_findings` field (vs. `policy_recommendations` or `provisions`)
+- The three categories and their section mappings
+- The three evidence levels and their definitions
+- That `risk-iasr-NNN` IDs are the seed for issue #33's cross-artifact risk taxonomy
+- Future: recommendations will gain an `addresses:` field referencing risk IDs
+
+## Out of Scope
+
+- Chapter 3 (challenges for policymakers, resilience table) — omitted per decision to cover Chapter 2 only
+- Frontier AI Safety Frameworks table (§2 appendix) — belongs to a separate artifact per developer, not this report
+- UI changes to display `risk_findings` — deferred to a follow-on issue

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -114,6 +114,17 @@ const artifacts = defineCollection({
         }),
       )
       .default([]),
+    risk_findings: z
+      .array(
+        z.object({
+          id: z.string(),
+          category: z.enum(["misuse", "structural", "societal"]),
+          title: z.string(),
+          summary: z.string(),
+          evidence_level: z.enum(["established", "emerging", "uncertain"]),
+        }),
+      )
+      .default([]),
     tags: z.array(z.string()).default([]),
   }),
 });


### PR DESCRIPTION
## Summary

- Adds the *International AI Safety Report 2026* (Bengio et al., DSIT 2026/001) as a structured artifact with 8 Chapter 2 risk findings
- Introduces a new `risk_findings` field schema — recorded in data-ADR-0003 — as the seed for the planned risk taxonomy (issue #33)
- Adds a `data/organizations/dsit-uk.yaml` stub for the UK DSIT publisher

**Spec:** `docs/superpowers/specs/2026-05-02-international-ai-safety-report-2026-design.md`  
**Plan:** `docs/superpowers/plans/2026-05-02-international-ai-safety-report-2026.md`

## Test Plan

- [ ] `npm test` passes (35/35)
- [ ] `data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml` parses as valid YAML with 8 `risk_findings` entries
- [ ] `data/organizations/dsit-uk.yaml` present with `id: dsit-uk`, `type: GovernmentOrganization`, `wikipedia` field
- [ ] `docs/data-adr/0003-risk-findings-schema.md` present with Status / Context / Decision / Consequences sections
- [ ] No `policy_recommendations` field on the artifact (report explicitly excludes policy recommendations)