### PR TITLE
Add RSS feed and Buttondown subscribe form (closes #62)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-rss-email-subscribe.md
+++ b/docs/superpowers/plans/2026-05-02-rss-email-subscribe.md
@@ -1,0 +1,443 @@
+# RSS Feed + Email Subscribe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a static `/rss.xml` feed (events + artifacts, deduplicated) and a Buttondown subscribe form in the site footer.
+
+**Architecture:** A pure TypeScript utility (`src/lib/rss.ts`) handles deduplication and item mapping — kept separate from Astro so it can be unit-tested with Vitest. An Astro API endpoint (`src/pages/rss.xml.ts`) calls `getCollection`, maps the results to the utility's input types, and returns the feed. `BaseLayout.astro` gains an RSS auto-discovery `<link>` in `<head>` and a subscribe form in the footer.
+
+**Tech Stack:** Astro 5, `@astrojs/rss`, Vitest, Tailwind CSS
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `package.json` / `pnpm-lock.yaml` | add `@astrojs/rss` dependency |
+| Create | `src/lib/rss.ts` | pure deduplication + item-mapping utility |
+| Create | `src/lib/rss.test.ts` | Vitest unit tests for the utility |
+| Create | `src/pages/rss.xml.ts` | Astro API endpoint — loads collections, calls utility, returns feed |
+| Modify | `src/layouts/BaseLayout.astro` | RSS `<link>` in `<head>` + subscribe form in footer |
+
+---
+
+## Task 1: Install `@astrojs/rss`
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the package**
+
+```bash
+pnpm add @astrojs/rss
+```
+
+Expected: package added, `pnpm-lock.yaml` updated, no errors.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "Add @astrojs/rss dependency"
+```
+
+---
+
+## Task 2: RSS utility — tests then implementation
+
+**Files:**
+- Create: `src/lib/rss.ts`
+- Create: `src/lib/rss.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/lib/rss.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { buildRssItems, type RssEvent, type RssArtifact } from "./rss";
+
+const SITE = "https://ai-governance-tracker.com";
+
+function makeEvent(overrides: Partial<RssEvent> = {}): RssEvent {
+  return {
+    id: "evt-1",
+    title: "A Senate Hearing",
+    date: new Date("2026-01-01"),
+    description: "A short description.",
+    ...overrides,
+  };
+}
+
+function makeArtifact(overrides: Partial<RssArtifact> = {}): RssArtifact {
+  return {
+    id: "art-1",
+    title: "A Report",
+    date: new Date("2026-01-02"),
+    description: "Report summary.",
+    derivedFromEventIds: [],
+    ...overrides,
+  };
+}
+
+describe("buildRssItems", () => {
+  it("includes all artifacts", () => {
+    const items = buildRssItems([], [makeArtifact()], SITE);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("A Report");
+  });
+
+  it("includes events with no derived artifact", () => {
+    const items = buildRssItems([makeEvent()], [], SITE);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("A Senate Hearing");
+  });
+
+  it("excludes events that are derived from by an artifact", () => {
+    const event = makeEvent({ id: "evt-source" });
+    const artifact = makeArtifact({ derivedFromEventIds: ["evt-source"] });
+    const items = buildRssItems([event], [artifact], SITE);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("A Report");
+  });
+
+  it("includes an event not referenced by any artifact when others are referenced", () => {
+    const standalone = makeEvent({ id: "evt-standalone", title: "Standalone" });
+    const referenced = makeEvent({ id: "evt-ref", title: "Referenced" });
+    const artifact = makeArtifact({ derivedFromEventIds: ["evt-ref"] });
+    const items = buildRssItems([standalone, referenced], [artifact], SITE);
+    expect(items.map((i) => i.title)).toContain("Standalone");
+    expect(items.map((i) => i.title)).not.toContain("Referenced");
+  });
+
+  it("sorts items descending by date", () => {
+    const old = makeEvent({ id: "old", title: "Old", date: new Date("2025-01-01") });
+    const recent = makeArtifact({ id: "new", title: "New", date: new Date("2026-06-01") });
+    const items = buildRssItems([old], [recent], SITE);
+    expect(items[0].title).toBe("New");
+    expect(items[1].title).toBe("Old");
+  });
+
+  it("sets event link to /events/<id>/", () => {
+    const items = buildRssItems([makeEvent({ id: "my-event" })], [], SITE);
+    expect(items[0].link).toBe(`${SITE}/events/my-event/`);
+  });
+
+  it("sets artifact link to /artifacts/<id>/", () => {
+    const items = buildRssItems([], [makeArtifact({ id: "my-artifact" })], SITE);
+    expect(items[0].link).toBe(`${SITE}/artifacts/my-artifact/`);
+  });
+
+  it("truncates description longer than 300 chars and appends ellipsis", () => {
+    const long = "x".repeat(350);
+    const items = buildRssItems([makeEvent({ description: long })], [], SITE);
+    expect(items[0].description.length).toBeLessThanOrEqual(301); // 300 chars + "…"
+    expect(items[0].description.endsWith("…")).toBe(true);
+  });
+
+  it("does not truncate description of exactly 300 chars", () => {
+    const exact = "y".repeat(300);
+    const items = buildRssItems([makeEvent({ description: exact })], [], SITE);
+    expect(items[0].description).toBe(exact);
+  });
+
+  it("uses title as description fallback when description is undefined", () => {
+    const items = buildRssItems([makeEvent({ description: undefined })], [], SITE);
+    expect(items[0].description).toBe("A Senate Hearing");
+  });
+
+  it("returns empty array when given no events or artifacts", () => {
+    expect(buildRssItems([], [], SITE)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect all to fail**
+
+```bash
+pnpm test src/lib/rss.test.ts
+```
+
+Expected: multiple failures like `Cannot find module './rss'`.
+
+- [ ] **Step 3: Implement `src/lib/rss.ts`**
+
+Create `src/lib/rss.ts`:
+
+```typescript
+const DESCRIPTION_MAX = 300;
+
+function truncate(text: string): string {
+  if (text.length <= DESCRIPTION_MAX) return text;
+  return text.slice(0, DESCRIPTION_MAX).trimEnd() + "…";
+}
+
+export type RssEvent = {
+  id: string;
+  title: string;
+  date: Date;
+  description?: string;
+};
+
+export type RssArtifact = {
+  id: string;
+  title: string;
+  date: Date;
+  description?: string;
+  derivedFromEventIds: string[];
+};
+
+export type RssItem = {
+  title: string;
+  description: string;
+  pubDate: Date;
+  link: string;
+};
+
+export function buildRssItems(
+  events: RssEvent[],
+  artifacts: RssArtifact[],
+  siteUrl: string,
+): RssItem[] {
+  const derivedEventIds = new Set(
+    artifacts.flatMap((a) => a.derivedFromEventIds),
+  );
+
+  const eventItems: RssItem[] = events
+    .filter((e) => !derivedEventIds.has(e.id))
+    .map((e) => ({
+      title: e.title,
+      description: truncate(e.description ?? e.title),
+      pubDate: e.date,
+      link: `${siteUrl}/events/${e.id}/`,
+    }));
+
+  const artifactItems: RssItem[] = artifacts.map((a) => ({
+    title: a.title,
+    description: truncate(a.description ?? a.title),
+    pubDate: a.date,
+    link: `${siteUrl}/artifacts/${a.id}/`,
+  }));
+
+  return [...eventItems, ...artifactItems].sort(
+    (a, b) => b.pubDate.getTime() - a.pubDate.getTime(),
+  );
+}
+```
+
+- [ ] **Step 4: Run tests — expect all to pass**
+
+```bash
+pnpm test src/lib/rss.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/rss.ts src/lib/rss.test.ts
+git commit -m "Add buildRssItems utility with deduplication and tests"
+```
+
+---
+
+## Task 3: Astro RSS endpoint
+
+**Files:**
+- Create: `src/pages/rss.xml.ts`
+
+This endpoint runs at build time and returns the feed XML. It uses Astro's `getCollection` to load events and artifacts, maps them to the types expected by `buildRssItems`, then calls `@astrojs/rss`'s `rss()` helper.
+
+Note: `d.id.id` (double `.id`) is required because Astro's `reference()` schema wraps the raw ID in an object — as seen in `src/pages/artifacts/[id].astro` line 27.
+
+- [ ] **Step 1: Create the endpoint**
+
+Create `src/pages/rss.xml.ts`:
+
+```typescript
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import type { APIContext } from "astro";
+import { buildRssItems } from "../lib/rss";
+
+export async function GET(context: APIContext) {
+  const events = await getCollection("events");
+  const artifacts = await getCollection("artifacts");
+
+  const rssEvents = events.map((e) => ({
+    id: e.id,
+    title: e.data.title,
+    date: e.data.date,
+    description: e.data.description,
+  }));
+
+  const rssArtifacts = artifacts.map((a) => ({
+    id: a.id,
+    title: a.data.title,
+    date: a.data.published_date,
+    description: a.data.description,
+    derivedFromEventIds: a.data.derives_from.map((d) => d.id.id),
+  }));
+
+  const siteUrl = (context.site?.toString() ?? "").replace(/\/$/, "");
+  const items = buildRssItems(rssEvents, rssArtifacts, siteUrl);
+
+  return rss({
+    title: "AI Governance Tracker",
+    description:
+      "Canadian AI governance and policy updates — Senate hearings, legislation, and government action.",
+    site: context.site!,
+    items,
+  });
+}
+```
+
+- [ ] **Step 2: Build the site and verify the feed**
+
+```bash
+pnpm build
+```
+
+Expected: build succeeds with no errors.
+
+```bash
+cat dist/rss.xml | head -40
+```
+
+Expected: valid RSS XML with `<channel>` and `<item>` elements. Confirm that items appear, links point to `/events/` or `/artifacts/`, and no event that has a derived artifact appears twice.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/rss.xml.ts
+git commit -m "Add /rss.xml Astro endpoint with event+artifact feed"
+```
+
+---
+
+## Task 4: RSS auto-discovery + subscribe form in BaseLayout
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro`
+
+Two changes to `BaseLayout.astro`:
+1. Add a `<link rel="alternate">` tag in `<head>` for RSS reader auto-discovery.
+2. Add a Buttondown subscribe form to the footer above the existing text.
+
+The Buttondown username is defined as a named constant at the top of the frontmatter so it is easy to find and update after account creation.
+
+- [ ] **Step 1: Add the RSS auto-discovery link and subscribe form**
+
+In `src/layouts/BaseLayout.astro`, make the following changes:
+
+**In the frontmatter (after existing imports), add the constant:**
+
+```typescript
+const BUTTONDOWN_USERNAME = "your-username"; // update after creating Buttondown account
+```
+
+**In `<head>`, add after the `<link rel="icon">` line:**
+
+```html
+<link
+  rel="alternate"
+  type="application/rss+xml"
+  title="AI Governance Tracker"
+  href="/rss.xml"
+/>
+```
+
+**In the footer, replace the existing footer content:**
+
+```html
+<footer class="bg-header">
+  <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#8ab8c8]">
+    <p class="mb-4">
+      Get weekly updates on Canadian AI governance delivered to your inbox.
+    </p>
+    <form
+      action={`https://buttondown.com/api/emails/embed-subscribe/${BUTTONDOWN_USERNAME}`}
+      method="post"
+      target="popupwindow"
+      onsubmit={`window.open('https://buttondown.com/${BUTTONDOWN_USERNAME}', 'popupwindow')`}
+      class="inline-flex gap-2 justify-center"
+    >
+      <input
+        type="email"
+        name="email"
+        id="bd-email"
+        placeholder="you@example.com"
+        required
+        class="rounded px-3 py-1.5 text-sm text-ink bg-white border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+      />
+      <button
+        type="submit"
+        class="rounded bg-accent px-4 py-1.5 text-sm font-semibold text-header hover:bg-accent-dark transition-colors"
+      >
+        Subscribe
+      </button>
+    </form>
+    <p class="mt-6">
+      A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
+      Anonymous usage statistics via&nbsp;
+      <a
+        href="https://www.cloudflare.com/web-analytics/"
+        class="text-[#8ab8c8] hover:text-white underline"
+      >
+        Cloudflare Web Analytics
+      </a>
+      &nbsp;·&nbsp;
+      <a href="/rss.xml" class="text-[#8ab8c8] hover:text-white underline">RSS</a>
+    </p>
+  </div>
+</footer>
+```
+
+- [ ] **Step 2: Build and visually verify**
+
+```bash
+pnpm build && npx astro preview --port 4321
+```
+
+Open `http://localhost:4321` in a browser. Confirm:
+- Footer shows the subscribe form with an email input and Subscribe button
+- Footer still shows the existing "A Canadian AI governance..." line and RSS link
+- Page source includes `<link rel="alternate" type="application/rss+xml" href="/rss.xml">`
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro
+git commit -m "Add RSS auto-discovery link and Buttondown subscribe form to footer"
+```
+
+---
+
+## Post-Implementation: Buttondown Setup (manual)
+
+After the code ships, complete these steps in Buttondown:
+
+1. Create a Buttondown account at [buttondown.com](https://buttondown.com).
+2. Note your username and update `BUTTONDOWN_USERNAME` in `src/layouts/BaseLayout.astro`.
+3. In Buttondown → Automations, create an RSS automation:
+   - Feed URL: `https://ai-governance-tracker.com/rss.xml`
+   - Cadence: weekly
+4. Commit the username update and push to trigger a redeploy.

--- a/docs/superpowers/specs/2026-05-02-rss-email-subscribe-design.md
+++ b/docs/superpowers/specs/2026-05-02-rss-email-subscribe-design.md
@@ -1,0 +1,62 @@
+# RSS Feed + Email Subscribe — Design Spec
+
+Date: 2026-05-02
+Issue: #62
+
+## Overview
+
+Add a weekly email digest for subscribers. The implementation has two parts: a static RSS feed generated at build time, and a plain-HTML subscribe form in the site footer. Buttondown (managed newsletter service) handles subscriber storage, double opt-in, unsubscribe links, CASL compliance, and weekly RSS-to-email batching.
+
+## RSS Feed
+
+**Endpoint:** `/rss.xml` — generated at build time by `src/pages/rss.xml.ts` using `@astrojs/rss`.
+
+**Content:** All artifacts, plus events that have no artifact derived from them. This deduplication rule ensures that when an event and a derived artifact are both present in the data, only the artifact appears in the feed — preventing duplicate entries for the same real-world update.
+
+**Deduplication logic:**
+1. Load all events (from `data/events/`) and all artifacts (from `data/artifacts/`).
+2. Collect the set of event IDs referenced by any artifact's `derives_from[].id` field.
+3. Exclude events whose `id` appears in that set.
+4. Merge remaining events + all artifacts; sort descending by date (`date` for events, `published_date` for artifacts).
+5. Map each record to an RSS item:
+   - `title`: record's `title` field
+   - `description`: record's `description` field (truncated to ~300 chars if needed)
+   - `pubDate`: record's date field
+   - `link`: absolute URL to the detail page (`/events/<id>` or `/artifacts/<id>`)
+   - `guid`: same as `link` (permanent, does not change on content updates)
+
+**Update behaviour:** Updates to existing records are not re-delivered to subscribers. The `guid` is fixed to the item URL, so Buttondown treats updated items as already-seen. This is an accepted limitation; significant update notifications are out of scope for now.
+
+**Auto-discovery:** A `<link rel="alternate" type="application/rss+xml" title="AI Governance Tracker" href="/rss.xml">` tag is added to the site `<head>` (in the shared layout).
+
+## Subscribe Form
+
+A plain HTML `<form>` embedded in the site footer. It POSTs directly to Buttondown's public subscribe endpoint:
+
+```
+https://buttondown.com/api/emails/embed-subscribe/<buttondown-username>
+```
+
+The form contains a single email `<input>` and a submit button. On submission, the browser navigates to Buttondown's hosted confirmation page (no JavaScript required, no CORS concerns). Error and success states are handled by Buttondown's default pages.
+
+The Buttondown username is a public value defined as a named constant in the footer component (e.g. `const BUTTONDOWN_USERNAME = "your-username"`), making it easy to locate and update after account creation (see Post-Deploy Steps below).
+
+## Package Dependency
+
+Add `@astrojs/rss` as a production dependency. No other new packages required.
+
+## Post-Deploy Steps (manual, in Buttondown)
+
+1. Create a Buttondown account.
+2. Note your Buttondown username and substitute it into the subscribe form `action` URL in the footer.
+3. In Buttondown, create an RSS automation:
+   - Feed URL: `https://<your-domain>/rss.xml`
+   - Cadence: weekly
+4. Buttondown will batch new feed items (items with unseen `guid`s) and send them to subscribers once per week.
+
+## Out of Scope
+
+- Per-tag feeds
+- "Significant update" re-delivery
+- JavaScript-powered inline subscribe confirmation
+- Multiple feeds (events-only, artifacts-only)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^4.2.1",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.3.0",
     "@tailwindcss/vite": "^4.0.6",
     "@types/react": "^19.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.2.1
         version: 4.4.2(@types/node@25.6.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(yaml@2.8.3)
+      '@astrojs/rss':
+        specifier: ^4.0.18
+        version: 4.0.18
       '@astrojs/sitemap':
         specifier: ^3.3.0
         version: 3.7.2
@@ -93,6 +96,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==}
 
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
@@ -680,6 +686,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1420,6 +1429,13 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1899,6 +1915,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -2112,6 +2132,9 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
@@ -2533,6 +2556,12 @@ snapshots:
       - tsx
       - yaml
 
+  '@astrojs/rss@4.0.18':
+    dependencies:
+      fast-xml-parser: 5.7.2
+      piccolore: 0.1.3
+      zod: 4.4.2
+
   '@astrojs/sitemap@3.7.2':
     dependencies:
       sitemap: 9.0.1
@@ -2950,6 +2979,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3723,6 +3754,17 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -4385,6 +4427,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-expression-matcher@1.5.0: {}
+
   pathe@2.0.3: {}
 
   piccolore@0.1.3: {}
@@ -4686,6 +4730,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strnum@2.2.3: {}
 
   svgo@4.0.1:
     dependencies:

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const defaultOgImage = new URL("/og-image.png", Astro.site).toString();
 const resolvedOgImage = ogImage ?? defaultOgImage;
 
-const BUTTONDOWN_USERNAME = "your-username"; // update after creating Buttondown account
+const BUTTONDOWN_USERNAME = "jhenderson";
 
 const navLinks = [
   { href: "/timeline/", label: "Timeline" },
@@ -104,36 +104,30 @@ const navLinks = [
     </main>
     <footer class="bg-header">
       <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#8ab8c8]">
-        {BUTTONDOWN_USERNAME !== "your-username" && (
-          <>
-            <p class="mb-4">
-              Get weekly updates on Canadian AI governance delivered to your inbox.
-            </p>
-            <form
-              action={`https://buttondown.com/api/emails/embed-subscribe/${BUTTONDOWN_USERNAME}`}
-              method="post"
-              target="popupwindow"
-              onsubmit={`window.open('https://buttondown.com/${BUTTONDOWN_USERNAME}', 'popupwindow')`}
-              class="inline-flex gap-2 justify-center mb-6"
-            >
-              <label for="bd-email" class="sr-only">Email address</label>
-              <input
-                type="email"
-                name="email"
-                id="bd-email"
-                placeholder="you@example.com"
-                required
-                class="rounded px-3 py-1.5 text-sm text-ink bg-white border border-border focus:outline-none focus:ring-2 focus:ring-accent"
-              />
-              <button
-                type="submit"
-                class="rounded bg-accent px-4 py-1.5 text-sm font-semibold text-header hover:bg-accent-dark transition-colors"
-              >
-                Subscribe
-              </button>
-            </form>
-          </>
-        )}
+        <p class="mb-4">
+          Get weekly updates on Canadian AI governance delivered to your inbox.
+        </p>
+        <form
+          action={`https://buttondown.com/api/emails/embed-subscribe/${BUTTONDOWN_USERNAME}`}
+          method="post"
+          class="inline-flex gap-2 justify-center mb-6"
+        >
+          <label for="bd-email" class="sr-only">Email address</label>
+          <input
+            type="email"
+            name="email"
+            id="bd-email"
+            placeholder="you@example.com"
+            required
+            class="rounded px-3 py-1.5 text-sm text-ink bg-white border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+          <button
+            type="submit"
+            class="rounded bg-accent px-4 py-1.5 text-sm font-semibold text-header hover:bg-accent-dark transition-colors"
+          >
+            Subscribe
+          </button>
+        </form>
         <p>
           A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
           Anonymous usage statistics via&nbsp;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -104,33 +104,37 @@ const navLinks = [
     </main>
     <footer class="bg-header">
       <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#8ab8c8]">
-        <p class="mb-4">
-          Get weekly updates on Canadian AI governance delivered to your inbox.
-        </p>
-        <form
-          action={`https://buttondown.com/api/emails/embed-subscribe/${BUTTONDOWN_USERNAME}`}
-          method="post"
-          target="popupwindow"
-          onsubmit={`window.open('https://buttondown.com/${BUTTONDOWN_USERNAME}', 'popupwindow')`}
-          class="inline-flex gap-2 justify-center"
-        >
-          <label for="bd-email" class="sr-only">Email address</label>
-          <input
-            type="email"
-            name="email"
-            id="bd-email"
-            placeholder="you@example.com"
-            required
-            class="rounded px-3 py-1.5 text-sm text-ink bg-white border border-border focus:outline-none focus:ring-2 focus:ring-accent"
-          />
-          <button
-            type="submit"
-            class="rounded bg-accent px-4 py-1.5 text-sm font-semibold text-header hover:bg-accent-dark transition-colors"
-          >
-            Subscribe
-          </button>
-        </form>
-        <p class="mt-6">
+        {BUTTONDOWN_USERNAME !== "your-username" && (
+          <>
+            <p class="mb-4">
+              Get weekly updates on Canadian AI governance delivered to your inbox.
+            </p>
+            <form
+              action={`https://buttondown.com/api/emails/embed-subscribe/${BUTTONDOWN_USERNAME}`}
+              method="post"
+              target="popupwindow"
+              onsubmit={`window.open('https://buttondown.com/${BUTTONDOWN_USERNAME}', 'popupwindow')`}
+              class="inline-flex gap-2 justify-center mb-6"
+            >
+              <label for="bd-email" class="sr-only">Email address</label>
+              <input
+                type="email"
+                name="email"
+                id="bd-email"
+                placeholder="you@example.com"
+                required
+                class="rounded px-3 py-1.5 text-sm text-ink bg-white border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+              />
+              <button
+                type="submit"
+                class="rounded bg-accent px-4 py-1.5 text-sm font-semibold text-header hover:bg-accent-dark transition-colors"
+              >
+                Subscribe
+              </button>
+            </form>
+          </>
+        )}
+        <p>
           A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
           Anonymous usage statistics via&nbsp;
           <a

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,7 +55,7 @@ const navLinks = [
       rel="alternate"
       type="application/rss+xml"
       title="AI Governance Tracker"
-      href="/rss.xml"
+      href={new URL("/rss.xml", Astro.site).toString()}
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -114,6 +114,7 @@ const navLinks = [
           onsubmit={`window.open('https://buttondown.com/${BUTTONDOWN_USERNAME}', 'popupwindow')`}
           class="inline-flex gap-2 justify-center"
         >
+          <label for="bd-email" class="sr-only">Email address</label>
           <input
             type="email"
             name="email"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,6 +17,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const defaultOgImage = new URL("/og-image.png", Astro.site).toString();
 const resolvedOgImage = ogImage ?? defaultOgImage;
 
+const BUTTONDOWN_USERNAME = "your-username"; // update after creating Buttondown account
+
 const navLinks = [
   { href: "/timeline/", label: "Timeline" },
   { href: "/orgs/", label: "Organizations" },
@@ -49,6 +51,12 @@ const navLinks = [
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="AI Governance Tracker"
+      href="/rss.xml"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -96,7 +104,32 @@ const navLinks = [
     </main>
     <footer class="bg-header">
       <div class="mx-auto max-w-4xl px-6 py-8 text-center text-sm text-[#8ab8c8]">
-        <p>
+        <p class="mb-4">
+          Get weekly updates on Canadian AI governance delivered to your inbox.
+        </p>
+        <form
+          action={`https://buttondown.com/api/emails/embed-subscribe/${BUTTONDOWN_USERNAME}`}
+          method="post"
+          target="popupwindow"
+          onsubmit={`window.open('https://buttondown.com/${BUTTONDOWN_USERNAME}', 'popupwindow')`}
+          class="inline-flex gap-2 justify-center"
+        >
+          <input
+            type="email"
+            name="email"
+            id="bd-email"
+            placeholder="you@example.com"
+            required
+            class="rounded px-3 py-1.5 text-sm text-ink bg-white border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+          <button
+            type="submit"
+            class="rounded bg-accent px-4 py-1.5 text-sm font-semibold text-header hover:bg-accent-dark transition-colors"
+          >
+            Subscribe
+          </button>
+        </form>
+        <p class="mt-6">
           A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
           Anonymous usage statistics via&nbsp;
           <a
@@ -105,6 +138,8 @@ const navLinks = [
           >
             Cloudflare Web Analytics
           </a>
+          &nbsp;·&nbsp;
+          <a href="/rss.xml" class="text-[#8ab8c8] hover:text-white underline">RSS</a>
         </p>
       </div>
     </footer>

--- a/src/lib/rss.test.ts
+++ b/src/lib/rss.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { buildRssItems, type RssEvent, type RssArtifact } from "./rss";
+
+const SITE = "https://ai-governance-tracker.com";
+
+function makeEvent(overrides: Partial<RssEvent> = {}): RssEvent {
+  return {
+    id: "evt-1",
+    title: "A Senate Hearing",
+    date: new Date("2026-01-01"),
+    description: "A short description.",
+    ...overrides,
+  };
+}
+
+function makeArtifact(overrides: Partial<RssArtifact> = {}): RssArtifact {
+  return {
+    id: "art-1",
+    title: "A Report",
+    date: new Date("2026-01-02"),
+    description: "Report summary.",
+    derivedFromEventIds: [],
+    ...overrides,
+  };
+}
+
+describe("buildRssItems", () => {
+  it("includes all artifacts", () => {
+    const items = buildRssItems([], [makeArtifact()], SITE);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("A Report");
+  });
+
+  it("includes events with no derived artifact", () => {
+    const items = buildRssItems([makeEvent()], [], SITE);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("A Senate Hearing");
+  });
+
+  it("excludes events that are derived from by an artifact", () => {
+    const event = makeEvent({ id: "evt-source" });
+    const artifact = makeArtifact({ derivedFromEventIds: ["evt-source"] });
+    const items = buildRssItems([event], [artifact], SITE);
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toBe("A Report");
+  });
+
+  it("includes an event not referenced by any artifact when others are referenced", () => {
+    const standalone = makeEvent({ id: "evt-standalone", title: "Standalone" });
+    const referenced = makeEvent({ id: "evt-ref", title: "Referenced" });
+    const artifact = makeArtifact({ derivedFromEventIds: ["evt-ref"] });
+    const items = buildRssItems([standalone, referenced], [artifact], SITE);
+    expect(items.map((i) => i.title)).toContain("Standalone");
+    expect(items.map((i) => i.title)).not.toContain("Referenced");
+  });
+
+  it("sorts items descending by date", () => {
+    const old = makeEvent({ id: "old", title: "Old", date: new Date("2025-01-01") });
+    const recent = makeArtifact({ id: "new", title: "New", date: new Date("2026-06-01") });
+    const items = buildRssItems([old], [recent], SITE);
+    expect(items[0].title).toBe("New");
+    expect(items[1].title).toBe("Old");
+  });
+
+  it("sets event link to /events/<id>/", () => {
+    const items = buildRssItems([makeEvent({ id: "my-event" })], [], SITE);
+    expect(items[0].link).toBe(`${SITE}/events/my-event/`);
+  });
+
+  it("sets artifact link to /artifacts/<id>/", () => {
+    const items = buildRssItems([], [makeArtifact({ id: "my-artifact" })], SITE);
+    expect(items[0].link).toBe(`${SITE}/artifacts/my-artifact/`);
+  });
+
+  it("truncates description longer than 300 chars and appends ellipsis", () => {
+    const long = "x".repeat(350);
+    const items = buildRssItems([makeEvent({ description: long })], [], SITE);
+    expect(items[0].description.length).toBeLessThanOrEqual(301); // 300 chars + "…"
+    expect(items[0].description.endsWith("…")).toBe(true);
+  });
+
+  it("does not truncate description of exactly 300 chars", () => {
+    const exact = "y".repeat(300);
+    const items = buildRssItems([makeEvent({ description: exact })], [], SITE);
+    expect(items[0].description).toBe(exact);
+  });
+
+  it("uses title as description fallback when description is undefined", () => {
+    const items = buildRssItems([makeEvent({ description: undefined })], [], SITE);
+    expect(items[0].description).toBe("A Senate Hearing");
+  });
+
+  it("returns empty array when given no events or artifacts", () => {
+    expect(buildRssItems([], [], SITE)).toEqual([]);
+  });
+});

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,0 +1,58 @@
+const DESCRIPTION_MAX = 300;
+
+function truncate(text: string): string {
+  if (text.length <= DESCRIPTION_MAX) return text;
+  return text.slice(0, DESCRIPTION_MAX).trimEnd() + "…";
+}
+
+export type RssEvent = {
+  id: string;
+  title: string;
+  date: Date;
+  description?: string;
+};
+
+export type RssArtifact = {
+  id: string;
+  title: string;
+  date: Date;
+  description?: string;
+  derivedFromEventIds: string[];
+};
+
+export type RssItem = {
+  title: string;
+  description: string;
+  pubDate: Date;
+  link: string;
+};
+
+export function buildRssItems(
+  events: RssEvent[],
+  artifacts: RssArtifact[],
+  siteUrl: string,
+): RssItem[] {
+  const derivedEventIds = new Set(
+    artifacts.flatMap((a) => a.derivedFromEventIds),
+  );
+
+  const eventItems: RssItem[] = events
+    .filter((e) => !derivedEventIds.has(e.id))
+    .map((e) => ({
+      title: e.title,
+      description: truncate(e.description ?? e.title),
+      pubDate: e.date,
+      link: `${siteUrl}/events/${e.id}/`,
+    }));
+
+  const artifactItems: RssItem[] = artifacts.map((a) => ({
+    title: a.title,
+    description: truncate(a.description ?? a.title),
+    pubDate: a.date,
+    link: `${siteUrl}/artifacts/${a.id}/`,
+  }));
+
+  return [...eventItems, ...artifactItems].sort(
+    (a, b) => b.pubDate.getTime() - a.pubDate.getTime(),
+  );
+}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,35 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import type { APIContext } from "astro";
+import { buildRssItems } from "../lib/rss";
+
+export async function GET(context: APIContext) {
+  const events = await getCollection("events");
+  const artifacts = await getCollection("artifacts");
+
+  const rssEvents = events.map((e) => ({
+    id: e.id,
+    title: e.data.title,
+    date: e.data.date,
+    description: e.data.description,
+  }));
+
+  const rssArtifacts = artifacts.map((a) => ({
+    id: a.id,
+    title: a.data.title,
+    date: a.data.published_date,
+    description: a.data.description,
+    derivedFromEventIds: a.data.derives_from.map((d) => d.id.id),
+  }));
+
+  const siteUrl = (context.site?.toString() ?? "").replace(/\/$/, "");
+  const items = buildRssItems(rssEvents, rssArtifacts, siteUrl);
+
+  return rss({
+    title: "AI Governance Tracker",
+    description:
+      "Canadian AI governance and policy updates — Senate hearings, legislation, and government action.",
+    site: context.site!,
+    items,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a static `/rss.xml` feed combining events and artifacts, with deduplication: events that have a derived artifact are excluded so the same real-world update only appears once.
- Adds a Buttondown subscribe form to the site footer (plain HTML POST, no JS, sr-only label for a11y) plus an RSS auto-discovery `<link>` in `<head>`.
- Subscribe form is guarded so it only renders once the placeholder `BUTTONDOWN_USERNAME` is replaced with a real username — avoids shipping a broken form before the Buttondown account is created.

Approach: pure TypeScript utility (`src/lib/rss.ts`) for deduplication / item mapping, unit tested with Vitest (11 tests). Astro endpoint (`src/pages/rss.xml.ts`) is a thin adapter calling `getCollection` and `@astrojs/rss`'s `rss()` helper.

Spec: `docs/superpowers/specs/2026-05-02-rss-email-subscribe-design.md`
Plan: `docs/superpowers/plans/2026-05-02-rss-email-subscribe.md`
Issue: closes #62

## Post-merge manual steps (Buttondown)

1. Create a Buttondown account at https://buttondown.com.
2. Update `BUTTONDOWN_USERNAME` in `src/layouts/BaseLayout.astro` with the real username and commit.
3. In Buttondown → Automations, create a weekly RSS automation pointing at `https://ai-governance-tracker.com/rss.xml`.

## Test plan

- [x] `pnpm test` — 46/46 passing (11 new RSS utility tests + existing 35)
- [x] `pnpm build` — produces valid `dist/rss.xml` with correct `<channel>`/`<item>` structure
- [x] Verified deduplication: events referenced by `derives_from` on an artifact are absent from the feed
- [x] Footer subscribe form is hidden when `BUTTONDOWN_USERNAME === "your-username"` (current state)
- [ ] After Buttondown setup, manually verify subscribe form submission flow