### PR TITLE
Add Bill C-34 and Bill C-36 with their AI provisions (#97)

### DIFF
--- a/data/artifacts/2022-06-16-bill-c27-aida.yaml
+++ b/data/artifacts/2022-06-16-bill-c27-aida.yaml
@@ -14,7 +14,7 @@ organizations:
   - id: house-of-commons-indu-committee
     role: reviewed_by
 
-description: >
+description: |
   The Digital Charter Implementation Act, 2022 bundled three components: the
   Consumer Privacy Protection Act, the Personal Information and Data Protection
   Tribunal Act, and the Artificial Intelligence and Data Act (AIDA) — Canada's

--- a/data/artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
+++ b/data/artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
@@ -33,11 +33,13 @@ description: >
   use natural-language interfaces to give adaptive, human-like conversational
   responses, can simulate sustained human-like relationships across sessions,
   and generate output that is not fully predetermined by their developers or
-  operators. Such services are brought under a chatbot-tailored duty to act
-  responsibly, with specific obligations around crisis situations and named
-  harmful behaviours — a legislative response to concerns about AI companions
-  forming parasocial relationships with vulnerable users and giving harmful
-  advice while appearing authoritative.
+  operators.
+
+  Such services are brought under a chatbot-tailored duty to act responsibly,
+  with specific obligations around crisis situations and named harmful
+  behaviours — a legislative response to concerns about AI companions forming
+  parasocial relationships with vulnerable users and giving harmful advice
+  while appearing authoritative.
 
   As of writing the bill sits at first reading; Parliament rises for the summer
   on 19 June 2026, with sittings resuming 21 September 2026.

--- a/data/artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
+++ b/data/artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
@@ -14,7 +14,7 @@ organizations:
   - id: canadian-heritage
     role: sponsor
 
-description: >
+description: |
   The Safe Social Media Act (Bill C-34) would enact two new statutes — the
   Digital Safety Act and the Digital Safety Commission of Canada Act — creating
   a federal online-safety regime aimed primarily at protecting children. It was

--- a/data/artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
+++ b/data/artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
@@ -1,0 +1,117 @@
+# artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
+
+id: bill-c34-safe-social-media-act
+type: Legislation
+schema_type: CreativeWork
+
+title: "Bill C-34 — Safe Social Media Act"
+published_date: 2026-06-10  # introduction / first reading date
+
+lifecycle_status: active
+current_stage: "First reading in the House of Commons, 10 June 2026"
+
+organizations:
+  - id: canadian-heritage
+    role: sponsor
+
+description: >
+  The Safe Social Media Act (Bill C-34) would enact two new statutes — the
+  Digital Safety Act and the Digital Safety Commission of Canada Act — creating
+  a federal online-safety regime aimed primarily at protecting children. It was
+  introduced by Marc Miller, Minister of Canadian Identity and Culture, on
+  10 June 2026.
+
+  Its headline measures are a minimum account age of 16 for social media
+  services (with an exemption pathway for services that can demonstrate adequate
+  child safeguards), mandated age verification, platform "duty to act
+  responsibly" obligations, and a new Digital Safety Commission of Canada to
+  administer and enforce the Act and support victims of online harms.
+
+  The bill is notable for this tracker because it is the first Canadian
+  legislation to directly regulate AI chatbots. It defines "chatbot services"
+  as AI systems that communicate over the internet, are publicly accessible,
+  use natural-language interfaces to give adaptive, human-like conversational
+  responses, can simulate sustained human-like relationships across sessions,
+  and generate output that is not fully predetermined by their developers or
+  operators. Such services are brought under a chatbot-tailored duty to act
+  responsibly, with specific obligations around crisis situations and named
+  harmful behaviours — a legislative response to concerns about AI companions
+  forming parasocial relationships with vulnerable users and giving harmful
+  advice while appearing authoritative.
+
+  As of writing the bill sits at first reading; Parliament rises for the summer
+  on 19 June 2026, with sittings resuming 21 September 2026.
+
+stages:
+  - date: 2026-06-10
+    stage: "Introduction and first reading"
+    note: "Bill C-34 introduced in the House of Commons by the Minister of Canadian Identity and Culture."
+
+provisions:
+  - id: chatbot-scope
+    title: "Scope: AI chatbot services"
+    summary: >
+      Bring "chatbot services" within the regime — AI systems that communicate
+      over the internet, are publicly accessible via websites or apps, use
+      natural-language interfaces for adaptive human-like conversation, can
+      simulate sustained human-like relationships across multiple sessions, and
+      produce output not fully predetermined by developers or operators.
+  - id: chatbot-duty-to-act-responsibly
+    title: "Chatbot duty to act responsibly"
+    summary: >
+      Subject chatbot operators to a duty to act responsibly tailored to
+      chatbots: mitigate the risk that the chatbot communicates harmful content,
+      implement emergency measures for crisis situations, and mitigate the risk
+      that the chatbot engages in harmful behaviour.
+  - id: chatbot-crisis-measures
+    title: "Crisis intervention for self-harm"
+    summary: >
+      Require chatbots to interrupt the conversation and direct users to human
+      crisis support when a user expresses suicidal thoughts or an intention to
+      self-harm.
+  - id: chatbot-prohibited-behaviours
+    title: "Named harmful chatbot behaviours"
+    summary: >
+      Require operators to curb four named behaviours: posing as a human,
+      posing as a licensed professional, using manipulative techniques that
+      build emotional dependency, and encouraging self-harm or suicide.
+  - id: under-16-social-media-ban
+    title: "Minimum account age of 16"
+    summary: >
+      Prohibit children under 16 from holding accounts on social media services,
+      with a pathway for services to seek an exemption if they can demonstrate
+      sufficient safeguards for children. Age-appropriate protections extend to
+      regulated chatbot services.
+  - id: digital-safety-commission
+    title: "Digital Safety Commission of Canada"
+    summary: >
+      Establish a Digital Safety Commission of Canada to administer and enforce
+      the Digital Safety Act, oversee regulated operators (including chatbot
+      services), and support victims of online harms.
+
+links:
+  - label: "LEGISinfo — Bill C-34 (45-1)"
+    url: https://www.parl.ca/legisinfo/en/bill/45-1/c-34
+    icon: document
+  - label: "Bill C-34 — First Reading text"
+    url: https://www.parl.ca/DocumentViewer/en/45-1/bill/C-34/first-reading
+    icon: document
+  - label: "Canada.ca — Bill C-34, the Safe Social Media Act"
+    url: https://www.canada.ca/en/canadian-heritage/services/safe-social-media-act.html
+    icon: document
+  - label: "Backgrounder — legislation to make social media and AI chatbots safer for children (Canadian Heritage)"
+    url: https://www.canada.ca/en/canadian-heritage/news/2026/06/government-of-canada-introduces-legislation-to-make-social-media-services-and-ai-chatbots-safer-for-children.html
+    icon: document
+  - label: "Michael Geist — Everything All At Once: Bill C-34 combines platform duties, a kids' social media ban, AI chatbot regulation, and a powerful Digital Safety Commission"
+    url: https://www.michaelgeist.ca/2026/06/everything-all-at-once-bill-c-34-combines-platform-duties-a-kids-social-media-ban-ai-chatbot-regulation-and-a-powerful-digital-safety-commission-into-a-risky-trust-us-bet/
+    icon: document
+
+tags:
+  - bill-c-34
+  - safe-social-media-act
+  - digital-safety-act
+  - digital-safety-commission
+  - ai-chatbots
+  - online-harms
+  - child-safety
+  - federal-government

--- a/data/artifacts/2026-06-15-bill-c36-ppcda.yaml
+++ b/data/artifacts/2026-06-15-bill-c36-ppcda.yaml
@@ -18,7 +18,7 @@ derives_from:
   - id: canada-national-ai-strategy-launched-2026
     relationship: advances
 
-description: >
+description: |
   Bill C-36 would enact the Protecting Privacy and Consumer Data Act (PPCDA),
   amend the Personal Information Protection and Electronic Documents Act
   (PIPEDA), and make related amendments to other Acts. It was tabled on

--- a/data/artifacts/2026-06-15-bill-c36-ppcda.yaml
+++ b/data/artifacts/2026-06-15-bill-c36-ppcda.yaml
@@ -1,0 +1,118 @@
+# artifacts/2026-06-15-bill-c36-ppcda.yaml
+
+id: bill-c36-ppcda
+type: Legislation
+schema_type: CreativeWork
+
+title: "Bill C-36 — Protecting Privacy and Consumer Data Act"
+published_date: 2026-06-15  # introduction / first reading date
+
+lifecycle_status: active
+current_stage: "First reading in the House of Commons, 15 June 2026"
+
+organizations:
+  - id: ised-canada
+    role: sponsor
+
+derives_from:
+  - id: canada-national-ai-strategy-launched-2026
+    relationship: advances
+
+description: >
+  Bill C-36 would enact the Protecting Privacy and Consumer Data Act (PPCDA),
+  amend the Personal Information Protection and Electronic Documents Act
+  (PIPEDA), and make related amendments to other Acts. It was tabled on
+  15 June 2026 by Evan Solomon, Minister of Artificial Intelligence and Digital
+  Innovation, and is the Carney government's successor to the private-sector
+  privacy reforms that died with Bill C-27 (AIDA) on prorogation in January
+  2025.
+
+  The bill recognizes privacy as a fundamental right and establishes a new
+  Digital Safety and Data Protection Commission of Canada with enhanced
+  enforcement powers, penalties, transparency obligations, and individual
+  rights (including data deletion). Commentators have noted it shifts
+  private-sector privacy oversight away from the Privacy Commissioner toward a
+  larger, multi-mandate commission.
+
+  The government frames Bill C-36 as a "cornerstone" of its National AI
+  Strategy — AI for All: by giving Canadians more control over their personal
+  data, it aims to build the public trust needed for higher adoption of AI
+  tools. Its most directly AI-relevant provisions govern automated
+  decision-making systems — tools that use AI, machine learning, or predictive
+  analytics to assist or replace human judgment — for which organizations would
+  owe transparency and disclosure obligations where a decision could have a
+  significant impact on an individual, and under which unfair or discriminatory
+  profiling may be treated as an inappropriate data practice. Civil-liberties
+  groups (CCLA) have criticized the bill for broad exceptions and for not going
+  far enough on documented AI harms.
+
+  Notably, this bill carries forward only the privacy reforms of the former
+  Bill C-27; it does not re-introduce AIDA, leaving Canada without dedicated
+  AI-specific legislation. As of writing the bill sits at first reading;
+  Parliament rises for the summer on 19 June 2026, with the government expected
+  to consult over the summer ahead of sittings resuming 21 September 2026.
+
+stages:
+  - date: 2026-06-15
+    stage: "Introduction and first reading"
+    note: "Bill C-36 introduced in the House of Commons by the Minister of Artificial Intelligence and Digital Innovation."
+
+provisions:
+  - id: automated-decision-making-scope
+    title: "Scope: automated decision-making systems"
+    summary: >
+      Define and regulate automated decision-making systems — tools that use
+      AI, machine learning, or predictive analytics to assist or replace human
+      judgment in decisions about individuals.
+  - id: automated-decision-transparency
+    title: "Transparency for automated decisions"
+    summary: >
+      Require organizations to make information available about their use of any
+      automated decision-making system that could have a significant impact on
+      an individual.
+  - id: profiling-appropriateness
+    title: "Profiling and inappropriate data practices"
+    summary: >
+      Treat profiling or categorization that leads to unfair, unethical, or
+      discriminatory treatment contrary to human-rights law as an inappropriate
+      data practice.
+  - id: privacy-fundamental-right
+    title: "Privacy as a fundamental right"
+    summary: >
+      Recognize privacy as a fundamental right and strengthen individual rights,
+      including consumer rights to control and delete personal data.
+  - id: digital-safety-data-protection-commission
+    title: "Digital Safety and Data Protection Commission of Canada"
+    summary: >
+      Establish a Digital Safety and Data Protection Commission of Canada to
+      administer the regime with enhanced enforcement powers, penalties, and
+      transparency obligations, taking over private-sector privacy oversight.
+
+links:
+  - label: "LEGISinfo — Bill C-36 (45-1)"
+    url: https://www.parl.ca/legisinfo/en/bill/45-1/c-36
+    icon: document
+  - label: "Bill C-36 — First Reading text"
+    url: https://www.parl.ca/DocumentViewer/en/45-1/bill/C-36/first-reading
+    icon: document
+  - label: "Backgrounder — legislation to protect Canadians' privacy in the digital age (ISED)"
+    url: https://www.canada.ca/en/innovation-science-economic-development/news/2026/06/government-of-canada-introduces-legislation-to-protect-canadians-privacy-in-the-digital-age.html
+    icon: document
+  - label: "Michael Geist — Canada's Digital Super-Regulator: Bill C-36 pushes out the Privacy Commissioner"
+    url: https://www.michaelgeist.ca/2026/06/canadas-digital-super-regulator-bill-c-36-pushes-out-the-privacy-commissioner-and-hands-private-sector-privacy-to-an-overloaded-commission/
+    icon: document
+  - label: "CCLA — Bill C-36 proposes empty privacy protections and little to address AI harms"
+    url: https://ccla.org/press-release/proposed-bill-c-36-protecting-privacy-and-consumer-data-act-erodes-federal-privacy-rights-and-fails-to-meaningfully-address-well-documented-ai-harms/
+    icon: document
+
+tags:
+  - bill-c-36
+  - protecting-privacy-and-consumer-data-act
+  - ppcda
+  - pipeda
+  - privacy
+  - automated-decision-making
+  - digital-safety-and-data-protection-commission
+  - ai-for-all
+  - evan-solomon
+  - federal-government

--- a/data/artifacts/2026-06-15-bill-c36-ppcda.yaml
+++ b/data/artifacts/2026-06-15-bill-c36-ppcda.yaml
@@ -30,27 +30,34 @@ description: >
   The bill recognizes privacy as a fundamental right and establishes a new
   Digital Safety and Data Protection Commission of Canada with enhanced
   enforcement powers, penalties, transparency obligations, and individual
-  rights (including data deletion). Commentators have noted it shifts
-  private-sector privacy oversight away from the Privacy Commissioner toward a
-  larger, multi-mandate commission.
+  rights (including data deletion).
 
   The government frames Bill C-36 as a "cornerstone" of its National AI
   Strategy — AI for All: by giving Canadians more control over their personal
   data, it aims to build the public trust needed for higher adoption of AI
-  tools. Its most directly AI-relevant provisions govern automated
-  decision-making systems — tools that use AI, machine learning, or predictive
-  analytics to assist or replace human judgment — for which organizations would
-  owe transparency and disclosure obligations where a decision could have a
+  tools.
+
+  Its most directly AI-relevant provisions govern automated decision-making
+  systems — tools that use AI, machine learning, or predictive analytics to
+  assist or replace human judgment — for which organizations would owe
+  transparency and disclosure obligations where a decision could have a
   significant impact on an individual, and under which unfair or discriminatory
-  profiling may be treated as an inappropriate data practice. Civil-liberties
-  groups (CCLA) have criticized the bill for broad exceptions and for not going
-  far enough on documented AI harms.
+  profiling may be treated as an inappropriate data practice.
 
   Notably, this bill carries forward only the privacy reforms of the former
   Bill C-27; it does not re-introduce AIDA, leaving Canada without dedicated
-  AI-specific legislation. As of writing the bill sits at first reading;
-  Parliament rises for the summer on 19 June 2026, with the government expected
-  to consult over the summer ahead of sittings resuming 21 September 2026.
+  AI-specific legislation.
+
+  The points above summarize what the bill says; the following reaction is
+  editorial. Commentators such as Michael Geist have noted the bill shifts
+  private-sector privacy oversight away from the Privacy Commissioner toward a
+  larger, multi-mandate commission, while civil-liberties groups such as the
+  CCLA have criticized it for broad exceptions and for not going far enough on
+  documented AI harms.
+
+  As of writing the bill sits at first reading; Parliament rises for the summer
+  on 19 June 2026, with the government expected to consult over the summer
+  ahead of sittings resuming 21 September 2026.
 
 stages:
   - date: 2026-06-15

--- a/data/events/2026-06-10-bill-c34-introduced.yaml
+++ b/data/events/2026-06-10-bill-c34-introduced.yaml
@@ -1,0 +1,38 @@
+# events/2026-06-10-bill-c34-introduced.yaml
+
+id: bill-c34-introduced-2026
+type: LegislativeAction
+schema_type: Event
+
+title: "Bill C-34 (Safe Social Media Act) introduced in the House of Commons (first reading)"
+date: 2026-06-10
+
+status: completed
+
+description: >
+  The Safe Social Media Act (Bill C-34) is introduced and receives first
+  reading in the House of Commons, tabled by Marc Miller, Minister of Canadian
+  Identity and Culture. It would enact the Digital Safety Act and the Digital
+  Safety Commission of Canada Act and is the first Canadian legislation to
+  directly regulate AI chatbot services — subjecting them to a duty to act
+  responsibly alongside a minimum social media account age of 16 and a new
+  Digital Safety Commission of Canada.
+
+organizations:
+  - id: canadian-heritage
+    role: introduced_by
+
+related_artifacts:
+  - id: bill-c34-safe-social-media-act
+
+tags:
+  - bill-c-34
+  - safe-social-media-act
+  - ai-chatbots
+  - federal-government
+  - house-of-commons
+
+links:
+  - label: "LEGISinfo — Bill C-34 (45-1)"
+    url: https://www.parl.ca/legisinfo/en/bill/45-1/c-34
+    icon: document

--- a/data/events/2026-06-15-bill-c36-introduced.yaml
+++ b/data/events/2026-06-15-bill-c36-introduced.yaml
@@ -1,0 +1,39 @@
+# events/2026-06-15-bill-c36-introduced.yaml
+
+id: bill-c36-introduced-2026
+type: LegislativeAction
+schema_type: Event
+
+title: "Bill C-36 (Protecting Privacy and Consumer Data Act) introduced in the House of Commons (first reading)"
+date: 2026-06-15
+
+status: completed
+
+description: >
+  The Protecting Privacy and Consumer Data Act (Bill C-36) is introduced and
+  receives first reading in the House of Commons, tabled by Evan Solomon,
+  Minister of Artificial Intelligence and Digital Innovation. It would enact the
+  PPCDA, amend PIPEDA, and establish a Digital Safety and Data Protection
+  Commission of Canada. Framed as a cornerstone of the AI for All national
+  strategy, it regulates automated decision-making systems and carries forward
+  the privacy reforms of the former Bill C-27 without re-introducing AIDA.
+
+organizations:
+  - id: ised-canada
+    role: introduced_by
+
+related_artifacts:
+  - id: bill-c36-ppcda
+
+tags:
+  - bill-c-36
+  - protecting-privacy-and-consumer-data-act
+  - automated-decision-making
+  - ai-for-all
+  - federal-government
+  - house-of-commons
+
+links:
+  - label: "LEGISinfo — Bill C-36 (45-1)"
+    url: https://www.parl.ca/legisinfo/en/bill/45-1/c-36
+    icon: document

--- a/data/organizations/canadian-heritage.yaml
+++ b/data/organizations/canadian-heritage.yaml
@@ -1,0 +1,15 @@
+# organizations/canadian-heritage.yaml
+
+id: canadian-heritage
+type: GovernmentOrganization
+schema_type: GovernmentOrganization
+country: ca
+
+name: "Department of Canadian Heritage"
+short_name: "PCH"
+url: https://www.canada.ca/en/canadian-heritage.html
+wikipedia: https://en.wikipedia.org/wiki/Department_of_Canadian_Heritage
+
+tags:
+  - federal-government
+  - canadian

--- a/e2e/policy.spec.ts
+++ b/e2e/policy.spec.ts
@@ -12,7 +12,10 @@ test.describe("policy page", () => {
 
   test("legislation card shows title, status badge, and stage", async ({ page }) => {
     await page.goto("/policy/");
-    const card = page.getByRole("link", { name: /Bill C-27/i });
+    // Target the card by its unique href: the whole card is one link whose
+    // accessible name includes the description, so a name regex like /Bill C-27/i
+    // also matches other cards (e.g. C-36) that mention C-27 in their text.
+    const card = page.locator('a[href="/artifacts/bill-c27-aida/"]');
     await expect(card).toBeVisible();
     await expect(card).toContainText("Died");
     await expect(card).toContainText("Died on the Order Paper");
@@ -20,7 +23,7 @@ test.describe("policy page", () => {
 
   test("legislation card links to artifact detail page", async ({ page }) => {
     await page.goto("/policy/");
-    await page.getByRole("link", { name: /Bill C-27/i }).click();
+    await page.locator('a[href="/artifacts/bill-c27-aida/"]').click();
     await expect(page).toHaveURL(/\/artifacts\/bill-c27-aida\//);
   });
 


### PR DESCRIPTION
Closes #97.

Adds two active 45th-Parliament bills as legislative artifacts (plus introduction events), modelled per the `adding-legislation` skill. Both are at first reading as of 18 June 2026, so each gets one introduction event and no final-status event.

## Bill C-34 — Safe Social Media Act (introduced 10 June 2026)
Sponsor: Marc Miller, Minister of Canadian Identity and Culture (Department of Canadian Heritage). Enacts the Digital Safety Act and the Digital Safety Commission of Canada Act.

**Why it's on this tracker — AI angle:** the first Canadian legislation to directly regulate AI chatbots. It defines "chatbot services" as AI systems with adaptive, human-like, non-predetermined conversational output that can simulate sustained relationships, and imposes a chatbot-tailored duty to act responsibly:
- mitigate harmful content;
- crisis intervention — interrupt and steer users to human help on suicidal ideation/self-harm;
- curb four named behaviours: posing as a human, posing as a licensed professional, manipulative techniques that build emotional dependency, and encouraging self-harm/suicide.

(The under-16 account ban, age verification, and platform duties are captured for completeness but are not AI-specific.)

## Bill C-36 — Protecting Privacy and Consumer Data Act (introduced 15 June 2026)
Sponsor: Evan Solomon, Minister of Artificial Intelligence and Digital Innovation (ISED). Enacts the PPCDA, amends PIPEDA, and creates a Digital Safety and Data Protection Commission of Canada. Linked via `derives_from` to the AI for All strategy launch event.

**AI angle:** framed as a "cornerstone" of the AI for All strategy (trust → AI adoption). Regulates automated decision-making systems (AI/ML/predictive analytics) with transparency/disclosure duties for significant-impact decisions, and treats unfair/discriminatory profiling as an inappropriate data practice. Notably it carries forward only Bill C-27's privacy reforms — it does **not** re-introduce AIDA, leaving Canada without dedicated AI-specific legislation.

## Also
- New `data/organizations/canadian-heritage.yaml` (sponsor of C-34).

## Test plan
- [x] `npm test` — 86 passed
- [x] `npm run build` — 59 pages built; both bill artifact/event pages and the new org page generated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)