### PR TITLE
Add the Standards Council of Canada's AI Program

### DIFF
--- a/data/artifacts/2021-04-19-scc-ai-program.yaml
+++ b/data/artifacts/2021-04-19-scc-ai-program.yaml
@@ -8,7 +8,7 @@ title: "Standards Council of Canada's AI Program (AI and Data Governance Standar
 published_date: 2021-04-19
 
 organizations:
-  - id: standards-council-canada
+  - id: standards-council-of-canada
     role: lead
   - id: ised-canada
     role: sponsor
@@ -19,6 +19,8 @@ current_stage: "Funding renewal committed in Canada's National AI Strategy (June
 derives_from:
   - id: pan-canadian-ai-strategy-phase-2-2021
     relationship: funded_by
+  - id: canada-national-ai-strategy-launched-2026
+    relationship: renewed_by
 
 description: |
   The Standards Council of Canada (SCC) runs the federal program to advance
@@ -35,8 +37,9 @@ description: |
 
   **Budget 2021** provided $8.6 million over five years (2021–22 to 2025–26)
   for SCC to advance AI standardization as part of Phase 2 of the
-  Pan-Canadian AI Strategy, whose commercialization pillar treated standards
-  as essential to responsible development and market implementation.
+  Pan-Canadian AI Strategy, whose dedicated standards pillar supports the
+  development and adoption of standards and conformity assessment related
+  to AI.
 
   In 2023, SCC extended the earlier collaborative into the **AI and Data
   Governance (AIDG) Standardization Collaborative**, chaired by Chief
@@ -45,7 +48,8 @@ description: |
   Canadian priorities — including Indigenous leadership in the digital
   economy and consistency between domestic and international standards — and
   builds on the roadmap and the Schwartz Reisman Institute white paper
-  *Discerning Signal from Noise: The State of Global AI Standardization*.
+  *Discerning signal from noise: The state of global AI standardization and
+  what it means for Canada*.
 
   In May 2025, SCC and Statistics Canada launched the **AIDG Standardization
   Hub**, an online one-stop shop for standardization education that helps
@@ -91,8 +95,8 @@ links:
 
 tags:
   - scc
+  - ised
   - standards
-  - ai-standards
   - conformity-assessment
   - quality-assurance
   - responsible-ai

--- a/data/artifacts/2021-04-19-scc-ai-program.yaml
+++ b/data/artifacts/2021-04-19-scc-ai-program.yaml
@@ -1,0 +1,102 @@
+# artifacts/2021-04-19-scc-ai-program.yaml
+
+id: scc-ai-program
+type: GovernmentProgram
+schema_type: CreativeWork
+
+title: "Standards Council of Canada's AI Program (AI and Data Governance Standardization)"
+published_date: 2021-04-19
+
+organizations:
+  - id: standards-council-canada
+    role: lead
+  - id: ised-canada
+    role: sponsor
+
+lifecycle_status: active
+current_stage: "Funding renewal committed in Canada's National AI Strategy (June 2026)"
+
+derives_from:
+  - id: pan-canadian-ai-strategy-phase-2-2021
+    relationship: funded_by
+
+description: |
+  The Standards Council of Canada (SCC) runs the federal program to advance
+  the development and adoption of standards and conformity assessment for
+  artificial intelligence — the standards-and-certification layer of Canada's
+  AI governance toolkit, complementing legislation and voluntary codes.
+
+  The program's roots are in the **Canadian Data Governance Standardization
+  Collaborative**, convened by SCC in 2019 with roughly 220 experts from
+  government, industry, civil society, Indigenous organizations, academia,
+  and standards development organizations. Its *Canadian Data Governance
+  Standardization Roadmap* (2021) mapped gaps in data governance
+  standardization and made recommendations that continue to guide the work.
+
+  **Budget 2021** provided $8.6 million over five years (2021–22 to 2025–26)
+  for SCC to advance AI standardization as part of Phase 2 of the
+  Pan-Canadian AI Strategy, whose commercialization pillar treated standards
+  as essential to responsible development and market implementation.
+
+  In 2023, SCC extended the earlier collaborative into the **AI and Data
+  Governance (AIDG) Standardization Collaborative**, chaired by Chief
+  Statistician of Canada Anil Arora alongside AI policy experts Philip Dawson
+  and Ashley Casovan. It develops standardization strategies aligned with
+  Canadian priorities — including Indigenous leadership in the digital
+  economy and consistency between domestic and international standards — and
+  builds on the roadmap and the Schwartz Reisman Institute white paper
+  *Discerning Signal from Noise: The State of Global AI Standardization*.
+
+  In May 2025, SCC and Statistics Canada launched the **AIDG Standardization
+  Hub**, an online one-stop shop for standardization education that helps
+  users — particularly micro, small, and medium enterprises — navigate AI and
+  data governance standards, supporting interoperability and access to
+  international markets.
+
+  **Canada's National AI Strategy ("AI for All", June 2026)** committed to
+  renew the program's funding under its first pillar (protecting Canadians
+  and safeguarding democracy): "Canada will renew funding for the Standards
+  Council of Canada's AI Program to support our standardization ecosystem,
+  shape global AI standards, and grow a robust AI quality assurance
+  ecosystem. This work will enable standards-based AI testing, certification,
+  interoperability, and global market access."
+
+stages:
+  - date: 2021-04-19
+    stage: "Budget 2021 funds SCC's AI standardization program"
+    note: "$8.6M over five years (2021–22 to 2025–26) under Phase 2 of the Pan-Canadian AI Strategy to advance AI standards and conformity assessment; builds on the Data Governance Standardization Collaborative convened in 2019 and extended to AI in 2023"
+  - date: 2025-05-29
+    stage: "AIDG Standardization Hub launched with Statistics Canada"
+    note: "Online platform helping businesses — especially MSMEs — navigate AI and data governance standardization"
+  - date: 2026-06-04
+    stage: "Funding renewal committed in AI for All strategy"
+    note: "Renewal to support the standardization ecosystem, shape global AI standards, and grow an AI quality assurance ecosystem enabling standards-based testing and certification"
+
+links:
+  - label: "SCC — AI and Data Governance Standardization Collaborative"
+    url: https://scc-ccn.ca/areas-work/digital-technology/ai-and-data-governance-standardization-collaborative
+    icon: document
+  - label: "SCC — Canadian Data Governance Standardization Roadmap"
+    url: https://scc-ccn.ca/resources/publications/canadian-data-governance-standardization-roadmap
+    icon: document
+  - label: "SCC & Statistics Canada — AIDG Standardization Hub launch"
+    url: https://scc-ccn.ca/resources/news/standards-council-canada-and-statistics-canada-launch-ai-and-data-governance
+    icon: document
+  - label: "ISED — Pan-Canadian AI Strategy (SCC funding)"
+    url: https://ised-isde.canada.ca/site/ised/en/pan-canadian-artificial-intelligence-strategy
+    icon: document
+  - label: "ISED — Canada's National AI Strategy: AI for All (renewal commitment)"
+    url: https://ised-isde.canada.ca/site/ised/en/canadas-national-artificial-intelligence-strategy-ai-all
+    icon: document
+
+tags:
+  - scc
+  - standards
+  - ai-standards
+  - conformity-assessment
+  - quality-assurance
+  - responsible-ai
+  - pan-canadian-ai-strategy
+  - ai-for-all
+  - national-ai-strategy
+  - federal-government

