### PR TITLE
Add latest-activity preview to homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 node_modules/
+.pnpm-store/
 dist/
 .astro/
 .env
 .env.*
 !.env.example
 .DS_Store
-.claude/settings.local.json
+.claude/
 CLAUDE.local.md
 playwright-report/
 test-results/

--- a/docs/homepage-ideas.md
+++ b/docs/homepage-ideas.md
@@ -1,0 +1,66 @@
+# Homepage improvement ideas
+
+The current homepage (`src/pages/index.astro`) is entirely static: two paragraphs
+of mission copy, two buttons, and two generic cards ("Timeline" / "Policy") that
+only *describe* sub-pages. It shows none of the actual content the site tracks,
+and it looks identical whether the dataset holds 1 event or 1,000.
+
+Meanwhile the data layer is rich: events, artifacts, organizations, dated entries,
+tags, source categories, org roles, and policy recommendations with `status`
+fields. The overarching opportunity is to **make the homepage show the living
+state of Canadian AI governance, not just describe the site.**
+
+Ideas, roughly ordered by impact-per-effort:
+
+## High impact, low effort
+
+### 1. "Latest activity" preview — the 3–5 most recent timeline entries
+Render the newest events at the top with date, title, and source badge, each
+linking through. Instantly signals the site is alive and current, and gives a
+returning visitor a reason to look. The list is already computed in
+`timeline/index.astro` — a small refactor into a shared helper.
+
+### 2. At-a-glance stat strip
+A row of numbers: *events tracked · reports & legislation · organizations ·
+last updated [date]*. Cheap to compute, conveys scope + freshness. The
+"last updated" date is especially good for trust.
+
+### 3. Policy implementation scoreboard
+The most *unique* data and arguably the site's whole point ("Track implementation
+status of policy recommendations"). A small visual breakdown — e.g.
+`X adopted · Y under review · Z rejected · N untracked` — that exists nowhere
+else. Links into `/policy/`.
+
+## Medium effort, high "useful"
+
+### 4. Compact visual timeline / activity sparkline
+A horizontal mini-timeline (by year, 2017→present) showing where activity
+density is. Turns an abstract list into a glanceable shape of how AI governance
+has accelerated.
+
+### 5. Topic / tag entry points
+Instead of two generic cards, surface the actual top tags (e.g. `bill-c27`,
+`pan-canadian-ai-strategy`, `federal-budget`) as clickable chips. Lets people
+jump straight to what they care about.
+
+## Polish
+
+### 6. Tighten the hero copy
+The two dense paragraphs bury the lede. A short headline + one-sentence value
+prop, with the nuance moved to an About page, would let the *content* below
+become the eye-catching part.
+
+---
+
+**Recommended first cut:** #1 + #2 + #3 together — recent activity + stat strip +
+policy scoreboard — all built from data already loaded, no new data model,
+fully static-renderable in Astro.
+
+## Status
+
+- [x] #1 Latest activity preview — *done*
+- [ ] #2 At-a-glance stat strip
+- [ ] #3 Policy implementation scoreboard
+- [ ] #4 Activity sparkline
+- [ ] #5 Topic / tag entry points
+- [ ] #6 Hero copy polish

