### PR TITLE
Remove homepage subtitle and soften phrasing

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,9 +7,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   description="Tracking Canadian AI governance and policy — Senate hearings, legislation, and government action."
 >
   <div class="py-8">
-    <p class="text-xs font-semibold uppercase tracking-widest text-accent-dark mb-3">
-      AI Policy · Governance · Safety
-    </p>
     <h1 class="font-display text-5xl leading-tight text-header tracking-tight">
       AI Governance Tracker
     </h1>
@@ -18,7 +15,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       The goal of this site is to be a resource for Canadians to understand the status of AI governance in Canada so that they can provide their own input into the ecosystem.
     </p>
     <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
-      Policy on the full range of AI risks and benefits is given space here, but emphasis is on the scenarios with the largest potential impacts — including widespread deployment of advanced AI across the economy, increased bio and cyber risk, and the implications of highly capable systems. Within that scope, the site reports on government action and civil society inputs neutrally, without editorial comment.
+      Policy on the full range of AI risks and benefits is given space here, but emphasis is on the scenarios with the largest potential impacts such as widespread deployment of advanced AI across the economy, increased bio and cyber risk, and the implications of highly capable systems. Within that scope, the site reports on government action and civil society inputs neutrally, without editorial comment.
     </p>
 
     <div class="mt-8 flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary

- Remove the "AI Policy · Governance · Safety" eyebrow/subtitle text from the homepage
- Change "impacts — including widespread" → "impacts such as widespread" for slightly softer phrasing

## Test plan

- [ ] Visit homepage and confirm subtitle tag is gone
- [ ] Confirm the paragraph reads "impacts such as widespread"
