### PR TITLE
Trim event descriptions that duplicate associated artifact content

### DIFF
--- a/data/events/2023-10-18-aigs-governing-ai-2023-published.yaml
+++ b/data/events/2023-10-18-aigs-governing-ai-2023-published.yaml
@@ -12,8 +12,7 @@ organizations:
 
 description: >
   AI Governance and Safety Canada (AIGS) publishes its inaugural white paper
-  outlining five high-impact actions for the Canadian government to advance
-  AI governance by end of Q2 2024.
+  on AI governance in Canada.
 
 related_artifacts:
   - id: aigs-governing-ai-2023

--- a/data/events/2024-06-26-aigs-governing-ai-2024-published.yaml
+++ b/data/events/2024-06-26-aigs-governing-ai-2024-published.yaml
@@ -12,8 +12,7 @@ organizations:
 
 description: >
   AI Governance and Safety Canada (AIGS) publishes the 2024 update to its
-  annual white paper, outlining five high-impact actions for the Canadian
-  government to advance AI governance by end of Q2 2025.
+  annual white paper on AI governance in Canada.
 
 related_artifacts:
   - id: aigs-governing-ai-2024

--- a/data/events/2025-10-21-aigs-preparing-for-ai-crisis-2025-published.yaml
+++ b/data/events/2025-10-21-aigs-preparing-for-ai-crisis-2025-published.yaml
@@ -11,11 +11,8 @@ organizations:
     role: publisher
 
 description: >
-  AI Governance and Safety Canada (AIGS) publishes its 2025 white paper,
-  warning that leading AI labs may develop smarter-than-human AI within
-  18 months and urging urgent federal action. Canada's G7 position and stable
-  society make it well placed to lead global talks while building resilience
-  at home.
+  AI Governance and Safety Canada (AIGS) publishes its 2025 white paper
+  on preparing Canada for the AI crisis.
 
 related_artifacts:
   - id: aigs-preparing-for-ai-crisis-2025

--- a/data/events/2025-12-08-canada-germany-digital-alliance-announced.yaml
+++ b/data/events/2025-12-08-canada-germany-digital-alliance-announced.yaml
@@ -15,17 +15,8 @@ organizations:
 
 description: >
   On the margins of the G7 Industry, Digital and Technology Ministers' Meeting
-  in Montréal, the Honourable Evan Solomon, Minister of Artificial Intelligence
-  and Digital Innovation, and Karsten Wildberger, Germany's Minister for Digital
-  Transformation and Government Modernization, announce a joint statement
-  agreeing to advance a Canada-Germany Digital Alliance — a partnership focused
-  on concrete collaboration in AI, digital sovereignty, digital infrastructure,
-  quantum, and the startup and digital economy. The ministers agree that, among
-  the Alliance's first deliverables, both sides will finalize a Joint Declaration
-  of Intent on AI in the coming months, with potential cooperation spanning
-  compute infrastructure, research and commercialization, AI safety, frontier
-  AI, and talent mobility. This Alliance is the foundation on which the Sovereign
-  Technology Alliance is launched in February 2026.
+  in Montréal, Minister Evan Solomon and Germany's Minister Karsten Wildberger
+  announce the Canada-Germany Digital Alliance.
 
 related_artifacts:
   - id: canada-germany-digital-alliance-2025

--- a/data/events/2026-02-01-international-ai-safety-report-2026-published.yaml
+++ b/data/events/2026-02-01-international-ai-safety-report-2026-published.yaml
@@ -13,11 +13,7 @@ organizations:
 description: >
   The UK Department for Science, Innovation and Technology publishes the
   International AI Safety Report 2026, led by Yoshua Bengio and produced by
-  over 100 independent experts from more than 30 countries. The report provides
-  a comprehensive evidence-based assessment of AI safety risks across misuse,
-  structural, and societal domains, along with risk management practices and
-  resilience-building measures. Policy recommendations are explicitly outside
-  its scope.
+  over 100 independent experts from more than 30 countries.
 
 related_artifacts:
   - id: international-ai-safety-report-2026

--- a/data/events/2026-02-05-ai-strategy-summary-of-inputs-published.yaml
+++ b/data/events/2026-02-05-ai-strategy-summary-of-inputs-published.yaml
@@ -14,9 +14,8 @@ organizations:
 
 description: >
   ISED publishes "Engagements on Canada's next AI Strategy: Summary of