--- a/docs/superpowers/plans/2026-06-17-homepage-tightening.md
+++ b/docs/superpowers/plans/2026-06-17-homepage-tightening.md
@@ -1,0 +1,459 @@
+# Homepage Tightening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the homepage snappier and cut timeline links from 4 to 2 — lean hero, 3-item activity preview, an Organizations card, a bottom About section, and a global footer Contribute link.
+
+**Architecture:** All changes are presentational Astro markup in two files (`src/pages/index.astro`, `src/layouts/BaseLayout.astro`) plus a `.gitignore` housekeeping change. There is no new logic — the only data change is `slice(0, 5)` → `slice(0, 3)`. Tests are end-to-end (Playwright `e2e/homepage.spec.ts`), since the changes are markup; we update those tests TDD-style (change the assertion first, watch it fail, then change the markup).
+
+**Tech Stack:** Astro 5, Tailwind CSS 4, Playwright (e2e). Spec: `docs/superpowers/specs/2026-06-17-homepage-tightening-design.md`.
+
+**Branch:** Continue on `feature/homepage-latest-activity` (stacks on PR #93).
+
+---
+
+## Notes for the implementer
+
+- **Running e2e:** The Playwright config starts the app with `pnpm preview`, which serves the built `dist/`. So a single spec run is: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts --project=chromium`. The build step is required — `preview` does not pick up source changes without it.
+- **Unit tests** (`pnpm test`) are unaffected by this work but must stay green.
+- A `<footer>` element has the implicit ARIA role `contentinfo`; a `<main>` has role `main`; an `<ol>`/`<ul>` has role `list`. The tests below use these roles to scope queries.
+
+---
+
+## Task 1: Housekeeping — gitignore untracked noise
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Inspect current ignores**
+
+Run: `cat .gitignore`
+Note whether `.pnpm-store`, `.claude`, `.superpowers` are already present (they are not, per `git status` showing them untracked).
+
+- [ ] **Step 2: Append the three entries**
+
+Add these lines to the end of `.gitignore`:
+
+```gitignore
+# Local package store / tooling / brainstorm artifacts
+.pnpm-store/
+.claude/
+.superpowers/
+```
+
+- [ ] **Step 3: Verify they are no longer listed as untracked**
+
+Run: `git status --short`
+Expected: no lines for `.pnpm-store/`, `.claude/`, or `.superpowers/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .gitignore
+git commit -m "Ignore .pnpm-store, .claude, and .superpowers"
+```
+
+---
+
+## Task 2: Add a global Contribute link to the footer
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro` (footer meta line, ~lines 184-195)
+- Test: `e2e/homepage.spec.ts` (the "contribute link" test, lines 17-25)
+
+- [ ] **Step 1: Update the e2e test to expect the link in the footer, on a non-home page**
+
+In `e2e/homepage.spec.ts`, replace the existing test:
+
+```typescript
+  test("contribute link points to GitHub new issue page", async ({ page }) => {
+    await page.goto("/");
+    const link = page.getByRole("link", { name: /Contribute/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/jrhender/ai-governance-tracker/issues/new"
+    );
+  });
+```
+
+with:
+
+```typescript
+  test("footer contribute link points to GitHub and is global", async ({ page }) => {
+    // Load a non-home page to prove the link lives in the global footer.
+    await page.goto("/timeline/");
+    const link = page
+      .getByRole("contentinfo")
+      .getByRole("link", { name: /Contribute/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/jrhender/ai-governance-tracker/issues/new"
+    );
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts -g "footer contribute" --project=chromium`
+Expected: FAIL — no `Contribute` link inside the footer (`contentinfo`) yet.
+
+- [ ] **Step 3: Add the link to the footer meta line**
+
+In `src/layouts/BaseLayout.astro`, find the footer meta paragraph:
+
+```astro
+        <p>
+          A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
+          Anonymous usage statistics via&nbsp;
+          <a
+            href="https://www.cloudflare.com/web-analytics/"
+            class="text-[#8ab8c8] hover:text-white underline"
+          >
+            Cloudflare Web Analytics
+          </a>
+          &nbsp;·&nbsp;
+          <a href="/rss.xml" class="text-[#8ab8c8] hover:text-white underline">RSS</a>
+        </p>
+```
+
+Replace it with (adds a Contribute link after RSS, matching the existing link style):
+
+```astro
+        <p>
+          A Canadian AI governance and policy timeline. &nbsp;·&nbsp;
+          Anonymous usage statistics via&nbsp;
+          <a
+            href="https://www.cloudflare.com/web-analytics/"
+            class="text-[#8ab8c8] hover:text-white underline"
+          >
+            Cloudflare Web Analytics
+          </a>
+          &nbsp;·&nbsp;
+          <a href="/rss.xml" class="text-[#8ab8c8] hover:text-white underline">RSS</a>
+          &nbsp;·&nbsp;
+          <a
+            href="https://github.com/jrhender/ai-governance-tracker/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-[#8ab8c8] hover:text-white underline"
+          >
+            Contribute on GitHub
+          </a>
+        </p>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts -g "footer contribute" --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro e2e/homepage.spec.ts
+git commit -m "Add global Contribute link to the footer"
+```
+
+---
+
+## Task 3: Trim the Latest activity preview to 3 items
+
+**Files:**
+- Modify: `src/pages/index.astro` (the `slice` at line 11, and add an `aria-label` to the `<ol>` at ~line 58)
+- Test: `e2e/homepage.spec.ts` (new test)
+
+- [ ] **Step 1: Add a failing test for a 3-item, labelled activity list**
+
+In `e2e/homepage.spec.ts`, add this test inside the `test.describe("homepage", ...)` block:
+
+```typescript
+  test("latest activity shows three items", async ({ page }) => {
+    await page.goto("/");
+    const list = page.getByRole("list", { name: /Latest activity/i });
+    await expect(list.locator("li")).toHaveCount(3);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts -g "latest activity shows three" --project=chromium`
+Expected: FAIL — the list has no accessible name "Latest activity" yet, and currently renders 5 items.
+
+- [ ] **Step 3: Change the slice from 5 to 3**
+
+In `src/pages/index.astro`, change line 11:
+
+```astro
+const latest = buildTimelineItems(events, organizations).slice(0, 5);
+```
+
+to:
+
+```astro
+const latest = buildTimelineItems(events, organizations).slice(0, 3);
+```
+
+- [ ] **Step 4: Add an aria-label to the activity list**
+
+In `src/pages/index.astro`, find the activity list opening tag:
+
+```astro
+        <ol class="mt-6 border-l-2 border-accent">
+```
+
+Replace it with:
+
+```astro
+        <ol aria-label="Latest activity" class="mt-6 border-l-2 border-accent">
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts -g "latest activity shows three" --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/index.astro e2e/homepage.spec.ts
+git commit -m "Trim homepage activity preview to 3 items"
+```
+
+---
+
+## Task 4: Slim the hero and add an About section
+
+Removes paragraph 2 and the button row from the hero, and adds an "About this project" section at the bottom of the page containing paragraph 2. Also replaces the now-removed "primary CTA" e2e test with one for the activity section's "View full timeline" link.
+
+**Files:**
+- Modify: `src/pages/index.astro` (hero paragraph 2 + button row; add About section)
+- Test: `e2e/homepage.spec.ts` (replace the "primary CTA" test)
+
+- [ ] **Step 1: Replace the "primary CTA" test with a "View full timeline" test**
+
+In `e2e/homepage.spec.ts`, replace this test:
+
+```typescript
+  test("primary CTA links to /timeline/", async ({ page }) => {
+    await page.goto("/");
+    const cta = page.getByRole("link", { name: /Browse the Timeline/i });
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("href", "/timeline/");
+  });
+```
+
+with:
+
+```typescript
+  test("latest activity links to the full timeline", async ({ page }) => {
+    await page.goto("/");
+    const link = page.getByRole("link", { name: /View full timeline/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "/timeline/");
+  });
+```
+
+- [ ] **Step 2: Run the homepage spec to confirm the old assertion is gone and the new one is the target**
+
+Run: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts -g "links to the full timeline" --project=chromium`
+Expected: PASS already — the "View full timeline →" link exists today (this guards against regressions in this task). Note: the removed "Browse the Timeline" test no longer runs.
+
+- [ ] **Step 3: Remove paragraph 2 and the button row from the hero**
+
+In `src/pages/index.astro`, delete this paragraph (the second `<p>`):
+
+```astro
+    <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
+      Policy on the full range of AI risks and benefits is given space here, but emphasis is on the scenarios with the largest potential impacts such as widespread deployment of advanced AI across the economy, increased bio and cyber risk, and the implications of highly capable systems. Within that scope, the site reports on government action and civil society inputs neutrally, without editorial comment.
+    </p>
+```
+
+And delete the entire button row:
+
+```astro
+    <div class="mt-8 flex flex-wrap gap-3">
+      <a
+        href="/timeline/"
+        class="inline-flex items-center rounded bg-header px-5 py-2.5 text-sm font-semibold text-white hover:bg-header-hover no-underline transition-colors"
+      >
+        Browse the Timeline →
+      </a>
+      <a
+        href="https://github.com/jrhender/ai-governance-tracker/issues/new"
+        class="inline-flex items-center rounded border border-border px-5 py-2.5 text-sm font-semibold text-muted hover:border-[#aabbcc] hover:text-ink no-underline transition-colors"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Contribute via GitHub
+      </a>
+    </div>
+```
+
+After this, the hero is: `<h1>` + the first `<p>` (mission sentence) only.
+
+- [ ] **Step 4: Add the About section at the bottom of the page**
+
+In `src/pages/index.astro`, find the closing of the two-card grid `</div>` immediately followed by the page-wrapper `</div>`:
+
+```astro
+    </div>
+  </div>
+</BaseLayout>
+```
+
+Insert an About section between the card grid's closing `</div>` and the wrapper's closing `</div>`, so it reads:
+
+```astro
+    </div>
+
+    <section class="mt-12 max-w-2xl">
+      <h2 class="font-display text-2xl text-header">About this project</h2>
+      <p class="mt-3 text-base text-muted leading-relaxed">
+        Policy on the full range of AI risks and benefits is given space here, but emphasis is on the scenarios with the largest potential impacts such as widespread deployment of advanced AI across the economy, increased bio and cyber risk, and the implications of highly capable systems. Within that scope, the site reports on government action and civil society inputs neutrally, without editorial comment.
+      </p>
+    </section>
+  </div>
+</BaseLayout>
+```
+
+- [ ] **Step 5: Run the homepage spec to confirm nothing broke**
+
+Run: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts --project=chromium`
+Expected: All homepage tests PASS. The "renders site title and values statement" test still passes because the `transformational impact` text is in paragraph 1, which stays in the hero.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/index.astro e2e/homepage.spec.ts
+git commit -m "Slim homepage hero and move project description to an About section"
+```
+
+---
+
+## Task 5: Swap the Timeline card for an Organizations card
+
+**Files:**
+- Modify: `src/pages/index.astro` (the first card in the 2-card grid)
+- Test: `e2e/homepage.spec.ts` (rewrite the "section cards" test)
+
+- [ ] **Step 1: Rewrite the "section cards" test to expect Policy + Organizations**
+
+In `e2e/homepage.spec.ts`, replace this test:
+
+```typescript
+  test("section cards link to /timeline/ and /policy/", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.locator("main").getByRole("link", { name: /Timeline/i }).first()
+    ).toHaveAttribute("href", "/timeline/");
+    await expect(
+      page.locator("main").getByRole("link", { name: /Policy/i }).first()
+    ).toHaveAttribute("href", "/policy/");
+  });
+```
+
+with:
+
+```typescript
+  test("explore cards link to /policy/ and /orgs/", async ({ page }) => {
+    await page.goto("/");
+    const main = page.locator("main");
+    await expect(
+      main.getByRole("link", { name: /Organizations/i }).first()
+    ).toHaveAttribute("href", "/orgs/");
+    await expect(
+      main.getByRole("link", { name: /Policy/i }).first()
+    ).toHaveAttribute("href", "/policy/");
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts -g "explore cards" --project=chromium`
+Expected: FAIL — there is no card linking to `/orgs/` yet (the first card still links to `/timeline/`).
+
+- [ ] **Step 3: Replace the Timeline card with an Organizations card**
+
+In `src/pages/index.astro`, find the first card in the grid:
+
+```astro
+      <a
+        href="/timeline/"
+        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
+      >
+        <h2 class="font-display text-lg text-header">Timeline</h2>
+        <p class="mt-1 text-sm text-muted">
+          Senate hearings, reports, and government announcements.
+        </p>
+      </a>
+```
+
+Replace it with:
+
+```astro
+      <a
+        href="/orgs/"
+        class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
+      >
+        <h2 class="font-display text-lg text-header">Organizations</h2>
+        <p class="mt-1 text-sm text-muted">
+          Government bodies, think tanks, and advocacy groups.
+        </p>
+      </a>
+```
+
+(Leave the Policy card that follows it unchanged.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm build && pnpm exec playwright test e2e/homepage.spec.ts -g "explore cards" --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/index.astro e2e/homepage.spec.ts
+git commit -m "Swap homepage Timeline card for an Organizations card"
+```
+
+---
+
+## Task 6: Full verification and push
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `pnpm test`
+Expected: all tests PASS (unchanged from before this work — the `buildTimelineItems`/filter tests).
+
+- [ ] **Step 2: Run the full e2e suite**
+
+Run: `pnpm test:e2e`
+Expected: all specs PASS, including the four updated homepage tests (site title, latest-activity-3-items, latest-activity-links-to-timeline, footer-contribute, explore-cards). Pay attention to `a11y.spec.ts` — the new `aria-label` and section headings should not introduce violations.
+
+- [ ] **Step 3: Sanity-check the built homepage**
+
+Run: `grep -c "Browse the Timeline" dist/index.html` → expected `0` (hero button gone).
+Run: `grep -o "About this project" dist/index.html` → expected one match.
+Run: `grep -o 'href="/orgs/"' dist/index.html` → expected at least one match (the new card).
+
+- [ ] **Step 4: Push the branch (updates PR #93)**
+
+```bash
+git push
+```
+
+- [ ] **Step 5: Confirm CI is green on the PR**
+
+Watch `Test / unit` and `Test / e2e` on PR #93. Both must pass before merge.
+
+---
+
+## Self-review notes (for reference)
+
+- **Spec coverage:** hero slim (Task 4), activity 5→3 (Task 3), Organizations card (Task 5), About section (Task 4), footer Contribute (Task 2), `.gitignore` (Task 1). All spec sections mapped.
+- **e2e:** the three pre-existing homepage tests the spec flagged are each addressed — "primary CTA" replaced (Task 4), "contribute" moved to footer (Task 2), "section cards" rewritten (Task 5).
+- **Link count:** after Task 4 + 5, on-page timeline links = 1 ("View full timeline"), plus the global nav = 2 total. Goal met.

--- a/docs/superpowers/specs/2026-06-17-homepage-tightening-design.md
+++ b/docs/superpowers/specs/2026-06-17-homepage-tightening-design.md
@@ -1,0 +1,103 @@
+# Homepage tightening — design
+
+**Date:** 2026-06-17
+**Status:** Approved
+**Branch:** `feature/homepage-latest-activity` (stacks on PR #93)
+
+## Problem
+
+The homepage just gained a "Latest activity" preview (PR #93), but the page now
+links to the timeline in **four** places: the global nav (every page), a hero
+"Browse the Timeline" button, the "View full timeline" link on the Latest
+activity section, and a "Timeline" card in the bottom 2-card grid. That's
+redundant. Separately, the hero opens with two dense paragraphs — the second
+(risk scope + neutrality) buries the lede and makes the top of the page slow to
+read.
+
+Goal: a snappier front page with the timeline links tightened from 4 to 2.
+
+## Design
+
+Implements layout option **B** (lean hero, section link) with the Contribute CTA
+moved to the global footer.
+
+### 1. Hero — `src/pages/index.astro`
+- Keep the `<h1>` and **paragraph 1** (mission sentence).
+- Remove **paragraph 2** from the hero (moves to a new About section, §4).
+- Remove the hero button row entirely — both "Browse the Timeline →" and
+  "Contribute via GitHub". The hero becomes headline + one paragraph.
+
+### 2. Latest activity — `src/pages/index.astro`
+- Reduce the preview from **5 items to 3**: `buildTimelineItems(...).slice(0, 3)`.
+- Keep the "View full timeline →" link in the section header. This is the single
+  on-page timeline entry point.
+
+### 3. Explore cards — `src/pages/index.astro`
+- The 2-card grid keeps **Policy** and replaces the **Timeline** card with an
+  **Organizations** card linking to `/orgs/`.
+  - Organizations card: heading "Organizations", description
+    "Government bodies, think tanks, and advocacy groups." (matches the
+    Policy card's one-line tone).
+- Rationale: `/orgs/` is a real page with no homepage entry point today; the
+  Timeline card was redundant with the nav link and the activity section.
+
+### 4. About this project — `src/pages/index.astro`
+- New section at the bottom of the page, heading "About this project".
+- Contains **paragraph 2** (the risk-scope + neutrality text moved out of the hero).
+- Placed after the explore cards.
+
+### 5. Footer — `src/layouts/BaseLayout.astro`
+- Add a **"Contribute on GitHub"** link to the footer meta line, alongside the
+  existing "Cloudflare Web Analytics" and "RSS" links.
+- Link target: `https://github.com/jrhender/ai-governance-tracker/issues/new`
+  — keeps the old button's destination, so "contribute" still means "file an
+  issue / suggest an edit". Opens in a new tab (`target="_blank"`,
+  `rel="noopener noreferrer"`), styled to match the adjacent footer links
+  (the underlined `#8ab8c8` link style).
+- Because the footer is global, this surfaces "contribute" on every page.
+
+### 6. Housekeeping — `.gitignore`
+- Add `.pnpm-store/`, `.claude/`, and `.superpowers/` (brainstorm artifacts) to
+  `.gitignore`. These are currently untracked noise.
+
+## Net effect
+
+- Timeline links: **4 → 2** (global nav + Latest activity section link).
+- Hero: 2 paragraphs + 2 buttons → 1 paragraph, no buttons.
+- Latest activity: 5 → 3 items.
+- New homepage entry point to Organizations; new global Contribute link.
+
+## Out of scope
+
+- The other homepage ideas in `docs/homepage-ideas.md` (#2 stat strip,
+  #3 policy scoreboard, #4 sparkline, #5 tag chips). Tracked separately.
+- A standalone `/about` page — the 2nd paragraph lives in a homepage section,
+  not a new route.
+
+## Testing
+
+- Existing unit tests (`buildTimelineItems`, filters) remain green; `slice(0, 3)`
+  needs no new logic.
+- `pnpm build` succeeds; built `dist/index.html` contains exactly 3 activity
+  items, the About section, no hero buttons, and the bottom cards link to
+  `/policy/` and `/orgs/`.
+
+### e2e changes (`e2e/homepage.spec.ts`)
+
+The current file has three tests that touch what we're changing — they must be
+updated, not left to "stay green":
+
+1. **"primary CTA links to /timeline/"** — asserts a "Browse the Timeline" hero
+   link. That link is removed. **Replace** with a test that the Latest activity
+   "View full timeline →" link has `href="/timeline/"`.
+2. **"contribute link points to GitHub new issue page"** — still valid: the
+   footer link keeps the `/issues/new` href and a name matching `/Contribute/i`.
+   Optionally strengthen it to also assert the link appears on a non-home page
+   (it's now global via the footer).
+3. **"section cards link to /timeline/ and /policy/"** — the Timeline card is
+   gone. **Rewrite** to assert the two cards link to `/policy/` and `/orgs/`.
+   (Note: scope card assertions so they don't accidentally match the
+   "View full timeline" link, which also matches `/Timeline/i` in `main`.)
+- The "renders site title and values statement" test checks for
+  `/transformational impact/i` — that text is in paragraph 1, which stays in the
+  hero, so this test is unaffected.

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -33,13 +33,14 @@ test.describe("homepage", () => {
     );
   });
 
-  test("section cards link to /timeline/ and /policy/", async ({ page }) => {
+  test("explore cards link to /policy/ and /orgs/", async ({ page }) => {
     await page.goto("/");
+    const main = page.locator("main");
     await expect(
-      page.locator("main").getByRole("link", { name: /Timeline/i }).first()
-    ).toHaveAttribute("href", "/timeline/");
+      main.getByRole("link", { name: /Organizations/i }).first()
+    ).toHaveAttribute("href", "/orgs/");
     await expect(
-      page.locator("main").getByRole("link", { name: /Policy/i }).first()
+      main.getByRole("link", { name: /Policy/i }).first()
     ).toHaveAttribute("href", "/policy/");
   });
 });

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -7,11 +7,11 @@ test.describe("homepage", () => {
     await expect(page.getByText(/transformational impact/i)).toBeVisible();
   });
 
-  test("primary CTA links to /timeline/", async ({ page }) => {
+  test("latest activity links to the full timeline", async ({ page }) => {
     await page.goto("/");
-    const cta = page.getByRole("link", { name: /Browse the Timeline/i });
-    await expect(cta).toBeVisible();
-    await expect(cta).toHaveAttribute("href", "/timeline/");
+    const link = page.getByRole("link", { name: /View full timeline/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", "/timeline/");
   });
 
   test("latest activity shows three items", async ({ page }) => {

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -14,6 +14,12 @@ test.describe("homepage", () => {
     await expect(cta).toHaveAttribute("href", "/timeline/");
   });
 
+  test("latest activity shows three items", async ({ page }) => {
+    await page.goto("/");
+    const list = page.getByRole("list", { name: /Latest activity/i });
+    await expect(list.locator("li")).toHaveCount(3);
+  });
+
   test("footer contribute link points to GitHub and is global", async ({ page }) => {
     // Load a non-home page to prove the link lives in the global footer.
     await page.goto("/timeline/");

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -14,9 +14,12 @@ test.describe("homepage", () => {
     await expect(cta).toHaveAttribute("href", "/timeline/");
   });
 
-  test("contribute link points to GitHub new issue page", async ({ page }) => {
-    await page.goto("/");
-    const link = page.getByRole("link", { name: /Contribute/i });
+  test("footer contribute link points to GitHub and is global", async ({ page }) => {
+    // Load a non-home page to prove the link lives in the global footer.
+    await page.goto("/timeline/");
+    const link = page
+      .getByRole("contentinfo")
+      .getByRole("link", { name: /Contribute/i });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute(
       "href",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -192,6 +192,15 @@ const navLinks = [
           </a>
           &nbsp;·&nbsp;
           <a href="/rss.xml" class="text-[#8ab8c8] hover:text-white underline">RSS</a>
+          &nbsp;·&nbsp;
+          <a
+            href="https://github.com/jrhender/ai-governance-tracker/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-[#8ab8c8] hover:text-white underline"
+          >
+            Contribute on GitHub
+          </a>
         </p>
       </div>
     </footer>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -197,9 +197,12 @@ const navLinks = [
             href="https://github.com/jrhender/ai-governance-tracker/issues/new"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-[#8ab8c8] hover:text-white underline"
+            class="inline-flex items-center gap-1.5 text-[#8ab8c8] hover:text-white"
           >
-            Contribute on GitHub
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true" class="shrink-0">
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+            </svg>
+            <span class="underline">Contribute on GitHub</span>
           </a>
         </p>
       </div>

--- a/src/lib/timeline.test.ts
+++ b/src/lib/timeline.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { filterByOrg, filterBySource, type TimelineItem } from "./timeline";
+import {
+  buildTimelineItems,
+  filterByOrg,
+  filterBySource,
+  type EventInput,
+  type OrgInput,
+  type TimelineItem,
+} from "./timeline";
 import type { SourceCategory } from "./sourceCategory";
 
 function make(id: string, orgIds: string[], sourceCategory: SourceCategory = "government"): TimelineItem {
@@ -17,6 +24,68 @@ function make(id: string, orgIds: string[], sourceCategory: SourceCategory = "go
     sourceCategory,
   };
 }
+
+describe("buildTimelineItems", () => {
+  const orgs: OrgInput[] = [
+    {
+      id: "ised-canada",
+      data: { name: "Innovation, Science and Economic Development Canada", short_name: "ISED", schema_type: "GovernmentOrganization" },
+    },
+    {
+      id: "cigi",
+      data: { name: "Centre for International Governance Innovation", schema_type: "Organization" },
+    },
+  ];
+
+  function event(id: string, date: string, orgIds: string[]): EventInput {
+    return {
+      id,
+      data: {
+        title: `Title ${id}`,
+        date: new Date(date),
+        description: "desc",
+        tags: ["t"],
+        type: "GovernmentAnnouncement",
+        organizations: orgIds.map((o) => ({ id: { id: o } })),
+        links: [],
+      },
+    };
+  }
+
+  it("sorts items newest first", () => {
+    const items = buildTimelineItems(
+      [event("a", "2017-03-22", ["ised-canada"]), event("b", "2022-06-16", ["ised-canada"])],
+      orgs,
+    );
+    expect(items.map((i) => i.id)).toEqual(["b", "a"]);
+  });
+
+  it("resolves org labels, preferring short_name and falling back to name", () => {
+    const [item] = buildTimelineItems([event("a", "2017-03-22", ["ised-canada", "cigi"])], orgs);
+    expect(item.orgs).toEqual([
+      { id: "ised-canada", label: "ISED" },
+      { id: "cigi", label: "Centre for International Governance Innovation" },
+    ]);
+  });
+
+  it("falls back to the raw id for unknown organizations", () => {
+    const [item] = buildTimelineItems([event("a", "2017-03-22", ["ghost"])], orgs);
+    expect(item.orgs).toEqual([{ id: "ghost", label: "ghost" }]);
+  });
+
+  it("derives sourceCategory from any government org", () => {
+    const [gov] = buildTimelineItems([event("a", "2017-03-22", ["cigi", "ised-canada"])], orgs);
+    const [civil] = buildTimelineItems([event("b", "2017-03-22", ["cigi"])], orgs);
+    expect(gov.sourceCategory).toBe("government");
+    expect(civil.sourceCategory).toBe("civil_society");
+  });
+
+  it("builds the event href and flattened orgIds", () => {
+    const [item] = buildTimelineItems([event("a", "2017-03-22", ["ised-canada", "cigi"])], orgs);
+    expect(item.href).toBe("/events/a/");
+    expect(item.orgIds).toEqual(["ised-canada", "cigi"]);
+  });
+});
 
 describe("filterByOrg", () => {
   const items: TimelineItem[] = [

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -1,4 +1,4 @@
-import type { SourceCategory } from "./sourceCategory";
+import { getSourceCategory, type SourceCategory } from "./sourceCategory";
 
 export type TimelineItem = {
   id: string;
@@ -20,6 +20,69 @@ export type OrgOption = {
   label: string; // short_name ?? name
   count: number; // pre-counted items referencing this org
 };
+
+// Minimal shapes of the Astro content collections, kept here so this builder
+// stays unit-testable without pulling in `astro:content`.
+export type EventInput = {
+  id: string;
+  data: {
+    title: string;
+    date: Date;
+    description?: string;
+    tags: string[];
+    type: string;
+    organizations: { id: { id: string } }[];
+    links: { label: string; url: string; icon?: string }[];
+  };
+};
+
+export type OrgInput = {
+  id: string;
+  data: { name: string; short_name?: string; schema_type: string };
+};
+
+// Map event + organization collections into TimelineItems, newest first.
+// Shared by the full timeline page and the homepage "latest activity" preview.
+export function buildTimelineItems(
+  events: EventInput[],
+  organizations: OrgInput[],
+): TimelineItem[] {
+  const orgMap = new Map<
+    string,
+    { name: string; short_name?: string; schema_type: string }
+  >();
+  for (const org of organizations) {
+    orgMap.set(org.id, {
+      name: org.data.name,
+      short_name: org.data.short_name,
+      schema_type: org.data.schema_type,
+    });
+  }
+
+  return events
+    .map((e) => ({
+      id: e.id,
+      kind: "event" as const,
+      title: e.data.title,
+      date: e.data.date.toISOString(),
+      description: e.data.description,
+      tags: e.data.tags,
+      href: `/events/${e.id}/`,
+      badge: e.data.type,
+      orgIds: e.data.organizations.map((o) => o.id.id),
+      orgs: e.data.organizations.map((o) => {
+        const org = orgMap.get(o.id.id);
+        return { id: o.id.id, label: org?.short_name ?? org?.name ?? o.id.id };
+      }),
+      links: e.data.links,
+      sourceCategory: getSourceCategory(
+        e.data.organizations.map(
+          (o) => orgMap.get(o.id.id)?.schema_type ?? "Organization",
+        ),
+      ),
+    }))
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
 
 export function filterByOrg(
   items: TimelineItem[],

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -72,12 +72,12 @@ const latest = buildTimelineItems(events, organizations).slice(0, 3);
 
     <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
       <a
-        href="/timeline/"
+        href="/orgs/"
         class="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
       >
-        <h2 class="font-display text-lg text-header">Timeline</h2>
+        <h2 class="font-display text-lg text-header">Organizations</h2>
         <p class="mt-1 text-sm text-muted">
-          Senate hearings, reports, and government announcements.
+          Government bodies, think tanks, and advocacy groups.
         </p>
       </a>
       <a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,27 +23,6 @@ const latest = buildTimelineItems(events, organizations).slice(0, 3);
       AI is likely to have a transformational impact on human society, and governance of AI is important to ensure that this transformation goes well.
       The goal of this site is to be a resource for Canadians to understand the status of AI governance in Canada so that they can provide their own input into the ecosystem.
     </p>
-    <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
-      Policy on the full range of AI risks and benefits is given space here, but emphasis is on the scenarios with the largest potential impacts such as widespread deployment of advanced AI across the economy, increased bio and cyber risk, and the implications of highly capable systems. Within that scope, the site reports on government action and civil society inputs neutrally, without editorial comment.
-    </p>
-
-    <div class="mt-8 flex flex-wrap gap-3">
-      <a
-        href="/timeline/"
-        class="inline-flex items-center rounded bg-header px-5 py-2.5 text-sm font-semibold text-white hover:bg-header-hover no-underline transition-colors"
-      >
-        Browse the Timeline →
-      </a>
-      <a
-        href="https://github.com/jrhender/ai-governance-tracker/issues/new"
-        class="inline-flex items-center rounded border border-border px-5 py-2.5 text-sm font-semibold text-muted hover:border-[#aabbcc] hover:text-ink no-underline transition-colors"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Contribute via GitHub
-      </a>
-    </div>
-
     {latest.length > 0 && (
       <section class="mt-12">
         <div class="flex items-baseline justify-between">
@@ -111,5 +90,12 @@ const latest = buildTimelineItems(events, organizations).slice(0, 3);
         </p>
       </a>
     </div>
+
+    <section class="mt-12 max-w-2xl">
+      <h2 class="font-display text-2xl text-header">About this project</h2>
+      <p class="mt-3 text-base text-muted leading-relaxed">
+        Policy on the full range of AI risks and benefits is given space here, but emphasis is on the scenarios with the largest potential impacts such as widespread deployment of advanced AI across the economy, increased bio and cyber risk, and the implications of highly capable systems. Within that scope, the site reports on government action and civil society inputs neutrally, without editorial comment.
+      </p>
+    </section>
   </div>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,21 +15,21 @@ const latest = buildTimelineItems(events, organizations).slice(0, 3);
   title="AI Governance Tracker"
   description="Tracking Canadian AI governance and policy — Senate hearings, legislation, and government action."
 >
-  <div class="py-8">
+  <div class="py-8 max-w-2xl">
     <h1 class="font-display text-5xl leading-tight text-header tracking-tight">
       AI Governance Tracker
     </h1>
-    <p class="mt-4 max-w-2xl text-base text-muted leading-relaxed">
+    <p class="mt-4 text-base text-muted leading-relaxed">
       AI is likely to have a transformational impact on human society, and governance of AI is important to ensure that this transformation goes well.
       The goal of this site is to be a resource for Canadians to understand the status of AI governance in Canada so that they can provide their own input into the ecosystem.
     </p>
     {latest.length > 0 && (
       <section class="mt-12">
-        <div class="flex items-baseline justify-between">
+        <div class="flex items-center justify-between gap-4">
           <h2 class="font-display text-2xl text-header">Latest activity</h2>
           <a
             href="/timeline/"
-            class="text-sm font-semibold text-accent-dark hover:text-header no-underline"
+            class="shrink-0 rounded-r-lg border border-border border-l-4 border-l-accent bg-surface px-4 py-2 text-sm font-semibold text-header hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
           >
             View full timeline →
           </a>
@@ -91,7 +91,7 @@ const latest = buildTimelineItems(events, organizations).slice(0, 3);
       </a>
     </div>
 
-    <section class="mt-12 max-w-2xl">
+    <section class="mt-12">
       <h2 class="font-display text-2xl text-header">About this project</h2>
       <p class="mt-3 text-base text-muted leading-relaxed">
         Policy on the full range of AI risks and benefits is given space here, but emphasis is on the scenarios with the largest potential impacts such as widespread deployment of advanced AI across the economy, increased bio and cyber risk, and the implications of highly capable systems. Within that scope, the site reports on government action and civil society inputs neutrally, without editorial comment.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import { fmtDate, humanizeType } from "../lib/format";
 const events = await getCollection("events");
 const organizations = await getCollection("organizations");
 
-const latest = buildTimelineItems(events, organizations).slice(0, 5);
+const latest = buildTimelineItems(events, organizations).slice(0, 3);
 ---
 
 <BaseLayout
@@ -55,7 +55,7 @@ const latest = buildTimelineItems(events, organizations).slice(0, 5);
             View full timeline →
           </a>
         </div>
-        <ol class="mt-6 border-l-2 border-accent">
+        <ol aria-label="Latest activity" class="mt-6 border-l-2 border-accent">
           {latest.map((item) => {
             const badge = sourceBadge[item.sourceCategory];
             return (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,14 @@
 ---
+import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { buildTimelineItems } from "../lib/timeline";
+import { sourceBadge, sourceDotColor } from "../lib/sourceCategory";
+import { fmtDate, humanizeType } from "../lib/format";
+
+const events = await getCollection("events");
+const organizations = await getCollection("organizations");
+
+const latest = buildTimelineItems(events, organizations).slice(0, 5);
 ---
 
 <BaseLayout
@@ -34,6 +43,53 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         Contribute via GitHub
       </a>
     </div>
+
+    {latest.length > 0 && (
+      <section class="mt-12">
+        <div class="flex items-baseline justify-between">
+          <h2 class="font-display text-2xl text-header">Latest activity</h2>
+          <a
+            href="/timeline/"
+            class="text-sm font-semibold text-accent-dark hover:text-header no-underline"
+          >
+            View full timeline →
+          </a>
+        </div>
+        <ol class="mt-6 border-l-2 border-accent">
+          {latest.map((item) => {
+            const badge = sourceBadge[item.sourceCategory];
+            return (
+              <li class="relative pl-7 pb-6">
+                <span
+                  class="absolute -left-[5px] top-[7px] h-2.5 w-2.5 rounded-full ring-2 ring-body"
+                  style={{ background: sourceDotColor[item.sourceCategory] }}
+                />
+                <time
+                  datetime={item.date}
+                  class="block text-xs text-faint font-medium mb-1"
+                >
+                  {fmtDate(item.date)}
+                </time>
+                <h3 class="font-serif text-base font-semibold text-header leading-snug mb-2">
+                  <a href={item.href} class="hover:text-accent-dark no-underline">
+                    {item.title}
+                  </a>
+                </h3>
+                <div class="flex flex-wrap gap-1.5 items-center">
+                  <span class="chip-type">{humanizeType(item.badge)}</span>
+                  <span
+                    class="text-xs font-bold rounded-full px-2 py-0.5"
+                    style={badge.style}
+                  >
+                    {badge.label}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </section>
+    )}
 
     <div class="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2">
       <a

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ const latest = buildTimelineItems(events, organizations).slice(0, 3);
     <h1 class="font-display text-5xl leading-tight text-header tracking-tight">
       AI Governance Tracker
     </h1>
-    <p class="mt-4 max-w-xl text-base text-muted leading-relaxed">
+    <p class="mt-4 max-w-2xl text-base text-muted leading-relaxed">
       AI is likely to have a transformational impact on human society, and governance of AI is important to ensure that this transformation goes well.
       The goal of this site is to be a resource for Canadians to understand the status of AI governance in Canada so that they can provide their own input into the ecosystem.
     </p>

--- a/src/pages/timeline/index.astro
+++ b/src/pages/timeline/index.astro
@@ -2,42 +2,19 @@
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import TimelineWithFilter from "../../components/TimelineWithFilter";
-import type { TimelineItem, OrgOption } from "../../lib/timeline";
-import { getSourceCategory } from "../../lib/sourceCategory";
+import { buildTimelineItems, type OrgOption } from "../../lib/timeline";
 
 const events = await getCollection("events");
 const organizations = await getCollection("organizations");
 
-const orgMap = new Map<string, { name: string; short_name?: string; schema_type: string }>();
-for (const org of organizations) {
-  orgMap.set(org.id, {
-    name: org.data.name,
-    short_name: org.data.short_name,
-    schema_type: org.data.schema_type,
-  });
-}
+const items = buildTimelineItems(events, organizations);
 
-const items: TimelineItem[] = events
-  .map((e) => ({
-    id: e.id,
-    kind: "event" as const,
-    title: e.data.title,
-    date: e.data.date.toISOString(),
-    description: e.data.description,
-    tags: e.data.tags,
-    href: `/events/${e.id}/`,
-    badge: e.data.type,
-    orgIds: e.data.organizations.map((o) => o.id.id),
-    orgs: e.data.organizations.map((o) => {
-      const org = orgMap.get(o.id.id);
-      return { id: o.id.id, label: org?.short_name ?? org?.name ?? o.id.id };
-    }),
-    links: e.data.links,
-    sourceCategory: getSourceCategory(
-      e.data.organizations.map((o) => orgMap.get(o.id.id)?.schema_type ?? "Organization"),
-    ),
-  }))
-  .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+const orgMap = new Map(
+  organizations.map((org) => [
+    org.id,
+    { name: org.data.name, short_name: org.data.short_name },
+  ]),
+);
 
 const orgCounts = new Map<string, number>();
 for (const item of items) {


### PR DESCRIPTION
## What

Adds a **Latest activity** section to the homepage showing the five most recent timeline entries (date, title, type, and source badge), each linking through to the event. A "View full timeline →" link sits alongside the heading.

This is idea #1 from the new `docs/homepage-ideas.md` brainstorm. The homepage was previously entirely static — it *described* the site but showed none of the content it tracks, looking identical regardless of how much data existed. Surfacing recent activity makes the page reflect the living state of Canadian AI governance.

## How

- Extracted the event → `TimelineItem` mapping out of `timeline/index.astro` into a shared, unit-tested `buildTimelineItems()` helper in `src/lib/timeline.ts`. Both the timeline page and the new homepage section use it.
- The homepage preview is plain Astro markup (no React island / `client:load`) since it has no interactivity — reuses the existing timeline visual language (colored source dots, type chip, source badge).
- Recorded the full set of homepage ideas in `docs/homepage-ideas.md` for follow-up (#2 stat strip, #3 policy scoreboard, etc.).

## Test plan

- [x] `pnpm test` — 86 passing, including 5 new `buildTimelineItems` cases (sort order, org-label resolution + fallback, sourceCategory derivation, href/orgIds)
- [x] `pnpm build` — succeeds; built `dist/index.html` contains the section with the 5 newest events newest-first
- [ ] CI `Test / unit` and `Test / e2e` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)