### PR TITLE
Backfill INDU AI study meetings 36, 38, 40, and 41

### DIFF
--- a/data/events/2026-04-30-indu-ai-strategic-industries-meeting-36.yaml
+++ b/data/events/2026-04-30-indu-ai-strategic-industries-meeting-36.yaml
@@ -1,0 +1,88 @@
+# events/2026-04-30-indu-ai-strategic-industries-meeting-36.yaml
+
+id: indu-ai-strategic-industries-meeting-36-2026
+type: CommitteeHearing
+schema_type: Event
+
+title: "INDU Meeting 36 — Opportunities, Risks, and Regulation of AI in Canada's Strategic Industries"
+date: 2026-04-30
+location:
+  name: "Room 425, Wellington Building, 197 Sparks Street, Ottawa, Ontario, Canada"
+  schema_type: Place
+
+status: completed
+
+description: >
+  Meeting 36 of the Standing Committee on Industry and Technology (INDU) as part
+  of its study on "Opportunities, Risks, and Regulation of AI in Canada's Strategic
+  Industries." The public AI portion ran from 11:01 a.m. to about 1:06 p.m. EDT and
+  was webcast; the committee then moved in camera to give drafting instructions for
+  its report on U.S. tariffs. Witnesses included CIGI founder Jim Balsillie, labour
+  representatives appearing for the Canadian Telecommunications Workers Alliance,
+  and leaders from Quantum Industry Canada and Qu Data Centres.
+
+organizations:
+  - id: house-of-commons-indu-committee
+    role: host
+
+witnesses:
+  - name: "Barry C. Sanders"
+    title: "Professor"
+    capacity: As an individual
+  - name: "Nathalie Blais"
+    title: "Research Representative, Canadian Union of Public Employees"
+    organization: "Canadian Telecommunications Workers Alliance"
+  - name: "Roch Leblanc"
+    title: "Telecommunications Director, Unifor"
+    organization: "Canadian Telecommunications Workers Alliance"
+  - name: "Corey Mandryk"
+    title: "Lead Organizer, United Steelworkers National Local 1944"
+    organization: "Canadian Telecommunications Workers Alliance"
+  - name: "James Beer"
+    title: "Chief Executive Officer"
+    organization: "Qu Data Centres Ltd."
+  - name: "Fenwick McKelvey"
+    title: "Associate Professor, Information and Communication Technology Policy"
+    organization: "Concordia University"
+    appearance_mode: by videoconference
+    capacity: As an individual
+  - name: "Jim Balsillie"
+    title: "Founder and Chair"
+    organization: "Centre for International Governance Innovation"
+  - name: "Lisa Lambert"
+    title: "Chief Executive Officer"
+    organization: "Quantum Industry Canada"
+    appearance_mode: by videoconference
+
+tags:
+  - ai-regulation
+  - artificial-intelligence
+  - strategic-industries
+  - federal-government
+  - house-of-commons
+  - standing-committee
+  - indu
+  - canadian
+  - labour
+  - telecommunications
+  - quantum
+  - data-centres
+  - cigi
+  - jim-balsillie
+
+links:
+  - label: "Notice of Meeting"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-36/notice
+    icon: document
+  - label: "Evidence (Transcript)"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-36/evidence
+    icon: document
+  - label: "Minutes"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-36/minutes
+    icon: document
+  - label: "Watch Recording"
+    url: https://www.ourcommons.ca/embed/en/m/13454753?ml=en&vt=watch&autoplay=true
+    icon: video
+  - label: "Committee Study Page"
+    url: https://www.ourcommons.ca/committees/en/INDU/StudyActivity?studyActivityId=13310104
+    icon: document

--- a/data/events/2026-05-07-indu-ai-strategic-industries-meeting-38.yaml
+++ b/data/events/2026-05-07-indu-ai-strategic-industries-meeting-38.yaml
@@ -18,8 +18,8 @@ description: >
   Industries." The session ran from 11:01 a.m. to 1:02 p.m. EDT and was webcast.
   Witnesses represented the Centre for Designing Change, INQ Law, Oracle, the
   Council of Canadian Innovators, Hypertec Group, and Photonic, covering AI
