### PR TITLE
Surface related artifacts as a featured card on event pages

### DIFF
--- a/docs/superpowers/plans/2026-06-11-event-artifact-card.md
+++ b/docs/superpowers/plans/2026-06-11-event-artifact-card.md
@@ -1,0 +1,287 @@
+# Featured Artifact Card on Event Pages — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make associated artifacts obvious on event pages by replacing the buried "Related artifacts" list with a prominent gold-trimmed card directly after the event description ([#83](https://github.com/jrhender/ai-governance-tracker/issues/83)).
+
+**Architecture:** Astro static site. All page changes live in `src/pages/events/[id].astro`; a new `humanizeType` helper goes in `src/lib/format.ts`; two gold colour tokens go in the Tailwind v4 `@theme` block in `src/styles/global.css` (Tailwind v4 auto-generates `text-gold-dark`, `border-l-gold` etc. from `--color-*` tokens).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-event-artifact-card-design.md`
+
+**Tech Stack:** Astro 5, Tailwind CSS v4, Vitest (unit), Playwright (e2e).
+
+**Branch:** `feature/event-artifact-card` (already created; spec is committed on it).
+
+> **⚠️ E2E caveat:** `npx playwright test` always fails inside the Claude Code sandbox (macOS IPC restriction — see CLAUDE.local.md). Verify e2e specs by `npm run build` + code review locally; the authoritative e2e run happens in CI on the PR (`Test / e2e`). Do not burn time retrying Playwright in the sandbox.
+
+---
+
+### Task 1: `humanizeType` helper (TDD)
+
+**Files:**
+- Create: `src/lib/format.test.ts`
+- Modify: `src/lib/format.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/format.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { humanizeType } from "./format";
+
+describe("humanizeType", () => {
+  it("returns single-word types unchanged", () => {
+    expect(humanizeType("Report")).toBe("Report");
+  });
+
+  it("splits CamelCase into spaced words", () => {
+    expect(humanizeType("PolicyDocument")).toBe("Policy Document");
+    expect(humanizeType("WhitePaper")).toBe("White Paper");
+    expect(humanizeType("GovernmentProgram")).toBe("Government Program");
+  });
+
+  it("passes already-spaced input through unchanged", () => {
+    expect(humanizeType("White Paper")).toBe("White Paper");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/lib/format.test.ts`
+Expected: FAIL — `humanizeType` is not exported from `./format`.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `src/lib/format.ts`:
+
+```ts
+export function humanizeType(type: string): string {
+  return type.replace(/([a-z])([A-Z])/g, "$1 $2");
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/format.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full unit suite to check for regressions**
+
+Run: `npm test`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/format.ts src/lib/format.test.ts
+git commit -m "Add humanizeType helper to split CamelCase artifact types"
+```
+
+---
+
+### Task 2: Gold tokens + artifact card on the event page
+
+**Files:**
+- Modify: `src/styles/global.css` (the `@theme` block, after the `--color-faint` line)
+- Modify: `src/pages/events/[id].astro`
+
+- [ ] **Step 1: Add gold colour tokens**
+
+In `src/styles/global.css`, inside the `@theme` block, directly after the line `--color-faint:     #5a6e78;`, add:
+
+```css
+  /* Artifact card accent */
+  --color-gold:      #b08d2e;
+  --color-gold-dark: #7a5f1a;
+```
+
+- [ ] **Step 2: Import the helper in the event page**
+
+In `src/pages/events/[id].astro`, change the format import line from:
+
+```ts
+import { fmtDate } from "../../lib/format";
+```
+
+to:
+
+```ts
+import { fmtDate, humanizeType } from "../../lib/format";
+```
+
+- [ ] **Step 3: Add the artifact card after the description**
+
+In `src/pages/events/[id].astro`, directly after the description block:
+
+```astro
+  {data.description && (
+    <p class="mt-6 text-ink leading-relaxed">{data.description}</p>
+  )}
+```
+
+insert:
+
+```astro
+  {relatedArtifacts.length > 0 && (
+    <section class="mt-6 space-y-4" aria-label="Related artifacts">
+      {relatedArtifacts.map((a) =>
+        a ? (
+          <a
+            href={`/artifacts/${a.id}/`}
+            class="group block rounded-lg border border-border border-l-4 border-l-gold bg-surface p-4 shadow-[0_2px_8px_rgba(15,42,56,0.08)]"
+          >
+            <div class="text-[0.65rem] font-bold uppercase tracking-widest text-gold-dark">
+              {humanizeType(a.data.type)}
+            </div>
+            <div class="mt-1 font-semibold text-ink group-hover:underline">
+              {a.data.title}
+            </div>
+            {a.data.description && (
+              <p class="mt-1 text-sm text-muted line-clamp-3">
+                {a.data.description}
+              </p>
+            )}
+            <div class="mt-2 text-sm font-semibold text-gold-dark">
+              Read the artifact →
+            </div>
+          </a>
+        ) : null,
+      )}
+    </section>
+  )}
+```
+
+- [ ] **Step 4: Remove the old "Related artifacts" section**
+
+In the same file, delete the entire old section (currently lines 117–134) — the block starting with `{relatedArtifacts.length > 0 && (` that contains the `<h2 ...>Related artifacts</h2>` heading and the `<ul>` list. The tags section (`{data.tags.length > 0 && ...}`) stays.
+
+- [ ] **Step 5: Build to verify**
+
+Run: `npm run build`
+Expected: build succeeds with no errors. (This also type-checks the `.astro` template.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/styles/global.css src/pages/events/[id].astro
+git commit -m "Surface related artifacts as a featured card on event pages (#83)"
+```
+
+---
+
+### Task 3: E2E coverage
+
+**Files:**
+- Create: `e2e/event-artifact.spec.ts`
+
+- [ ] **Step 1: Write the e2e spec**
+
+Create `e2e/event-artifact.spec.ts`:
+
+```ts
+import { test, expect } from "@playwright/test";
+
+const EVENT_WITH_ARTIFACT = "/events/cigi-pco-report-published-2026/";
+const EVENT_WITHOUT_ARTIFACT =
+  "/events/indu-ai-strategic-industries-meeting-27-2026/";
+const ARTIFACT_PATH = "/artifacts/cigi-pco-ai-national-security-report-2026/";
+
+test.describe("event artifact card", () => {
+  test("artifact card renders before the Organizations section", async ({
+    page,
+  }) => {
+    await page.goto(EVENT_WITH_ARTIFACT);
+
+    const card = page.getByRole("link", { name: /Read the artifact/i });
+    await expect(card).toBeVisible();
+
+    const order = await page.evaluate(() => {
+      const section = document.querySelector(
+        'section[aria-label="Related artifacts"]',
+      );
+      const orgsHeading = [...document.querySelectorAll("h2")].find((h) =>
+        h.textContent?.includes("Organizations"),
+      );
+      if (!section || !orgsHeading) return "missing";
+      return section.compareDocumentPosition(orgsHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+        ? "card-first"
+        : "orgs-first";
+    });
+    expect(order).toBe("card-first");
+  });
+
+  test("card links to the artifact page", async ({ page }) => {
+    await page.goto(EVENT_WITH_ARTIFACT);
+
+    await page.getByRole("link", { name: /Read the artifact/i }).click();
+
+    await expect(page).toHaveURL(new RegExp(`${ARTIFACT_PATH}$`));
+    await expect(
+      page.getByRole("heading", {
+        name: /AI and National Security: Scenarios Workshop Summary Report/i,
+      }),
+    ).toBeVisible();
+  });
+
+  test("event without artifacts shows no card", async ({ page }) => {
+    await page.goto(EVENT_WITHOUT_ARTIFACT);
+
+    await expect(
+      page.getByRole("link", { name: /Read the artifact/i }),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('section[aria-label="Related artifacts"]'),
+    ).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Verify the spec compiles and the unit suite still passes**
+
+Run: `npm test`
+Expected: all unit tests pass (Vitest excludes `e2e/`, so this confirms no accidental import breakage elsewhere).
+
+Do **not** run `npx playwright test` in the sandbox — it cannot work (see caveat at top). E2E runs in CI on the PR.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/event-artifact.spec.ts
+git commit -m "Add e2e coverage for the event-page artifact card"
+```
+
+---
+
+### Task 4: Push and open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feature/event-artifact-card
+```
+
+- [ ] **Step 2: Open the PR via GitHub API**
+
+Use `curl` with `$GITHUB_TOKEN` (NOT the `gh` CLI — it cannot work in this sandbox, see CLAUDE.local.md). Repo slug is `jrhender/ai-governance-tracker`:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/jrhender/ai-governance-tracker/pulls \
+  -d @- <<'EOF'
+{
+  "title": "Surface related artifacts as a featured card on event pages",
+  "head": "feature/event-artifact-card",
+  "base": "main",
+  "body": "Closes #83.\n\n## Summary\n- Replace the buried \"Related artifacts\" list on event pages with a prominent white card (gold left bar + gold accents) rendered directly after the event description\n- Whole card links to the artifact page; shows humanized type label, title, and a 3-line description clamp\n- Add `humanizeType` helper to `src/lib/format.ts` and gold colour tokens to the theme\n\nSpec: `docs/superpowers/specs/2026-06-11-event-artifact-card-design.md`\nPlan: `docs/superpowers/plans/2026-06-11-event-artifact-card.md`\n\n## Test plan\n- [ ] `npm test` — unit tests pass (incl. new `humanizeType` tests)\n- [ ] CI `Test / e2e` — new `e2e/event-artifact.spec.ts` passes\n- [ ] Manual: event with artifact shows card above Organizations; event without artifact unchanged\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+}
+EOF
+```
+
+- [ ] **Step 3: Confirm CI passes**
+
+Check the PR's check runs via the API; both `Test / unit` and `Test / e2e` must be green before merge.

--- a/docs/superpowers/specs/2026-06-11-event-artifact-card-design.md
+++ b/docs/superpowers/specs/2026-06-11-event-artifact-card-design.md
@@ -1,0 +1,77 @@
+# Featured artifact card on event pages
+
+**Date:** 2026-06-11
+**Issue:** [#83 — Make the artifact more obvious from event](https://github.com/jrhender/ai-governance-tracker/issues/83)
+
+## Problem
+
+On event pages, the associated artifact (report, policy document, etc.) is rendered
+as a plain "Related artifacts" link list — the third section down the page, after
+Organizations and Links. Visitors have to scroll to discover that an event produced
+an artifact at all. For publication-type events the artifact is usually the main
+payload of the page, so it should be prominent near the top.
+
+## Design
+
+All page changes are in `src/pages/events/[id].astro`.
+
+### Featured artifact card
+
+- Rendered directly **after the event description** and **before the Organizations
+  section**. One card per entry in `related_artifacts`, stacked vertically with a
+  small gap when there are several.
+- The existing "Related artifacts" list section at the bottom of the page is
+  **removed** — the card replaces it.
+- Events with no related artifacts render exactly as today (no card, no empty
+  section).
+
+### Card appearance ("gold trim" treatment)
+
+White surface card lifted off the grey page background:
+
+- Background `--color-surface` (white), 1px border `--color-border`, rounded
+  corners, subtle shadow (`0 2px 8px rgba(15,42,56,0.08)`).
+- 4px **antique-gold left border** — the warm accent against the site's teal/grey
+  palette.
+- Contents, top to bottom:
+  1. Uppercase letter-spaced type label in dark gold (artifact `type`, humanized:
+     `PolicyDocument` → "Policy Document").
+  2. Artifact title, bold, `--color-ink`.
+  3. Artifact description, `--color-muted`, clamped to 3 lines (`line-clamp-3`).
+     Omitted when the artifact has no description.
+  4. "Read the artifact →" link line, dark gold, semibold.
+- The **whole card is a single `<a>`** to `/artifacts/{id}/` — large tap target;
+  the arrow line makes the affordance explicit. Hover state: underline on the
+  title.
+
+### Colour tokens
+
+Add to the `@theme` block in `src/styles/global.css` so the gold is reusable:
+
+```css
+--color-gold:      #b08d2e;  /* left border */
+--color-gold-dark: #7a5f1a;  /* type label + link text (4.5:1+ on white) */
+```
+
+### Type label helper
+
+Add `humanizeType(type: string): string` to `src/lib/format.ts` — splits
+CamelCase enum values into spaced words ("WhitePaper" → "White Paper"). Used for
+the card's type label.
+
+## Testing
+
+- **Unit:** `humanizeType` cases — single word ("Report"), multi-word
+  ("PolicyDocument", "WhitePaper"), already-spaced input passthrough.
+- **E2E (Playwright):** on an event page with a related artifact (e.g.
+  `cigi-pco-report-published-2026`):
+  - the artifact card appears before the Organizations section in DOM order;
+  - the card links to the corresponding `/artifacts/{id}/` page;
+  - an event without related artifacts shows no card.
+
+## Out of scope
+
+- Artifact pages (no changes to `/artifacts/[id].astro`).
+- Timeline/list views.
+- Surfacing artifact metadata beyond type/title/description (stages,
+  recommendations, etc.).

--- a/e2e/event-artifact.spec.ts
+++ b/e2e/event-artifact.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+const EVENT_WITH_ARTIFACT = "/events/cigi-pco-report-published-2026/";
+const EVENT_WITHOUT_ARTIFACT =
+  "/events/indu-ai-strategic-industries-meeting-27-2026/";
+const ARTIFACT_PATH = "/artifacts/cigi-pco-ai-national-security-report-2026/";
+
+test.describe("event artifact card", () => {
+  test("artifact card renders before the Organizations section", async ({
+    page,
+  }) => {
+    await page.goto(EVENT_WITH_ARTIFACT);
+
+    const card = page.getByRole("link", { name: /Read the artifact/i });
+    await expect(card).toBeVisible();
+
+    const order = await page.evaluate(() => {
+      const section = document.querySelector(
+        'section[aria-label="Related artifacts"]',
+      );
+      const orgsHeading = [...document.querySelectorAll("h2")].find((h) =>
+        h.textContent?.includes("Organizations"),
+      );
+      if (!section || !orgsHeading) return "missing";
+      return section.compareDocumentPosition(orgsHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+        ? "card-first"
+        : "orgs-first";
+    });
+    expect(order).toBe("card-first");
+  });
+
+  test("card links to the artifact page", async ({ page }) => {
+    await page.goto(EVENT_WITH_ARTIFACT);
+
+    await page.getByRole("link", { name: /Read the artifact/i }).click();
+
+    await expect(page).toHaveURL(new RegExp(`${ARTIFACT_PATH}$`));
+    await expect(
+      page.getByRole("heading", {
+        name: /AI and National Security: Scenarios Workshop Summary Report/i,
+      }),
+    ).toBeVisible();
+  });
+
+  test("event without artifacts shows no card", async ({ page }) => {
+    await page.goto(EVENT_WITHOUT_ARTIFACT);
+
+    await expect(
+      page.getByRole("link", { name: /Read the artifact/i }),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('section[aria-label="Related artifacts"]'),
+    ).toHaveCount(0);
+  });
+});

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { humanizeType } from "./format";
+import { humanizeType, leadText } from "./format";
 
 describe("humanizeType", () => {
   it("returns single-word types unchanged", () => {
@@ -14,5 +14,24 @@ describe("humanizeType", () => {
 
   it("passes already-spaced input through unchanged", () => {
     expect(humanizeType("White Paper")).toBe("White Paper");
+  });
+});
+
+describe("leadText", () => {
+  it("returns a single plain paragraph unchanged", () => {
+    expect(leadText("A short folded description.")).toBe(
+      "A short folded description.",
+    );
+  });
+
+  it("returns only the first paragraph of multi-paragraph Markdown", () => {
+    const md = "Lead paragraph here.\n\n- bullet one\n- bullet two";
+    expect(leadText(md)).toBe("Lead paragraph here.");
+  });
+
+  it("strips bold markers from the lead paragraph", () => {
+    expect(leadText("Focused on **building public trust** in AI.")).toBe(
+      "Focused on building public trust in AI.",
+    );
   });
 });

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { humanizeType } from "./format";
+
+describe("humanizeType", () => {
+  it("returns single-word types unchanged", () => {
+    expect(humanizeType("Report")).toBe("Report");
+  });
+
+  it("splits CamelCase into spaced words", () => {
+    expect(humanizeType("PolicyDocument")).toBe("Policy Document");
+    expect(humanizeType("WhitePaper")).toBe("White Paper");
+    expect(humanizeType("GovernmentProgram")).toBe("Government Program");
+  });
+
+  it("passes already-spaced input through unchanged", () => {
+    expect(humanizeType("White Paper")).toBe("White Paper");
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -11,3 +11,9 @@ export function fmtDate(date: Date | string): string {
 export function humanizeType(type: string): string {
   return type.replace(/([a-z])([A-Z])/g, "$1 $2");
 }
+
+// Plain-text lead for summaries: the first paragraph, with inline Markdown
+// stripped. Folded descriptions without a blank-line break are left whole.
+export function leadText(markdown: string): string {
+  return markdown.split(/\n\s*\n/)[0].replace(/\*\*/g, "");
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -7,3 +7,7 @@ export function fmtDate(date: Date | string): string {
     timeZone: "UTC",
   });
 }
+
+export function humanizeType(type: string): string {
+  return type.replace(/([a-z])([A-Z])/g, "$1 $2");
+}

--- a/src/pages/artifacts/[id].astro
+++ b/src/pages/artifacts/[id].astro
@@ -2,7 +2,7 @@
 import { getCollection, getEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { marked } from "marked";
-import { fmtDate } from "../../lib/format";
+import { fmtDate, leadText } from "../../lib/format";
 import { buildCreativeWorkJsonLd, type OrgRef } from "../../lib/jsonld";
 
 export async function getStaticPaths() {
@@ -60,11 +60,9 @@ const descriptionHtml = data.description
   ? await marked.parse(data.description)
   : "";
 
-// Plain-text lead for <meta> and JSON-LD: the first paragraph, with inline
-// Markdown stripped. Folded descriptions without a blank-line break are left
-// whole (unchanged behaviour); Markdown descriptions use just the lead para.
+// Plain-text lead for <meta> and JSON-LD.
 const metaDescription = data.description
-  ? data.description.split(/\n\s*\n/)[0].replace(/\*\*/g, "")
+  ? leadText(data.description)
   : undefined;
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection, getEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import { fmtDate } from "../../lib/format";
+import { fmtDate, humanizeType } from "../../lib/format";
 import { buildEventJsonLd, type OrgRef } from "../../lib/jsonld";
 
 export async function getStaticPaths() {
@@ -72,6 +72,34 @@ const jsonLd = buildEventJsonLd({
     <p class="mt-6 text-ink leading-relaxed">{data.description}</p>
   )}
 
+  {relatedArtifacts.length > 0 && (
+    <section class="mt-6 space-y-4" aria-label="Related artifacts">
+      {relatedArtifacts.map((a) =>
+        a ? (
+          <a
+            href={`/artifacts/${a.id}/`}
+            class="group block rounded-lg border border-border border-l-4 border-l-gold bg-surface p-4 shadow-[0_2px_8px_rgba(15,42,56,0.08)]"
+          >
+            <div class="text-[0.65rem] font-bold uppercase tracking-widest text-gold-dark">
+              {humanizeType(a.data.type)}
+            </div>
+            <div class="mt-1 font-semibold text-ink group-hover:underline">
+              {a.data.title}
+            </div>
+            {a.data.description && (
+              <p class="mt-1 text-sm text-muted line-clamp-3">
+                {a.data.description}
+              </p>
+            )}
+            <div class="mt-2 text-sm font-semibold text-gold-dark">
+              Read the artifact →
+            </div>
+          </a>
+        ) : null,
+      )}
+    </section>
+  )}
+
   {orgs.length > 0 && (
     <section class="mt-8">
       <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
@@ -110,25 +138,6 @@ const jsonLd = buildEventJsonLd({
             </a>
           </li>
         ))}
-      </ul>
-    </section>
-  )}
-
-  {relatedArtifacts.length > 0 && (
-    <section class="mt-8">
-      <h2 class="text-xs font-semibold uppercase tracking-wide text-faint mb-2">
-        Related artifacts
-      </h2>
-      <ul class="space-y-1">
-        {relatedArtifacts.map((a) =>
-          a ? (
-            <li>
-              <a href={`/artifacts/${a.id}/`} class="text-ink hover:text-accent-dark hover:underline">
-                {a.data.title}
-              </a>
-            </li>
-          ) : null,
-        )}
       </ul>
     </section>
   )}

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection, getEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import { fmtDate, humanizeType } from "../../lib/format";
+import { fmtDate, humanizeType, leadText } from "../../lib/format";
 import { buildEventJsonLd, type OrgRef } from "../../lib/jsonld";
 
 export async function getStaticPaths() {
@@ -88,7 +88,7 @@ const jsonLd = buildEventJsonLd({
             </div>
             {a.data.description && (
               <p class="mt-1 text-sm text-muted line-clamp-3">
-                {a.data.description}
+                {leadText(a.data.description)}
               </p>
             )}
             <div class="mt-2 text-sm font-semibold text-gold-dark">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,6 +20,10 @@
   --color-muted:     #4a5f6e;
   --color-faint:     #5a6e78;
 
+  /* Artifact card accent */
+  --color-gold:      #b08d2e;
+  --color-gold-dark: #7a5f1a;
+
   /* Source category colours */
   --color-gov-border:       #2d5060;
   --color-gov-bg:           #f2f6f8;


### PR DESCRIPTION
Relates to #83 (left open intentionally).

## Summary
- Replace the buried "Related artifacts" list on event pages with a prominent white card (gold left bar + gold accents) rendered directly after the event description
- Whole card links to the artifact page; shows humanized type label, title, and a 3-line description clamp (lead paragraph only, Markdown stripped)
- Add `humanizeType` and `leadText` helpers to `src/lib/format.ts` and gold colour tokens to the theme

Spec: `docs/superpowers/specs/2026-06-11-event-artifact-card-design.md`
Plan: `docs/superpowers/plans/2026-06-11-event-artifact-card.md`

## Test plan
- [x] `npm test` — unit tests pass (incl. new `humanizeType` and `leadText` tests)
- [x] CI `Test / e2e` — new `e2e/event-artifact.spec.ts` passes
- [x] Manual: event with artifact shows card above Organizations; event without artifact unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)