--- a/data/events/2021-04-19-pan-canadian-ai-strategy-phase-2-announced.yaml
+++ b/data/events/2021-04-19-pan-canadian-ai-strategy-phase-2-announced.yaml
@@ -25,6 +25,7 @@ description: >
 
 related_artifacts:
   - id: pan-canadian-ai-strategy
+  - id: scc-ai-program
 
 tags:
   - cifar

--- a/data/events/2026-06-04-canada-national-ai-strategy-launched.yaml
+++ b/data/events/2026-06-04-canada-national-ai-strategy-launched.yaml
@@ -23,6 +23,7 @@ description: >
 
 related_artifacts:
   - id: canada-national-ai-strategy-ai-for-all
+  - id: scc-ai-program
 
 tags:
   - ai-for-all

--- a/data/organizations/standards-council-of-canada.yaml
+++ b/data/organizations/standards-council-of-canada.yaml
@@ -1,6 +1,6 @@
 # organizations/standards-council-of-canada.yaml
 
-id: standards-council-canada
+id: standards-council-of-canada
 type: GovernmentOrganization
 schema_type: GovernmentOrganization
 country: ca

--- a/data/organizations/standards-council-of-canada.yaml
+++ b/data/organizations/standards-council-of-canada.yaml
@@ -1,0 +1,17 @@
+# organizations/standards-council-of-canada.yaml
+
+id: standards-council-canada
+type: GovernmentOrganization
+schema_type: GovernmentOrganization
+country: ca
+
+name: "Standards Council of Canada"
+short_name: "SCC"
+url: https://scc-ccn.ca
+wikipedia: https://en.wikipedia.org/wiki/Standards_Council_of_Canada
+
+tags:
+  - federal-government
+  - canadian
+  - crown-corporation
+  - standards


### PR DESCRIPTION
## Summary

Closes #84.

Adds the Standards Council of Canada's AI Program, which the *AI for All* strategy commits to renewing under Pillar 1 (protecting Canadians and safeguarding democracy).

- **New organization** `data/organizations/standards-council-of-canada.yaml` — SCC (federal Crown corporation).
- **New artifact** `data/artifacts/2021-04-19-scc-ai-program.yaml` — `GovernmentProgram` dated to its Budget 2021 funding ($8.6M over five years under PCAIS Phase 2), with stages for the May 2025 AIDG Standardization Hub launch (with Statistics Canada) and the June 2026 renewal commitment. The 2019 Data Governance Standardization Collaborative and its 2023 extension to AI (AIDG Collaborative, chaired by Anil Arora with Philip Dawson and Ashley Casovan) are covered in the description prose because only year-level dates are verifiable from public sources.
- **Cross-links**: `related_artifacts` entries added to the PCAIS Phase 2 announcement event and the AI for All launch event, and the artifact `derives_from` the Phase 2 event (`funded_by`).

Modeled on the Sovereign Technology Alliance addition (#82) and the AI for All strategy artifact (#81).

### Sources

- [ISED — Pan-Canadian AI Strategy](https://ised-isde.canada.ca/site/ised/en/pan-canadian-artificial-intelligence-strategy) ($8.6M Budget 2021 funding for SCC)
- [ISED — AI for All strategy](https://ised-isde.canada.ca/site/ised/en/canadas-national-artificial-intelligence-strategy-ai-all) (renewal commitment quoted in the issue)
- [SCC — AIDG Standardization Collaborative](https://scc-ccn.ca/areas-work/digital-technology/ai-and-data-governance-standardization-collaborative)
- [SCC — AIDG Standardization Hub launch](https://scc-ccn.ca/resources/news/standards-council-canada-and-statistics-canada-launch-ai-and-data-governance)
- [SCC — Canadian Data Governance Standardization Roadmap](https://scc-ccn.ca/resources/publications/canadian-data-governance-standardization-roadmap)

## Test plan

- [x] `npm run build` passes (Zod content-collection validation, 51 pages)
- [x] `npm test` passes (81 tests)
- [ ] CI `Test / unit` and `Test / e2e` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)