-  adoption, legal and regulatory questions, compute infrastructure, and quantum
-  technology.
+  adoption, legal and regulatory questions, compute and data-centre
+  infrastructure, and quantum technology.
 
 organizations:
   - id: house-of-commons-indu-committee

--- a/data/events/2026-05-07-indu-ai-strategic-industries-meeting-38.yaml
+++ b/data/events/2026-05-07-indu-ai-strategic-industries-meeting-38.yaml
@@ -1,0 +1,84 @@
+# events/2026-05-07-indu-ai-strategic-industries-meeting-38.yaml
+
+id: indu-ai-strategic-industries-meeting-38-2026
+type: CommitteeHearing
+schema_type: Event
+
+title: "INDU Meeting 38 — Opportunities, Risks, and Regulation of AI in Canada's Strategic Industries"
+date: 2026-05-07
+location:
+  name: "Room 425, Wellington Building, 197 Sparks Street, Ottawa, Ontario, Canada"
+  schema_type: Place
+
+status: completed
+
+description: >
+  Meeting 38 of the Standing Committee on Industry and Technology (INDU) as part
+  of its study on "Opportunities, Risks, and Regulation of AI in Canada's Strategic
+  Industries." The session ran from 11:01 a.m. to 1:02 p.m. EDT and was webcast.
+  Witnesses represented the Centre for Designing Change, INQ Law, Oracle, the
+  Council of Canadian Innovators, Hypertec Group, and Photonic, covering AI
+  adoption, legal and regulatory questions, compute infrastructure, and quantum
+  technology.
+
+organizations:
+  - id: house-of-commons-indu-committee
+    role: host
+
+witnesses:
+  - name: "Kulbir Colin Singh Dhillon"
+    title: "Executive Director"
+    organization: "Centre for Designing Change"
+  - name: "Carole Piovesan"
+    title: "Managing Partner"
+    organization: "INQ Law"
+    appearance_mode: by videoconference
+  - name: "Hamza Jahangir"
+    title: "Vice-President, AI Solution Engineering"
+    organization: "Oracle"
+    appearance_mode: by videoconference
+  - name: "Laurent Carbonneau"
+    title: "Vice-President, Policy and Advocacy"
+    organization: "Council of Canadian Innovators"
+  - name: "Daniel Perry"
+    title: "Director, Federal Affairs"
+    organization: "Council of Canadian Innovators"
+  - name: "Simon Ahdoot"
+    title: "Chief Executive Officer"
+    organization: "Hypertec Group Inc."
+  - name: "Stephanie Simmons"
+    title: "Chief Quantum Officer"
+    organization: "Photonic Inc"
+    appearance_mode: by videoconference
+
+tags:
+  - ai-regulation
+  - artificial-intelligence
+  - strategic-industries
+  - federal-government
+  - house-of-commons
+  - standing-committee
+  - indu
+  - canadian
+  - council-of-canadian-innovators
+  - oracle
+  - quantum
+  - data-centres
+  - ai-law
+
+links:
+  - label: "Notice of Meeting"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-38/notice
+    icon: document
+  - label: "Evidence (Transcript)"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-38/evidence
+    icon: document
+  - label: "Minutes"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-38/minutes
+    icon: document
+  - label: "Watch Recording"
+    url: https://www.ourcommons.ca/embed/en/m/13475150?ml=en&vt=watch&autoplay=true
+    icon: video
+  - label: "Committee Study Page"
+    url: https://www.ourcommons.ca/committees/en/INDU/StudyActivity?studyActivityId=13310104
+    icon: document

