### PR TITLE
Add Hiroshima AI Process and a Canada/International jurisdiction selector (#101)

### DIFF
--- a/data/artifacts/2023-05-19-hiroshima-ai-process.yaml
+++ b/data/artifacts/2023-05-19-hiroshima-ai-process.yaml
@@ -1,0 +1,100 @@
+# artifacts/2023-05-19-hiroshima-ai-process.yaml
+
+id: hiroshima-ai-process
+type: PolicyDocument
+schema_type: CreativeWork
+jurisdiction: international
+
+title: "Hiroshima AI Process — G7 code of conduct and reporting framework for advanced AI"
+published_date: 2023-05-19
+
+organizations:
+  - id: g7
+    role: initiator
+  - id: oecd
+    role: implementing_partner
+
+description: |
+  The Hiroshima AI Process (HAIP) is the G7's initiative for international
+  governance of advanced AI systems, launched at the G7 Hiroshima Summit in
+  May 2023 under Japan's presidency. It produced the International Guiding
+  Principles on AI and the International Code of Conduct for Organizations
+  Developing Advanced AI Systems (October 2023) — voluntary commitments on
+  risk assessment, incident reporting, transparency, and information sharing
+  for developers of the most advanced AI systems.
+
+  In February 2025 the OECD operationalized the Code of Conduct by launching
+  the HAIP Reporting Framework at the Paris AI Action Summit — the first
+  global framework through which companies report, in comparable form, on
+  their AI risk management practices. A streamlined version 2.0 of the
+  reporting framework followed on 28 May 2026, launched at a Tech7 event
+  alongside the G7 Digital and Tech Ministerial Meeting in Paris, designed to
+  make participation practical for small and medium-sized enterprises; more
+  than 50 organizations pledged to submit reports under the new framework,
+  with submissions requested by 1 September 2026 for the next analytical
+  review.
+
+  Canada participates as a G7 member, and its 2025 G7 presidency carried the
+  work forward: the leaders' statement on AI for Prosperity issued at the
+  Kananaskis Summit commits to building on the Hiroshima AI Process to
+  strengthen trust in AI through voluntary, standards-based frameworks.
+
+stages:
+  - date: 2023-05-19
+    stage: "Launched at the G7 Hiroshima Summit"
+    note: "G7 leaders, under Japan's presidency, establish the Hiroshima AI Process to develop international governance of generative and advanced AI."
+    links:
+      - label: "G7 Hiroshima Leaders' Communiqué"
+        url: https://www.g7.utoronto.ca/summit/2023hiroshima/230520-communique.html
+        icon: document
+  - date: 2023-10-30
+    stage: "International Guiding Principles and Code of Conduct published"
+    note: "G7 leaders issue the International Guiding Principles on AI and the voluntary International Code of Conduct for Organizations Developing Advanced AI Systems."
+    links:
+      - label: "Hiroshima Process International Code of Conduct"
+        url: https://digital-strategy.ec.europa.eu/en/library/hiroshima-process-international-code-conduct-advanced-ai-systems
+        icon: document
+  - date: 2023-12-01
+    stage: "Comprehensive Policy Framework endorsed"
+    note: "G7 digital and tech ministers endorse the Hiroshima AI Process Comprehensive Policy Framework, wrapping up Japan's presidency."
+  - date: 2025-02-07
+    stage: "OECD launches the HAIP Reporting Framework"
+    note: "Launched at the Paris AI Action Summit; companies report on their application of the Code of Conduct, with inaugural reports invited by 15 April 2025."
+    links:
+      - label: "OECD press release"
+        url: https://www.oecd.org/en/about/news/press-releases/2025/02/oecd-launches-global-framework-to-monitor-application-of-g7-hiroshima-ai-code-of-conduct.html
+        icon: document
+  - date: 2025-06-17
+    stage: "Canada's G7 presidency builds on HAIP"
+    note: "The G7 Leaders' Statement on AI for Prosperity, issued at the Kananaskis Summit under Canada's presidency, commits to leveraging HAIP outcomes to foster trust in AI."
+    links:
+      - label: "G7 Leaders' Statement on AI for Prosperity"
+        url: https://www.pm.gc.ca/en/news/statements/2025/06/17/g7-leaders-statement-ai-prosperity
+        icon: document
+  - date: 2026-05-28
+    stage: "OECD launches HAIP Reporting Framework 2.0"
+    note: "Streamlined framework launched at a Tech7 event alongside the G7 Digital and Tech Ministerial in Paris, lowering the reporting burden so SMEs can participate; 50+ organizations pledged reports, requested by 1 September 2026."
+    links:
+      - label: "OECD.AI launch page"
+        url: https://oecd.ai/en/haip-2-launch
+        icon: document
+
+links:
+  - label: "OECD.AI — Hiroshima AI Process"
+    url: https://oecd.ai/en/hiroshima
+    icon: website
+  - label: "HAIP transparency reports portal"
+    url: https://transparency.oecd.ai/
+    icon: website
+  - label: "Japan MIC — Hiroshima AI Process"
+    url: https://www.soumu.go.jp/hiroshimaaiprocess/en/
+    icon: website
+
+tags:
+  - hiroshima-ai-process
+  - g7
+  - oecd
+  - code-of-conduct
+  - reporting-framework
+  - transparency
+  - international

--- a/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+++ b/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
@@ -3,6 +3,7 @@
 id: international-ai-safety-report-2026
 type: Report
 schema_type: CreativeWork
+jurisdiction: international
 
 title: "International AI Safety Report 2026"
 published_date: 2026-02-01

--- a/data/events/2023-05-19-hiroshima-ai-process-launched.yaml
+++ b/data/events/2023-05-19-hiroshima-ai-process-launched.yaml
@@ -1,0 +1,41 @@
+# data/events/2023-05-19-hiroshima-ai-process-launched.yaml
+
+id: hiroshima-ai-process-launched
+type: GovernmentAnnouncement
+schema_type: Event
+jurisdiction: international
+title: "G7 leaders launch the Hiroshima AI Process"
+date: 2023-05-19
+status: completed
+
+location:
+  name: "Hiroshima, Japan"
+  schema_type: Place
+
+organizations:
+  - id: g7
+    role: convener
+
+description: >
+  At the Hiroshima Summit under Japan's presidency, G7 leaders establish the
+  Hiroshima AI Process to develop international governance of generative and
+  advanced AI — the workstream that later produces the International Code of
+  Conduct for Organizations Developing Advanced AI Systems and the OECD-run
+  HAIP Reporting Framework.
+
+related_artifacts:
+  - id: hiroshima-ai-process
+
+tags:
+  - hiroshima-ai-process
+  - g7
+  - generative-ai
+  - international
+
+links:
+  - label: "G7 Hiroshima Leaders' Communiqué"
+    url: https://www.g7.utoronto.ca/summit/2023hiroshima/230520-communique.html
+    icon: document
+  - label: "Japan MIC — Hiroshima AI Process"
+    url: https://www.soumu.go.jp/hiroshimaaiprocess/en/
+    icon: website

--- a/data/events/2026-02-01-international-ai-safety-report-2026-published.yaml
+++ b/data/events/2026-02-01-international-ai-safety-report-2026-published.yaml
@@ -3,6 +3,7 @@
 id: international-ai-safety-report-2026-published
 type: Publication
 schema_type: Event
+jurisdiction: international
 title: "DSIT publishes International AI Safety Report 2026 (Bengio et al.)"
 date: 2026-02-01
 

--- a/data/events/2026-05-28-haip-reporting-framework-2-launched.yaml
+++ b/data/events/2026-05-28-haip-reporting-framework-2-launched.yaml
@@ -1,0 +1,45 @@
+# data/events/2026-05-28-haip-reporting-framework-2-launched.yaml
+
+id: haip-reporting-framework-2-launched
+type: GovernmentAnnouncement
+schema_type: Event
+jurisdiction: international
+title: "OECD launches Hiroshima AI Process Reporting Framework 2.0"
+date: 2026-05-28
+status: completed
+
+location:
+  name: "Paris, France"
+  schema_type: Place
+
+organizations:
+  - id: oecd
+    role: publisher
+
+description: >
+  The OECD launches a streamlined version 2.0 of the Hiroshima AI Process
+  Reporting Framework at a Tech7 event alongside the G7 Digital and Tech
+  Ministerial Meeting in Paris. The revision lowers the reporting burden so
+  small and medium-sized enterprises can report on how they apply the G7 Code
+  of Conduct for advanced AI development; more than 50 organizations pledged
+  to submit reports, requested by 1 September 2026 for the next analytical
+  review.
+
+related_artifacts:
+  - id: hiroshima-ai-process
+
+tags:
+  - hiroshima-ai-process
+  - g7
+  - oecd
+  - reporting-framework
+  - transparency
+  - international
+
+links:
+  - label: "OECD.AI — HAIP 2.0 launch"
+    url: https://oecd.ai/en/haip-2-launch
+    icon: website
+  - label: "OECD press release"
+    url: https://www.oecd.org/en/about/news/press-releases/2026/05/oecd-launches-streamlined-hiroshima-ai-process-reporting-framework-to-help-small-and-medium-sized-enterprises-participate.html
+    icon: document

--- a/data/organizations/g7.yaml
+++ b/data/organizations/g7.yaml
@@ -1,0 +1,14 @@
+# organizations/g7.yaml
+
+id: g7
+type: IntergovernmentalForum
+schema_type: GovernmentOrganization
+country: international
+
+name: "Group of Seven"
+short_name: "G7"
+wikipedia: https://en.wikipedia.org/wiki/G7
+
+tags:
+  - intergovernmental
+  - international

--- a/data/organizations/oecd.yaml
+++ b/data/organizations/oecd.yaml
@@ -1,0 +1,16 @@
+# organizations/oecd.yaml
+
+id: oecd
+type: IntergovernmentalOrganization
+schema_type: GovernmentOrganization
+country: international
+
+name: "Organisation for Economic Co-operation and Development"
+short_name: "OECD"
+url: https://www.oecd.org
+wikipedia: https://en.wikipedia.org/wiki/OECD
+
+tags:
+  - intergovernmental
+  - international
+  - ai-policy

--- a/e2e/organizations.spec.ts
+++ b/e2e/organizations.spec.ts
@@ -26,6 +26,16 @@ test.describe("organizations page", () => {
     await expect(page).toHaveURL(/\/orgs\/$/);
   });
 
+  test("International country pill shows international orgs", async ({ page }) => {
+    await page.goto("/orgs/");
+    const countryFilter = page.getByLabel("Filter by country");
+
+    await countryFilter.getByRole("button", { name: "International" }).click();
+    await expect(page.locator('main a[href="/orgs/oecd/"]')).toBeVisible();
+    await expect(page.locator('main a[href="/orgs/g7/"]')).toBeVisible();
+    await expect(page.locator('main a[href="/orgs/ised-canada/"]')).toHaveCount(0);
+  });
+
   test("header nav contains Organizations link", async ({ page }) => {
     await page.goto("/");
     const nav = page.locator("header nav");

--- a/e2e/policy.spec.ts
+++ b/e2e/policy.spec.ts
@@ -27,6 +27,19 @@ test.describe("policy page", () => {
     await expect(page).toHaveURL(/\/artifacts\/bill-c27-aida\//);
   });
 
+  test("jurisdiction filter narrows policy cards to international", async ({ page }) => {
+    await page.goto("/policy/");
+    const jurisdictionFilter = page.getByLabel("Filter by jurisdiction");
+
+    await jurisdictionFilter.getByRole("button", { name: "International" }).click();
+    await expect(page.locator('a[href="/artifacts/hiroshima-ai-process/"]')).toBeVisible();
+    await expect(page.locator('a[href="/artifacts/bill-c27-aida/"]')).toHaveCount(0);
+
+    await jurisdictionFilter.getByRole("button", { name: "Canada" }).click();
+    await expect(page.locator('a[href="/artifacts/bill-c27-aida/"]')).toBeVisible();
+    await expect(page.locator('a[href="/artifacts/hiroshima-ai-process/"]')).toHaveCount(0);
+  });
+
   test("reports section shows at least one card", async ({ page }) => {
     await page.goto("/policy/");
     const section = page.locator("section").filter({ has: page.getByRole("heading", { name: "Reports" }) });

--- a/e2e/timeline.spec.ts
+++ b/e2e/timeline.spec.ts
@@ -60,6 +60,29 @@ test.describe("timeline", () => {
     await expect(orgFilterAll).toHaveAttribute("aria-pressed", "true");
   });
 
+  test("jurisdiction filter narrows to international events and back", async ({
+    page,
+  }) => {
+    await page.goto("/timeline/");
+    const jurisdictionFilter = page.getByLabel("Filter by jurisdiction");
+
+    await jurisdictionFilter.getByRole("button", { name: "International" }).click();
+    await expect(
+      page.getByRole("heading", { name: /Hiroshima AI Process Reporting Framework 2\.0/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: NON_CIGI_EVENT_TITLE }),
+    ).toHaveCount(0);
+
+    await jurisdictionFilter.getByRole("button", { name: "Canada" }).click();
+    await expect(
+      page.getByRole("heading", { name: NON_CIGI_EVENT_TITLE }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /Hiroshima AI Process Reporting Framework 2\.0/i }),
+    ).toHaveCount(0);
+  });
+
   test("timeline does not contain artifact entries", async ({ page }) => {
     await page.goto("/timeline/");
     const items = timelineItems(page);

--- a/src/components/JurisdictionFilter.test.tsx
+++ b/src/components/JurisdictionFilter.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import JurisdictionFilter from "./JurisdictionFilter";
+
+describe("JurisdictionFilter", () => {
+  it("renders All, Canada, and International buttons", () => {
+    render(<JurisdictionFilter selected="all" onSelect={() => {}} />);
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Canada" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "International" })).toBeInTheDocument();
+  });
+
+  it("sets aria-pressed='true' on the active button only", () => {
+    render(<JurisdictionFilter selected="international" onSelect={() => {}} />);
+    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Canada" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "International" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("calls onSelect with 'canada' when Canada is clicked", async () => {
+    const onSelect = vi.fn();
+    render(<JurisdictionFilter selected="all" onSelect={onSelect} />);
+    await userEvent.click(screen.getByRole("button", { name: "Canada" }));
+    expect(onSelect).toHaveBeenCalledWith("canada");
+  });
+
+  it("calls onSelect with 'international' when International is clicked", async () => {
+    const onSelect = vi.fn();
+    render(<JurisdictionFilter selected="all" onSelect={onSelect} />);
+    await userEvent.click(screen.getByRole("button", { name: "International" }));
+    expect(onSelect).toHaveBeenCalledWith("international");
+  });
+
+  it("calls onSelect with 'all' when All is clicked", async () => {
+    const onSelect = vi.fn();
+    render(<JurisdictionFilter selected="canada" onSelect={onSelect} />);
+    await userEvent.click(screen.getByRole("button", { name: "All" }));
+    expect(onSelect).toHaveBeenCalledWith("all");
+  });
+});

--- a/src/components/JurisdictionFilter.tsx
+++ b/src/components/JurisdictionFilter.tsx
@@ -1,0 +1,39 @@
+import type { Jurisdiction } from "../lib/jurisdiction";
+import { jurisdictionLabels } from "../lib/jurisdiction";
+
+type Option = { value: Jurisdiction | "all"; label: string };
+
+const OPTIONS: Option[] = [
+  { value: "all", label: "All" },
+  { value: "canada", label: jurisdictionLabels.canada },
+  { value: "international", label: jurisdictionLabels.international },
+];
+
+type Props = {
+  selected: Jurisdiction | "all";
+  onSelect: (jurisdiction: Jurisdiction | "all") => void;
+};
+
+export default function JurisdictionFilter({ selected, onSelect }: Props) {
+  const pillBase =
+    "rounded-full px-3 py-1 text-sm font-medium transition-colors cursor-pointer border";
+  const active = "bg-header text-white border-header";
+  const inactive =
+    "bg-body text-muted border-border hover:bg-surface hover:text-ink";
+
+  return (
+    <div role="group" aria-label="Filter by jurisdiction" className="flex flex-wrap gap-2">
+      {OPTIONS.map(({ value, label }) => (
+        <button
+          key={value}
+          type="button"
+          aria-pressed={selected === value}
+          className={`${pillBase} ${selected === value ? active : inactive}`}
+          onClick={() => onSelect(value)}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/OrgsWithCountryFilter.test.tsx
+++ b/src/components/OrgsWithCountryFilter.test.tsx
@@ -85,6 +85,29 @@ describe("OrgsWithCountryFilter", () => {
     expect(screen.getAllByText("Canada").length).toBeGreaterThanOrEqual(2);
   });
 
+  it("filters to international orgs when International pill is clicked", async () => {
+    const orgsWithIntl = [
+      ...orgs,
+      {
+        id: "oecd",
+        name: "Organisation for Economic Co-operation and Development",
+        short_name: "OECD",
+        country: "international" as const,
+        tags: ["intergovernmental"],
+        events: 1,
+        artifacts: 1,
+      },
+    ];
+    render(<OrgsWithCountryFilter orgs={orgsWithIntl} />);
+    expect(
+      screen.getByRole("button", { name: "International" }),
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "International" }));
+    expect(screen.getByText("OECD")).toBeInTheDocument();
+    expect(screen.queryByText("AIGS")).not.toBeInTheDocument();
+    expect(screen.queryByText("DSIT")).not.toBeInTheDocument();
+  });
+
   it("auto-adds a pill when a new country appears in props", () => {
     const orgsWithUs = [
       ...orgs,

--- a/src/components/OrgsWithCountryFilter.tsx
+++ b/src/components/OrgsWithCountryFilter.tsx
@@ -1,13 +1,17 @@
 import { useState, useMemo } from "react";
 
-const COUNTRY_LABELS: Record<string, string> = { ca: "Canada", uk: "UK" };
+const COUNTRY_LABELS: Record<string, string> = {
+  ca: "Canada",
+  uk: "UK",
+  international: "International",
+};
 
 export type OrgEntry = {
   id: string;
   name: string;
   short_name?: string;
   url?: string;
-  country: "ca" | "uk";
+  country: "ca" | "uk" | "international";
   tags: string[];
   events: number;
   artifacts: number;

--- a/src/components/PolicyWithSourceFilter.test.tsx
+++ b/src/components/PolicyWithSourceFilter.test.tsx
@@ -10,6 +10,7 @@ const govArtifact: ArtifactEntry = {
   title: "Bill C-27",
   publishedDate: "2022-06-16",
   sourceCategory: "government",
+  jurisdiction: "canada",
 };
 
 const civilArtifact: ArtifactEntry = {
@@ -18,6 +19,16 @@ const civilArtifact: ArtifactEntry = {
   title: "Governing AI: A Plan for Canada",
   publishedDate: "2023-10-18",
   sourceCategory: "civil_society",
+  jurisdiction: "canada",
+};
+
+const intlArtifact: ArtifactEntry = {
+  id: "hiroshima-ai-process",
+  type: "PolicyDocument",
+  title: "Hiroshima AI Process",
+  publishedDate: "2023-05-19",
+  sourceCategory: "government",
+  jurisdiction: "international",
 };
 
 describe("PolicyWithSourceFilter", () => {
@@ -56,6 +67,37 @@ describe("PolicyWithSourceFilter", () => {
     await userEvent.click(screen.getByRole("button", { name: "Government" }));
     expect(screen.queryByText("White Papers")).not.toBeInTheDocument();
     expect(screen.getByText("Legislation")).toBeInTheDocument();
+  });
+
+  it("shows only canadian artifacts after clicking Canada", async () => {
+    render(
+      <PolicyWithSourceFilter artifacts={[govArtifact, intlArtifact]} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Canada" }));
+    expect(screen.getByText("Bill C-27")).toBeInTheDocument();
+    expect(screen.queryByText("Hiroshima AI Process")).not.toBeInTheDocument();
+  });
+
+  it("shows only international artifacts after clicking International", async () => {
+    render(
+      <PolicyWithSourceFilter artifacts={[govArtifact, intlArtifact]} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "International" }));
+    expect(screen.queryByText("Bill C-27")).not.toBeInTheDocument();
+    expect(screen.getByText("Hiroshima AI Process")).toBeInTheDocument();
+  });
+
+  it("combines source and jurisdiction filters", async () => {
+    render(
+      <PolicyWithSourceFilter
+        artifacts={[govArtifact, civilArtifact, intlArtifact]}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Government" }));
+    await userEvent.click(screen.getByRole("button", { name: "International" }));
+    expect(screen.getByText("Hiroshima AI Process")).toBeInTheDocument();
+    expect(screen.queryByText("Bill C-27")).not.toBeInTheDocument();
+    expect(screen.queryByText("Governing AI: A Plan for Canada")).not.toBeInTheDocument();
   });
 
   it("renders lifecycle status badge alongside source badge for Legislation", () => {

--- a/src/components/PolicyWithSourceFilter.tsx
+++ b/src/components/PolicyWithSourceFilter.tsx
@@ -1,7 +1,9 @@
 import { useState, useMemo } from "react";
 import type { SourceCategory } from "../lib/sourceCategory";
 import { sourceBadge, sourceCardStyle } from "../lib/sourceCategory";
+import type { Jurisdiction } from "../lib/jurisdiction";
 import SourceFilter from "./SourceFilter";
+import JurisdictionFilter from "./JurisdictionFilter";
 import { fmtDate } from "../lib/format";
 import { badgeClass, statusLabel } from "../lib/legislation";
 
@@ -20,6 +22,7 @@ export type ArtifactEntry = {
   lifecycleStatus?: string;
   currentStage?: string;
   sourceCategory: SourceCategory;
+  jurisdiction: Jurisdiction;
 };
 
 type Props = {
@@ -72,19 +75,29 @@ const SECTIONS: {
 
 export default function PolicyWithSourceFilter({ artifacts }: Props) {
   const [selectedSource, setSelectedSource] = useState<SourceCategory | "all">("all");
+  const [selectedJurisdiction, setSelectedJurisdiction] = useState<Jurisdiction | "all">("all");
 
   const filtered = useMemo(
     () =>
-      selectedSource === "all"
-        ? artifacts
-        : artifacts.filter((a) => a.sourceCategory === selectedSource),
-    [artifacts, selectedSource],
+      artifacts
+        .filter((a) => selectedSource === "all" || a.sourceCategory === selectedSource)
+        .filter(
+          (a) => selectedJurisdiction === "all" || a.jurisdiction === selectedJurisdiction,
+        ),
+    [artifacts, selectedSource, selectedJurisdiction],
   );
 
   return (
     <div>
-      <div className="mt-6">
-        <SourceFilter selected={selectedSource} onSelect={setSelectedSource} />
+      <div className="mt-6 space-y-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-faint mb-2">Source</p>
+          <SourceFilter selected={selectedSource} onSelect={setSelectedSource} />
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-faint mb-2">Jurisdiction</p>
+          <JurisdictionFilter selected={selectedJurisdiction} onSelect={setSelectedJurisdiction} />
+        </div>
       </div>
 
       {SECTIONS.map(({ type, heading, description }) => {

--- a/src/components/TimelineWithFilter.tsx
+++ b/src/components/TimelineWithFilter.tsx
@@ -1,10 +1,12 @@
 // src/components/TimelineWithFilter.tsx
 import { useState, useEffect, useMemo } from "react";
 import type { TimelineItem, OrgOption } from "../lib/timeline";
-import { filterByOrg, filterBySource } from "../lib/timeline";
+import { filterByOrg, filterBySource, filterByJurisdiction } from "../lib/timeline";
 import type { SourceCategory } from "../lib/sourceCategory";
+import type { Jurisdiction } from "../lib/jurisdiction";
 import OrgFilter from "./OrgFilter";
 import SourceFilter from "./SourceFilter";
+import JurisdictionFilter from "./JurisdictionFilter";
 import TimelineList from "./TimelineList";
 
 type Props = {
@@ -15,6 +17,7 @@ type Props = {
 export default function TimelineWithFilter({ items, orgs }: Props) {
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(null);
   const [selectedSource, setSelectedSource] = useState<SourceCategory | "all">("all");
+  const [selectedJurisdiction, setSelectedJurisdiction] = useState<Jurisdiction | "all">("all");
 
   useEffect(() => {
     function resolveOrg(): string | null {
@@ -44,8 +47,12 @@ export default function TimelineWithFilter({ items, orgs }: Props) {
   }
 
   const filteredItems = useMemo(
-    () => filterBySource(filterByOrg(items, selectedOrgId), selectedSource),
-    [items, selectedOrgId, selectedSource],
+    () =>
+      filterByJurisdiction(
+        filterBySource(filterByOrg(items, selectedOrgId), selectedSource),
+        selectedJurisdiction,
+      ),
+    [items, selectedOrgId, selectedSource, selectedJurisdiction],
   );
 
   return (
@@ -54,6 +61,10 @@ export default function TimelineWithFilter({ items, orgs }: Props) {
         <div>
           <p className="text-xs font-semibold uppercase tracking-wide text-faint mb-2">Source</p>
           <SourceFilter selected={selectedSource} onSelect={setSelectedSource} />
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-faint mb-2">Jurisdiction</p>
+          <JurisdictionFilter selected={selectedJurisdiction} onSelect={setSelectedJurisdiction} />
         </div>
         <div>
           <p className="text-xs font-semibold uppercase tracking-wide text-faint mb-2">Organization</p>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -16,6 +16,12 @@ const orgRoleSchema = z.object({
   role: z.string(),
 });
 
+// Which polity a record belongs to. Canadian records are the default; records
+// from international processes (G7, OECD, UN, ...) opt in explicitly.
+const jurisdictionSchema = z
+  .enum(["canada", "international"])
+  .default("canada");
+
 const events = defineCollection({
   loader: yamlGlob({ pattern: "*.yaml", base: dataDir("events") }),
   schema: z.object({
@@ -45,6 +51,7 @@ const events = defineCollection({
     related_artifacts: z
       .array(z.object({ id: reference("artifacts") }))
       .default([]),
+    jurisdiction: jurisdictionSchema,
   }),
 });
 
@@ -129,6 +136,7 @@ const artifacts = defineCollection({
       )
       .default([]),
     tags: z.array(z.string()).default([]),
+    jurisdiction: jurisdictionSchema,
   }),
 });
 
@@ -142,7 +150,7 @@ const organizations = defineCollection({
     short_name: z.string().optional(),
     url: z.string().url().optional(),
     wikipedia: z.string().url().optional(),
-    country: z.enum(["ca", "uk"]),
+    country: z.enum(["ca", "uk", "international"]),
     tags: z.array(z.string()).default([]),
   }),
 });

--- a/src/lib/jurisdiction.ts
+++ b/src/lib/jurisdiction.ts
@@ -1,0 +1,6 @@
+export type Jurisdiction = "canada" | "international";
+
+export const jurisdictionLabels: Record<Jurisdiction, string> = {
+  canada: "Canada",
+  international: "International",
+};

--- a/src/lib/timeline.test.ts
+++ b/src/lib/timeline.test.ts
@@ -3,13 +3,20 @@ import {
   buildTimelineItems,
   filterByOrg,
   filterBySource,
+  filterByJurisdiction,
   type EventInput,
   type OrgInput,
   type TimelineItem,
 } from "./timeline";
 import type { SourceCategory } from "./sourceCategory";
+import type { Jurisdiction } from "./jurisdiction";
 
-function make(id: string, orgIds: string[], sourceCategory: SourceCategory = "government"): TimelineItem {
+function make(
+  id: string,
+  orgIds: string[],
+  sourceCategory: SourceCategory = "government",
+  jurisdiction: Jurisdiction = "canada",
+): TimelineItem {
   return {
     id,
     kind: "event",
@@ -22,6 +29,7 @@ function make(id: string, orgIds: string[], sourceCategory: SourceCategory = "go
     orgs: [],
     links: [],
     sourceCategory,
+    jurisdiction,
   };
 }
 
@@ -37,7 +45,12 @@ describe("buildTimelineItems", () => {
     },
   ];
 
-  function event(id: string, date: string, orgIds: string[]): EventInput {
+  function event(
+    id: string,
+    date: string,
+    orgIds: string[],
+    jurisdiction: Jurisdiction = "canada",
+  ): EventInput {
     return {
       id,
       data: {
@@ -48,6 +61,7 @@ describe("buildTimelineItems", () => {
         type: "GovernmentAnnouncement",
         organizations: orgIds.map((o) => ({ id: { id: o } })),
         links: [],
+        jurisdiction,
       },
     };
   }
@@ -78,6 +92,16 @@ describe("buildTimelineItems", () => {
     const [civil] = buildTimelineItems([event("b", "2017-03-22", ["cigi"])], orgs);
     expect(gov.sourceCategory).toBe("government");
     expect(civil.sourceCategory).toBe("civil_society");
+  });
+
+  it("passes jurisdiction through to the timeline item", () => {
+    const [intl] = buildTimelineItems(
+      [event("a", "2023-05-19", ["ised-canada"], "international")],
+      orgs,
+    );
+    const [ca] = buildTimelineItems([event("b", "2023-05-19", ["ised-canada"])], orgs);
+    expect(intl.jurisdiction).toBe("international");
+    expect(ca.jurisdiction).toBe("canada");
   });
 
   it("builds the event href and flattened orgIds", () => {
@@ -136,5 +160,31 @@ describe("filterBySource", () => {
 
   it("returns [] for empty input", () => {
     expect(filterBySource([], "government")).toEqual([]);
+  });
+});
+
+describe("filterByJurisdiction", () => {
+  const items: TimelineItem[] = [
+    make("a", [], "government", "canada"),
+    make("b", [], "government", "international"),
+    make("c", [], "civil_society", "canada"),
+  ];
+
+  it("returns all items when 'all' is selected", () => {
+    expect(filterByJurisdiction(items, "all")).toEqual(items);
+  });
+
+  it("returns only canadian items", () => {
+    const result = filterByJurisdiction(items, "canada");
+    expect(result.map((i) => i.id)).toEqual(["a", "c"]);
+  });
+
+  it("returns only international items", () => {
+    const result = filterByJurisdiction(items, "international");
+    expect(result.map((i) => i.id)).toEqual(["b"]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(filterByJurisdiction([], "canada")).toEqual([]);
   });
 });

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -1,4 +1,5 @@
 import { getSourceCategory, type SourceCategory } from "./sourceCategory";
+import type { Jurisdiction } from "./jurisdiction";
 
 export type TimelineItem = {
   id: string;
@@ -13,6 +14,7 @@ export type TimelineItem = {
   orgs: { id: string; label: string }[]; // for displaying org chips
   links: { label: string; url: string; icon?: string }[]; // source links
   sourceCategory: SourceCategory;
+  jurisdiction: Jurisdiction;
 };
 
 export type OrgOption = {
@@ -33,6 +35,7 @@ export type EventInput = {
     type: string;
     organizations: { id: { id: string } }[];
     links: { label: string; url: string; icon?: string }[];
+    jurisdiction: Jurisdiction;
   };
 };
 
@@ -75,6 +78,7 @@ export function buildTimelineItems(
         return { id: o.id.id, label: org?.short_name ?? org?.name ?? o.id.id };
       }),
       links: e.data.links,
+      jurisdiction: e.data.jurisdiction,
       sourceCategory: getSourceCategory(
         e.data.organizations.map(
           (o) => orgMap.get(o.id.id)?.schema_type ?? "Organization",
@@ -98,4 +102,12 @@ export function filterBySource(
 ): TimelineItem[] {
   if (sourceCategory === "all") return items;
   return items.filter((i) => i.sourceCategory === sourceCategory);
+}
+
+export function filterByJurisdiction(
+  items: TimelineItem[],
+  jurisdiction: Jurisdiction | "all",
+): TimelineItem[] {
+  if (jurisdiction === "all") return items;
+  return items.filter((i) => i.jurisdiction === jurisdiction);
 }

--- a/src/pages/policy/index.astro
+++ b/src/pages/policy/index.astro
@@ -38,6 +38,7 @@ const artifacts: ArtifactEntry[] = artifactCollection
       lifecycleStatus: a.data.lifecycle_status,
       currentStage: a.data.current_stage,
       sourceCategory: getSourceCategory(orgSchemaTypes),
+      jurisdiction: a.data.jurisdiction,
     };
   })
   .sort((a, b) => new Date(b.publishedDate).getTime() - new Date(a.publishedDate).getTime());


### PR DESCRIPTION
Closes #101.

## What this does

**Content — Hiroshima AI Process (HAIP).** Modelled as one `PolicyDocument` artifact (`hiroshima-ai-process`) carrying the full stage history — Hiroshima Summit launch (May 2023), International Guiding Principles + Code of Conduct (Oct 2023), Comprehensive Policy Framework (Dec 2023), OECD Reporting Framework launch at the Paris AI Action Summit (Feb 2025), the Kananaskis "AI for Prosperity" statement under Canada's G7 presidency (Jun 2025), and the Reporting Framework 2.0 launch (28 May 2026, the news item in the issue) — plus two headline timeline events (process launch, Framework 2.0 launch), mirroring the legislation hybrid pattern so the timeline stays uncluttered. New org records: G7 and OECD.

**"International" selector.** Events and artifacts now carry `jurisdiction: canada | international` (schema default `canada`, so existing records are untouched). A new `JurisdictionFilter` pill group (All / Canada / International) appears on the Timeline and Policy pages alongside the Source filter; the Organizations page gets an International pill through its existing country filter (`country` enum extended with `international` for intergovernmental bodies). The existing International AI Safety Report 2026 (+ its event) is now marked `jurisdiction: international`.

## Design notes for review

- Jurisdiction filters default to **All** on Timeline/Policy (the Orgs page keeps its existing Canada default) — easy to flip if you'd rather default to Canada.
- G7 and OECD use `schema_type: GovernmentOrganization` so HAIP items get the GOVERNMENT source badge.
- The homepage "latest activity" preview intentionally has no filter (it's a 3-item teaser).

## Test plan

- [x] `pnpm test` — 100/100 unit tests pass (new: JurisdictionFilter component, `filterByJurisdiction`, jurisdiction pass-through in `buildTimelineItems`, policy + orgs filter behaviour)
- [x] `pnpm build` — site builds; HAIP artifact/event/org pages generated; description renders as 3 paragraphs (literal block scalar check)
- [ ] `Test / e2e` in CI — new Playwright specs for the jurisdiction filter on timeline/policy/orgs (Playwright has no chromium build for this dev sandbox's ubuntu-arm64, so e2e must run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
