### PR TITLE
Fix broken mobile nav with hamburger menu

### DIFF
--- a/e2e/mobile-nav.spec.ts
+++ b/e2e/mobile-nav.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("mobile nav", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("shows hamburger and hides desktop nav on mobile", async ({ page }) => {
+    await expect(page.getByRole("button", { name: /toggle navigation/i })).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Main navigation" })).toBeHidden();
+  });
+
+  test("toggles mobile nav open and closed", async ({ page }) => {
+    const toggle = page.getByRole("button", { name: /toggle navigation/i });
+    const mobileNav = page.getByRole("navigation", { name: "Mobile navigation" });
+
+    await expect(mobileNav).toBeHidden();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await toggle.click();
+    await expect(mobileNav).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    await toggle.click();
+    await expect(mobileNav).toBeHidden();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("closes mobile nav with Escape key", async ({ page }) => {
+    const toggle = page.getByRole("button", { name: /toggle navigation/i });
+    const mobileNav = page.getByRole("navigation", { name: "Mobile navigation" });
+
+    await toggle.click();
+    await expect(mobileNav).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(mobileNav).toBeHidden();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("mobile nav links navigate correctly", async ({ page }) => {
+    await page.getByRole("button", { name: /toggle navigation/i }).click();
+    await page.getByRole("navigation", { name: "Mobile navigation" }).getByRole("link", { name: "Timeline" }).click();
+    await expect(page).toHaveURL("/timeline/");
+  });
+});
+
+test.describe("desktop nav", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("shows desktop nav and hides hamburger", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("button", { name: /toggle navigation/i })).toBeHidden();
+    await expect(page.getByRole("navigation", { name: "Main navigation" })).toBeVisible();
+  });
+});

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -108,8 +108,8 @@ const navLinks = [
       <!-- mobile nav: shown when hamburger is open -->
       <nav
         id="mobile-nav"
-        class="hidden border-t border-[#1a4a60] sm:hidden"
-        aria-label="Main navigation"
+        class="hidden border-t border-header-hover sm:hidden"
+        aria-label="Mobile navigation"
       >
         {navLinks.map(({ href, label }) => {
           const active = path.startsWith(href);
@@ -133,10 +133,24 @@ const navLinks = [
     <script is:inline>
       const toggle = document.getElementById('nav-toggle');
       const menu = document.getElementById('mobile-nav');
-      toggle?.addEventListener('click', () => {
-        const isHidden = menu.classList.toggle('hidden');
-        toggle.setAttribute('aria-expanded', String(!isHidden));
-      });
+      if (toggle && menu) {
+        const close = () => {
+          menu.classList.add('hidden');
+          toggle.setAttribute('aria-expanded', 'false');
+        };
+        toggle.addEventListener('click', () => {
+          const isHidden = menu.classList.toggle('hidden');
+          toggle.setAttribute('aria-expanded', String(!isHidden));
+        });
+        document.addEventListener('keydown', (e) => {
+          if (e.key === 'Escape' && !menu.classList.contains('hidden')) {
+            close();
+            toggle.focus();
+          }
+        });
+        const mq = window.matchMedia('(min-width: 640px)');
+        mq.addEventListener('change', (e) => { if (e.matches) close(); });
+      }
     </script>
     <main class="mx-auto max-w-4xl px-6 py-10">
       <slot />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -70,7 +70,22 @@ const navLinks = [
           </span>
           {siteTitle}
         </a>
-        <nav class="flex" aria-label="Main navigation">
+        <!-- hamburger: mobile only -->
+        <button
+          id="nav-toggle"
+          class="flex items-center py-4 text-[#8ab8c8] hover:text-white sm:hidden"
+          aria-label="Toggle navigation"
+          aria-expanded="false"
+          aria-controls="mobile-nav"
+        >
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        </button>
+        <!-- desktop nav -->
+        <nav class="hidden sm:flex" aria-label="Main navigation">
           {navLinks.map(({ href, label }) => {
             const active = path.startsWith(href);
             return (
@@ -90,7 +105,39 @@ const navLinks = [
           })}
         </nav>
       </div>
+      <!-- mobile nav: shown when hamburger is open -->
+      <nav
+        id="mobile-nav"
+        class="hidden border-t border-[#1a4a60] sm:hidden"
+        aria-label="Main navigation"
+      >
+        {navLinks.map(({ href, label }) => {
+          const active = path.startsWith(href);
+          return (
+            <a
+              href={href}
+              class={[
+                "block px-6 py-3 text-sm font-medium border-l-[3px] transition-colors no-underline",
+                active
+                  ? "text-white border-accent"
+                  : "text-[#8ab8c8] border-transparent hover:text-white",
+              ].join(" ")}
+              aria-current={active ? "page" : undefined}
+            >
+              {label}
+            </a>
+          );
+        })}
+      </nav>
     </header>
+    <script is:inline>
+      const toggle = document.getElementById('nav-toggle');
+      const menu = document.getElementById('mobile-nav');
+      toggle?.addEventListener('click', () => {
+        const isHidden = menu.classList.toggle('hidden');
+        toggle.setAttribute('aria-expanded', String(!isHidden));
+      });
+    </script>
     <main class="mx-auto max-w-4xl px-6 py-10">
       <slot />
     </main>


### PR DESCRIPTION
## Summary

- Root cause: `<nav>` in `BaseLayout.astro` used plain `flex` with no responsive breakpoints — on narrow screens (~375px) the site title + 3 nav links overflowed horizontally
- Added a hamburger button (`sm:hidden`) that toggles a stacked vertical nav below the header bar on mobile
- Desktop nav (`hidden sm:flex`) is unchanged
- Toggle uses a small inline script; no framework dependency

Closes #44

## Test plan

- [ ] At 375px width: hamburger icon visible, no horizontal overflow
- [ ] Click hamburger: Timeline / Organizations / Policy appear stacked below header
- [ ] Click again: menu collapses
- [ ] At 640px+: horizontal nav shown, hamburger hidden
- [ ] Active page link has accent underline on both mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)