--- a/data/events/2026-05-28-indu-ai-strategic-industries-meeting-40.yaml
+++ b/data/events/2026-05-28-indu-ai-strategic-industries-meeting-40.yaml
@@ -1,0 +1,67 @@
+# events/2026-05-28-indu-ai-strategic-industries-meeting-40.yaml
+
+id: indu-ai-strategic-industries-meeting-40-2026
+type: CommitteeHearing
+schema_type: Event
+
+title: "INDU Meeting 40 — Opportunities, Risks, and Regulation of AI in Canada's Strategic Industries"
+date: 2026-05-28
+location:
+  name: "Room 425, Wellington Building, 197 Sparks Street, Ottawa, Ontario, Canada"
+  schema_type: Place
+
+status: completed
+
+description: >
+  Meeting 40 of the Standing Committee on Industry and Technology (INDU) as part
+  of its study on "Opportunities, Risks, and Regulation of AI in Canada's Strategic
+  Industries." The public AI portion ran from 11:00 a.m. to 12:07 p.m. EDT and was
+  webcast; the committee then moved in camera to consider its draft report on U.S.
+  tariffs. Witnesses covered AI economic policy, copyright and music licensing,
+  and government data analytics.
+
+organizations:
+  - id: house-of-commons-indu-committee
+    role: host
+
+witnesses:
+  - name: "Sean Mullin"
+    title: "Senior Fellow, Munk School of Global Affairs & Public Policy"
+    organization: "University of Toronto"
+    capacity: As an individual
+  - name: "Jennifer Brown"
+    title: "Chief Executive Officer"
+    organization: "Society of Composers, Authors and Music Publishers of Canada"
+  - name: "Michael Lee"
+    title: "Chief Strategy Officer"
+    organization: "UrbanLogiq"
+
+tags:
+  - ai-regulation
+  - artificial-intelligence
+  - strategic-industries
+  - federal-government
+  - house-of-commons
+  - standing-committee
+  - indu
+  - canadian
+  - copyright
+  - music-industry
+  - data-analytics
+
+links:
+  - label: "Notice of Meeting"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-40/notice
+    icon: document
+  - label: "Evidence (Transcript)"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-40/evidence
+    icon: document
+  - label: "Minutes"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-40/minutes
+    icon: document
+  - label: "Watch Recording"
+    url: https://www.ourcommons.ca/embed/en/m/13511029?ml=en&vt=watch&autoplay=true
+    icon: video
+  - label: "Committee Study Page"
+    url: https://www.ourcommons.ca/committees/en/INDU/StudyActivity?studyActivityId=13310104
+    icon: document

--- a/data/events/2026-06-01-indu-ai-strategic-industries-meeting-41.yaml
+++ b/data/events/2026-06-01-indu-ai-strategic-industries-meeting-41.yaml
@@ -67,6 +67,8 @@ tags:
   - ai-safety
   - sustainability
 
+# Evidence and Minutes not yet published as of data entry (June 11, 2026);
+# add those links once they appear on ourcommons.ca.
 links:
   - label: "Notice of Meeting"
     url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-41/notice

