### PR TITLE
Add Sovereign Technology Alliance (Canada-Germany)

### DIFF
--- a/data/artifacts/2025-12-08-canada-germany-digital-alliance.yaml
+++ b/data/artifacts/2025-12-08-canada-germany-digital-alliance.yaml
@@ -1,0 +1,65 @@
+# artifacts/2025-12-08-canada-germany-digital-alliance.yaml
+
+id: canada-germany-digital-alliance-2025
+type: JointStatement
+schema_type: CreativeWork
+
+title: "Joint Statement Announcing the Canada-Germany Digital Alliance"
+published_date: 2025-12-08
+
+organizations:
+  - id: ised-canada
+    role: publisher
+
+description: >
+  Joint statement issued by Canada's Minister of Artificial Intelligence and
+  Digital Innovation, the Honourable Evan Solomon, and Germany's Minister for
+  Digital Transformation and Government Modernization, Karsten Wildberger,
+  following their meeting on the margins of the G7 Industry, Digital and
+  Technology Ministers' Meeting in Montréal, Quebec, on December 8, 2025.
+
+  The ministers reaffirmed the longstanding partnership between Canada and
+  Germany — including collaboration through multilateral fora such as the
+  Organisation for Economic Co-operation and Development (OECD), the Global
+  Partnership on Artificial Intelligence (GPAI), and the G7 — and agreed to
+  advance a Canada-Germany Digital Alliance, a joint partnership focused on
+  concrete collaboration in areas of mutual interest: artificial intelligence,
+  digital sovereignty, digital infrastructure, quantum, and cooperation on
+  startups and the digital economy.
+
+  Among the Alliance's first deliverables, both sides agreed to finalize a
+  Joint Declaration of Intent (JDoI) on AI in the coming months. Potential areas
+  of cooperation identified under the JDoI include: building and deploying
+  compute infrastructure; exchange on policy development and interoperability;
+  research and commercialization; AI adoption with a focus on physical and
+  industrial AI; AI safety; development and adoption of generative and frontier
+  AI; talent attraction and mobility; and business engagement and
+  entrepreneurship. Both sides agreed to assign key contacts to develop a
+  workplan under the Alliance.
+
+  The Digital Alliance is the foundation on which Canada and Germany subsequently
+  signed the Joint Declaration of Intent on AI and launched the Sovereign
+  Technology Alliance at the Munich Security Conference in February 2026.
+
+derives_from:
+  - id: canada-germany-digital-alliance-announced-2025
+    relationship: announced_at
+
+links:
+  - label: "ISED — Joint Statement (Solomon & Wildberger)"
+    url: https://www.canada.ca/en/innovation-science-economic-development/news/2025/12/joint-statement-by-canadas-minister-solomon-and-germanys-minister-wildberger-announcing-the-canada-germany-digital-alliance.html
+    icon: document
+
+tags:
+  - international-cooperation
+  - sovereign-technology
+  - sovereign-technology-alliance
+  - ai-safety
+  - generative-ai
+  - quantum-computing
+  - oecd
+  - gpai
+  - ised
+  - federal-government
+  - evan-solomon
+  - germany

