### PR TITLE
Fix ControlAI org card title styling to match other cards

### DIFF
--- a/src/components/OrgsWithCountryFilter.tsx
+++ b/src/components/OrgsWithCountryFilter.tsx
@@ -74,16 +74,18 @@ export default function OrgsWithCountryFilter({ orgs }: Props) {
               href={`/orgs/${org.id}/`}
               className="block rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
             >
-              {org.short_name && (
+              {org.short_name ? (
+                <>
+                  <div className="text-base font-bold text-header">
+                    {org.short_name}
+                  </div>
+                  <div className="mt-0.5 text-sm text-muted">{org.name}</div>
+                </>
+              ) : (
                 <div className="text-base font-bold text-header">
-                  {org.short_name}
+                  {org.name}
                 </div>
               )}
-              <div
-                className={`text-sm text-muted ${org.short_name ? "mt-0.5" : "font-bold text-base text-header"}`}
-              >
-                {org.name}
-              </div>
               <div className="mt-1 text-xs text-faint">
                 {COUNTRY_LABELS[org.country] ?? org.country.toUpperCase()}
               </div>


### PR DESCRIPTION
## Summary

The ControlAI org card rendered its title in a noticeably different style (smaller, muted) than every other organization card.

**Cause:** ControlAI is the only org without a `short_name`. The card's title markup always rendered the full `name` in a subtitle `<div>` (`text-sm text-muted`) and, for orgs lacking a `short_name`, tried to promote it to a title by appending `font-bold text-base text-header`. That produced conflicting Tailwind utilities (`text-sm`+`text-base`, `text-muted`+`text-header`), so the title rendered inconsistently with the clean `text-base font-bold text-header` used by every other card's primary title.

**Fix:** Branch explicitly on `short_name`. The primary title now always uses the same `text-base font-bold text-header` styling — the short name for orgs that have one, the full name otherwise. The full-name subtitle only renders when a short name is present.

## Test plan

- [x] `npx vitest run src/components/OrgsWithCountryFilter.test.tsx` — 7/7 pass
- [ ] CI `Test / unit` and `Test / e2e` green
- [ ] Visual check: ControlAI card title matches other org cards on `/orgs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)