--- a/data/events/2026-06-01-indu-ai-strategic-industries-meeting-41.yaml
+++ b/data/events/2026-06-01-indu-ai-strategic-industries-meeting-41.yaml
@@ -1,0 +1,79 @@
+# events/2026-06-01-indu-ai-strategic-industries-meeting-41.yaml
+
+id: indu-ai-strategic-industries-meeting-41-2026
+type: CommitteeHearing
+schema_type: Event
+
+title: "INDU Meeting 41 — Opportunities, Risks, and Regulation of AI in Canada's Strategic Industries"
+date: 2026-06-01
+location:
+  name: "Room 425, Wellington Building, 197 Sparks Street, Ottawa, Ontario, Canada"
+  schema_type: Place
+
+status: completed
+
+description: >
+  Meeting 41 of the Standing Committee on Industry and Technology (INDU) as part
+  of its study on "Opportunities, Risks, and Regulation of AI in Canada's Strategic
+  Industries" — the last meeting of the study before the launch of Canada's National
+  AI Strategy on June 4, 2026. The session ran from 3:40 p.m. to 5:45 p.m. EDT and
+  was webcast. The first panel covered AI and copyright law and the space industry;
+  the second panel, appearing by videoconference, included cultural-sector
+  representatives, ControlAI, and AI sustainability researcher Sasha Luccioni.
+
+organizations:
+  - id: house-of-commons-indu-committee
+    role: host
+
+witnesses:
+  - name: "Barry Sookman"
+    title: "Senior Counsel, McCarthy Tétrault"
+    capacity: As an individual
+  - name: "Ewan Reid"
+    title: "Founder and Chief Executive Officer"
+    organization: "Mission Control Space Services Inc."
+  - name: "Brian Gallant"
+    title: "Chief Executive Officer"
+    organization: "Space Canada"
+  - name: "Marie-Julie Desrochers"
+    title: "Executive Director"
+    organization: "Coalition for the Diversity of Cultural Expressions"
+    appearance_mode: by videoconference
+  - name: "Samuel Buteau"
+    title: "Consulting Program Officer"
+    organization: "ControlAI"
+    appearance_mode: by videoconference
+  - name: "Christian Laforce"
+    title: "Executive Director"
+    organization: "Copibec"
+    appearance_mode: by videoconference
+  - name: "Sasha Luccioni"
+    title: "Co-founder and Chief Scientific Officer"
+    organization: "Sustainable AI Group"
+    appearance_mode: by videoconference
+
+tags:
+  - ai-regulation
+  - artificial-intelligence
+  - strategic-industries
+  - federal-government
+  - house-of-commons
+  - standing-committee
+  - indu
+  - canadian
+  - copyright
+  - space-industry
+  - controlai
+  - ai-safety
+  - sustainability
+
+links:
+  - label: "Notice of Meeting"
+    url: https://www.ourcommons.ca/DocumentViewer/en/45-1/INDU/meeting-41/notice
+    icon: document
+  - label: "Watch Recording"
+    url: https://www.ourcommons.ca/embed/en/m/13512541?ml=en&vt=watch&autoplay=true
+    icon: video
+  - label: "Committee Study Page"
+    url: https://www.ourcommons.ca/committees/en/INDU/StudyActivity?studyActivityId=13310104
+    icon: document


### PR DESCRIPTION
## Summary

Backfills four INDU committee meetings under the study "Opportunities, Risks, and Regulation of AI in Canada's Strategic Industries" that were missing between tracked meeting 31 (April 13) and the National AI Strategy launch (June 4):

- **Meeting 36** (April 30) — Jim Balsillie (CIGI), Canadian Telecommunications Workers Alliance, Quantum Industry Canada, Qu Data Centres; AI portion followed by in-camera tariff-report drafting instructions
- **Meeting 38** (May 7) — Centre for Designing Change, INQ Law, Oracle, Council of Canadian Innovators, Hypertec, Photonic
- **Meeting 40** (May 28) — Sean Mullin (Munk School), SOCAN, UrbanLogiq; AI portion followed by in-camera tariff draft-report consideration
- **Meeting 41** (June 1) — Barry Sookman, Mission Control Space Services, Space Canada, Coalition for the Diversity of Cultural Expressions, ControlAI, Copibec, Sasha Luccioni (Sustainable AI Group). Last study meeting before the strategy launch.

All details sourced from ourcommons.ca notices and minutes. Webcast embed IDs verified against the ParlVU `fk` IDs on each meeting page (the convention matches existing records, e.g. meeting 31). Meeting 41's minutes and evidence are not yet published (404), so its witness list comes from the notice of meeting and only the notice, recording, and study page are linked — a follow-up can add the evidence/minutes links once published.

## Test plan

- [x] `npm test` — 81 tests pass
- [x] `npm run build` — 49 pages built, including the four new event pages
- [x] Evidence/minutes/notice URLs spot-checked (HTTP 200; meeting 41 evidence 404 as expected, link omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)