--- a/data/artifacts/2026-02-14-canada-germany-ai-joint-declaration.yaml
+++ b/data/artifacts/2026-02-14-canada-germany-ai-joint-declaration.yaml
@@ -1,0 +1,67 @@
+# artifacts/2026-02-14-canada-germany-ai-joint-declaration.yaml
+
+id: canada-germany-ai-joint-declaration-2026
+type: JointStatement
+schema_type: CreativeWork
+
+title: "Canada-Germany Joint Declaration of Intent on Artificial Intelligence"
+published_date: 2026-02-14
+
+organizations:
+  - id: ised-canada
+    role: publisher
+
+description: >
+  Joint Declaration of Intent on Artificial Intelligence signed by Canada's
+  Minister of Artificial Intelligence and Digital Innovation, the Honourable
+  Evan Solomon, and Germany's Minister for Digital Transformation and Government
+  Modernization, Karsten Wildberger, on the margins of the Munich Security
+  Conference on February 14, 2026. Building on the Canada-Germany Digital
+  Alliance announced in December 2025, the declaration creates a practical
+  framework to expand bilateral cooperation on artificial intelligence,
+  reflecting both countries' commitment to advancing secure, resilient and
+  sovereign AI capabilities.
+
+  Cooperation under the declaration focuses on expanding secure compute
+  infrastructure, accelerating AI research and commercialization, and
+  strengthening talent development to address critical skills gaps — supporting
+  researchers, startups and industry in both countries to scale and compete
+  globally. The declaration identifies collaboration with research organizations
+  advancing safe-by-design AI systems — including Canada's LawZero, the nonprofit
+  founded by Turing Award winner Professor Yoshua Bengio and incubated within
+  the Quebec AI institute Mila — as a potential area for future cooperation.
+
+  Alongside the declaration, the ministers launched the Sovereign Technology
+  Alliance: a platform through which Canada and Germany will deepen coordination
+  with trusted partners to strengthen sovereign AI capacity and reduce strategic
+  technology dependencies, focused on delivering real capability and shared
+  economic benefit. Canada will also welcome Germany as Country of the Year at
+  the All In conference in Montréal in September 2026. The Sovereign Technology
+  Alliance is later cited in Canada's National AI Strategy and in the
+  Canada-Finland Joint Statement, which explores Finland's participation.
+
+derives_from:
+  - id: canada-germany-ai-joint-declaration-signed-2026
+    relationship: issued_at
+
+links:
+  - label: "ISED — News Release"
+    url: https://www.canada.ca/en/innovation-science-economic-development/news/2026/02/canada-and-germany-sign-ai-joint-declaration-and-launch-sovereign-technology-alliance.html
+    icon: document
+  - label: "Background: Canada-Germany Digital Alliance (Dec 2025)"
+    url: https://www.canada.ca/en/innovation-science-economic-development/news/2025/12/joint-statement-by-canadas-minister-solomon-and-germanys-minister-wildberger-announcing-the-canada-germany-digital-alliance.html
+    icon: document
+
+tags:
+  - international-cooperation
+  - sovereign-technology
+  - sovereign-technology-alliance
+  - sovereign-ai
+  - ai-safety
+  - generative-ai
+  - oecd
+  - gpai
+  - ised
+  - federal-government
+  - evan-solomon
+  - germany

--- a/data/artifacts/2026-02-14-canada-germany-ai-joint-declaration.yaml
+++ b/data/artifacts/2026-02-14-canada-germany-ai-joint-declaration.yaml
@@ -59,8 +59,6 @@ tags:
   - sovereign-ai
   - ai-safety
   - generative-ai
-  - oecd
-  - gpai
   - ised
   - federal-government
   - evan-solomon

--- a/data/events/2025-12-08-canada-germany-digital-alliance-announced.yaml
+++ b/data/events/2025-12-08-canada-germany-digital-alliance-announced.yaml
@@ -1,0 +1,48 @@
+# data/events/2025-12-08-canada-germany-digital-alliance-announced.yaml
+
+id: canada-germany-digital-alliance-announced-2025
+type: GovernmentAnnouncement
+schema_type: Event
+title: "Canada and Germany announce the Canada-Germany Digital Alliance"
+date: 2025-12-08
+
+location:
+  name: "Montréal, Quebec"
+
+organizations:
+  - id: ised-canada
+    role: participant
+
+description: >
+  On the margins of the G7 Industry, Digital and Technology Ministers' Meeting
+  in Montréal, the Honourable Evan Solomon, Minister of Artificial Intelligence
+  and Digital Innovation, and Karsten Wildberger, Germany's Minister for Digital
+  Transformation and Government Modernization, announce a joint statement
+  agreeing to advance a Canada-Germany Digital Alliance — a partnership focused
+  on concrete collaboration in AI, digital sovereignty, digital infrastructure,
+  quantum, and the startup and digital economy. The ministers agree that, among
+  the Alliance's first deliverables, both sides will finalize a Joint Declaration
+  of Intent on AI in the coming months, with potential cooperation spanning
+  compute infrastructure, research and commercialization, AI safety, frontier
+  AI, and talent mobility. This Alliance is the foundation on which the Sovereign
+  Technology Alliance is launched in February 2026.
+
+related_artifacts:
+  - id: canada-germany-digital-alliance-2025
+
+links:
+  - label: "ISED — Joint Statement (Solomon & Wildberger)"
+    url: https://www.canada.ca/en/innovation-science-economic-development/news/2025/12/joint-statement-by-canadas-minister-solomon-and-germanys-minister-wildberger-announcing-the-canada-germany-digital-alliance.html
+    icon: document
+
+tags:
+  - international-cooperation
+  - sovereign-technology
+  - sovereign-technology-alliance
+  - ai-safety
+  - oecd
+  - gpai
+  - ised
+  - federal-government
+  - evan-solomon
+  - germany