-  inputs," synthesizing over 11,300 public responses, 28 AI Strategy Task
-  Force reports, and nearly 300 policy submissions gathered during the
-  October 2025 30-day national sprint.
+  inputs," the report synthesizing feedback from the October 2025 30-day
+  national AI Sprint.
 
 related_artifacts:
   - id: ai-strategy-summary-of-inputs-2026

--- a/data/events/2026-02-14-canada-germany-ai-joint-declaration-signed.yaml
+++ b/data/events/2026-02-14-canada-germany-ai-joint-declaration-signed.yaml
@@ -14,20 +14,10 @@ organizations:
     role: participant
 
 description: >
-  On the margins of the Munich Security Conference, the Honourable Evan Solomon,
-  Minister of Artificial Intelligence and Digital Innovation, and Karsten
-  Wildberger, Germany's Minister for Digital Transformation and Government
-  Modernization, sign the Joint Declaration of Intent on Artificial Intelligence
-  and announce the launch of the Sovereign Technology Alliance. Building on the
-  Canada-Germany Digital Alliance announced in December 2025, the declaration
-  creates a practical framework to expand bilateral AI cooperation on secure
-  compute infrastructure, AI research and commercialization, and talent
-  development. The Sovereign Technology Alliance is launched as a platform for
-  practical cooperation among trusted partners to strengthen sovereign AI
-  capacity and reduce strategic technology dependencies. The ministers also
-  identify collaboration with safe-by-design AI research organizations —
-  including Canada's LawZero, founded by Turing Award winner Yoshua Bengio — as
-  a potential area for future cooperation.
+  On the margins of the Munich Security Conference, Minister Evan Solomon and
+  Germany's Minister Karsten Wildberger sign the Joint Declaration of Intent
+  on Artificial Intelligence and announce the launch of the Sovereign
+  Technology Alliance.
 
 related_artifacts:
   - id: canada-germany-ai-joint-declaration-2026

--- a/data/events/2026-04-14-canada-finland-joint-statement-signed.yaml
+++ b/data/events/2026-04-14-canada-finland-joint-statement-signed.yaml
@@ -12,14 +12,7 @@ organizations:
 
 description: >
   Prime Minister Mark Carney and President of Finland Alexander Stubb sign
-  a joint statement in Ottawa setting out expanded bilateral cooperation on
-  sovereign technology, artificial intelligence, quantum computing, Arctic
-  and maritime issues, and defence. The statement commits both countries to
-  deepen AI collaboration, including exploring frontier AI models with
-  safety and responsibility as foundational design principles, and exploring
-  Finland's participation in the Sovereign Technology Alliance (launched with
-  Germany in February 2026). OECD and GPAI are cited as existing multilateral
-  channels through which the two countries already cooperate on AI.
+  a joint statement in Ottawa on sovereign technology and AI cooperation.
 
 related_artifacts:
   - id: canada-finland-joint-statement-2026

--- a/data/events/2026-06-04-canada-national-ai-strategy-launched.yaml
+++ b/data/events/2026-06-04-canada-national-ai-strategy-launched.yaml
@@ -19,14 +19,7 @@ organizations:
 description: >
   In Toronto, Prime Minister Mark Carney launches "AI for All," Canada's
   renewed national artificial intelligence strategy, alongside Evan Solomon,
-  Minister of Artificial Intelligence and Digital Innovation. Anchored in
-  three priorities — building public trust, creating opportunities, and
-  reinforcing Canadian sovereignty — the strategy commits roughly $2 billion
-  in new federal investment over five years, including a national public AI
-  supercomputer, an expanded Canadian AI Safety Institute, a National AI
-  Literacy Initiative, and an AI Missions Program led by a health mission. The
-  strategy is the culmination of the 2025 AI Sprint and AI Strategy Task Force
-  engagement and the February 2026 summary of inputs.
+  Minister of Artificial Intelligence and Digital Innovation.
 
 related_artifacts:
   - id: canada-national-ai-strategy-ai-for-all


### PR DESCRIPTION
## Summary

- After #85 (artifact cards surfaced on event pages), event descriptions no longer need to summarize what the artifact contains
- Trimmed 6 event descriptions to just describe the publication/announcement (who published what, where, when)
- Artifact details — findings, scope, recommendations — remain in the artifact records where they belong

## Test plan

- [ ] Visit an event page with a linked artifact (e.g. AIGS 2025, AI for All launch) and confirm the artifact card appears
- [ ] Confirm event description no longer repeats artifact content
- [ ] Check timeline view looks clean with the shorter descriptions