--- a/data/events/2026-02-14-canada-germany-ai-joint-declaration-signed.yaml
+++ b/data/events/2026-02-14-canada-germany-ai-joint-declaration-signed.yaml
@@ -1,0 +1,49 @@
+# data/events/2026-02-14-canada-germany-ai-joint-declaration-signed.yaml
+
+id: canada-germany-ai-joint-declaration-signed-2026
+type: GovernmentAnnouncement
+schema_type: Event
+title: "Canada and Germany sign AI Joint Declaration and launch the Sovereign Technology Alliance"
+date: 2026-02-14
+
+location:
+  name: "Munich, Germany"
+
+organizations:
+  - id: ised-canada
+    role: participant
+
+description: >
+  On the margins of the Munich Security Conference, the Honourable Evan Solomon,
+  Minister of Artificial Intelligence and Digital Innovation, and Karsten
+  Wildberger, Germany's Minister for Digital Transformation and Government
+  Modernization, sign the Joint Declaration of Intent on Artificial Intelligence
+  and announce the launch of the Sovereign Technology Alliance. Building on the
+  Canada-Germany Digital Alliance announced in December 2025, the declaration
+  creates a practical framework to expand bilateral AI cooperation on secure
+  compute infrastructure, AI research and commercialization, and talent
+  development. The Sovereign Technology Alliance is launched as a platform for
+  practical cooperation among trusted partners to strengthen sovereign AI
+  capacity and reduce strategic technology dependencies. The ministers also
+  identify collaboration with safe-by-design AI research organizations —
+  including Canada's LawZero, founded by Turing Award winner Yoshua Bengio — as
+  a potential area for future cooperation.
+
+related_artifacts:
+  - id: canada-germany-ai-joint-declaration-2026
+
+links:
+  - label: "ISED — News Release"
+    url: https://www.canada.ca/en/innovation-science-economic-development/news/2026/02/canada-and-germany-sign-ai-joint-declaration-and-launch-sovereign-technology-alliance.html
+    icon: document
+
+tags:
+  - international-cooperation
+  - sovereign-technology
+  - sovereign-technology-alliance
+  - sovereign-ai
+  - ai-safety
+  - ised
+  - federal-government
+  - evan-solomon
+  - germany


### PR DESCRIPTION
## Summary

Adds the **Sovereign Technology Alliance** (Canada–Germany) to the tracker, closing #78. Two milestones from the issue's source links are each modelled as an **event + `JointStatement` artifact**, following the existing Canada–Finland precedent:

- **Dec 8, 2025 — Canada–Germany Digital Alliance** announced at the G7 Industry, Digital and Technology Ministers' Meeting in Montréal (Solomon & Wildberger). Establishes the partnership and commits to a Joint Declaration of Intent on AI.
- **Feb 14, 2026 — Joint Declaration of Intent on AI + STA launch** at the Munich Security Conference. Launches the Sovereign Technology Alliance to strengthen sovereign AI capacity and reduce strategic technology dependencies; notes LawZero (Bengio) as a future-cooperation area.

### Modelling notes
- **STA stays a tag (`sovereign-technology-alliance`), not an organization** — consistent with the Finland precedent and avoiding a schema change, since the org `country` enum is `ca`/`uk` only and the STA is multinational.
- Org reference is `ised-canada` (Solomon is the ISED minister), as with Finland.
- Cross-refs wired both directions (`related_artifacts` ↔ `derives_from`).

### Already satisfied (no changes needed)
- *"Should reference it in the Canada-Finland agreement"* — the Canada–Finland artifact already links and describes the Feb 2026 STA release in prose. The new STA artifact also references the Finland statement.
- *"Also mentioned in the AI strategy"* — already present in the National AI Strategy artifact (a "Sovereign Technology Alliance of international partners").

## Files
- `data/events/2025-12-08-canada-germany-digital-alliance-announced.yaml`
- `data/artifacts/2025-12-08-canada-germany-digital-alliance.yaml`
- `data/events/2026-02-14-canada-germany-ai-joint-declaration-signed.yaml`
- `data/artifacts/2026-02-14-canada-germany-ai-joint-declaration.yaml`

Sources: [ISED — Feb 2026 STA launch](https://www.canada.ca/en/innovation-science-economic-development/news/2026/02/canada-and-germany-sign-ai-joint-declaration-and-launch-sovereign-technology-alliance.html) · [ISED — Dec 2025 Digital Alliance](https://www.canada.ca/en/innovation-science-economic-development/news/2025/12/joint-statement-by-canadas-minister-solomon-and-germanys-minister-wildberger-announcing-the-canada-germany-digital-alliance.html)

## Test plan
- [x] `npm run build` — Astro validates YAML against the content schema and that all `reference()` IDs resolve; 4 new pages built (2 events, 2 artifacts)
- [x] `npm test` — 75 unit tests pass
- [ ] CI `Test / unit` and `Test / e2e` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)