### PR TITLE
Add jurisdiction icons to selectors and to event, org, and artifact views

### DIFF
--- a/src/components/JurisdictionFilter.test.tsx
+++ b/src/components/JurisdictionFilter.test.tsx
@@ -11,6 +11,13 @@ describe("JurisdictionFilter", () => {
     expect(screen.getByRole("button", { name: "International" })).toBeInTheDocument();
   });
 
+  it("shows a flag icon on Canada and a world icon on International, hidden from the accessible name", () => {
+    render(<JurisdictionFilter selected="all" onSelect={() => {}} />);
+    expect(screen.getByRole("button", { name: "Canada" })).toHaveTextContent("🇨🇦");
+    expect(screen.getByRole("button", { name: "International" })).toHaveTextContent("🌐");
+    expect(screen.getByRole("button", { name: "All" })).not.toHaveTextContent("🌐");
+  });
+
   it("sets aria-pressed='true' on the active button only", () => {
     render(<JurisdictionFilter selected="international" onSelect={() => {}} />);
     expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("aria-pressed", "false");

--- a/src/components/JurisdictionFilter.tsx
+++ b/src/components/JurisdictionFilter.tsx
@@ -1,12 +1,20 @@
 import type { Jurisdiction } from "../lib/jurisdiction";
-import { jurisdictionLabels } from "../lib/jurisdiction";
+import { jurisdictionLabels, jurisdictionIcons } from "../lib/jurisdiction";
 
-type Option = { value: Jurisdiction | "all"; label: string };
+type Option = { value: Jurisdiction | "all"; label: string; icon?: string };
 
 const OPTIONS: Option[] = [
   { value: "all", label: "All" },
-  { value: "canada", label: jurisdictionLabels.canada },
-  { value: "international", label: jurisdictionLabels.international },
+  {
+    value: "canada",
+    label: jurisdictionLabels.canada,
+    icon: jurisdictionIcons.canada,
+  },
+  {
+    value: "international",
+    label: jurisdictionLabels.international,
+    icon: jurisdictionIcons.international,
+  },
 ];
 
 type Props = {
@@ -23,7 +31,7 @@ export default function JurisdictionFilter({ selected, onSelect }: Props) {
 
   return (
     <div role="group" aria-label="Filter by jurisdiction" className="flex flex-wrap gap-2">
-      {OPTIONS.map(({ value, label }) => (
+      {OPTIONS.map(({ value, label, icon }) => (
         <button
           key={value}
           type="button"
@@ -31,6 +39,11 @@ export default function JurisdictionFilter({ selected, onSelect }: Props) {
           className={`${pillBase} ${selected === value ? active : inactive}`}
           onClick={() => onSelect(value)}
         >
+          {icon && (
+            <span aria-hidden="true" className="mr-1.5">
+              {icon}
+            </span>
+          )}
           {label}
         </button>
       ))}

--- a/src/components/OrgsWithCountryFilter.test.tsx
+++ b/src/components/OrgsWithCountryFilter.test.tsx
@@ -85,6 +85,14 @@ describe("OrgsWithCountryFilter", () => {
     expect(screen.getAllByText("Canada").length).toBeGreaterThanOrEqual(2);
   });
 
+  it("shows country icons on pills and org cards without changing accessible names", () => {
+    render(<OrgsWithCountryFilter orgs={orgs} />);
+    expect(screen.getByRole("button", { name: "Canada" })).toHaveTextContent("🇨🇦");
+    expect(screen.getByRole("button", { name: "UK" })).toHaveTextContent("🇬🇧");
+    // Cards for the two visible CA orgs carry the flag too
+    expect(screen.getAllByText("🇨🇦").length).toBeGreaterThanOrEqual(3);
+  });
+
   it("filters to international orgs when International pill is clicked", async () => {
     const orgsWithIntl = [
       ...orgs,

--- a/src/components/OrgsWithCountryFilter.tsx
+++ b/src/components/OrgsWithCountryFilter.tsx
@@ -1,10 +1,5 @@
 import { useState, useMemo } from "react";
-
-const COUNTRY_LABELS: Record<string, string> = {
-  ca: "Canada",
-  uk: "UK",
-  international: "International",
-};
+import { countryLabels, countryIcons } from "../lib/country";
 
 export type OrgEntry = {
   id: string;
@@ -63,7 +58,12 @@ export default function OrgsWithCountryFilter({ orgs }: Props) {
             className={`${pillBase} ${selected === code ? active : inactive}`}
             onClick={() => setSelected(code)}
           >
-            {COUNTRY_LABELS[code] ?? code.toUpperCase()}
+            {countryIcons[code] && (
+              <span aria-hidden="true" className="mr-1.5">
+                {countryIcons[code]}
+              </span>
+            )}
+            {countryLabels[code] ?? code.toUpperCase()}
           </button>
         ))}
       </div>
@@ -91,7 +91,12 @@ export default function OrgsWithCountryFilter({ orgs }: Props) {
                 </div>
               )}
               <div className="mt-1 text-xs text-faint">
-                {COUNTRY_LABELS[org.country] ?? org.country.toUpperCase()}
+                {countryIcons[org.country] && (
+                  <span aria-hidden="true" className="mr-1">
+                    {countryIcons[org.country]}
+                  </span>
+                )}
+                <span>{countryLabels[org.country] ?? org.country.toUpperCase()}</span>
               </div>
               <div className="mt-3 text-xs text-faint">
                 {[

--- a/src/components/PolicyWithSourceFilter.test.tsx
+++ b/src/components/PolicyWithSourceFilter.test.tsx
@@ -38,6 +38,12 @@ describe("PolicyWithSourceFilter", () => {
     expect(screen.getByText("Governing AI: A Plan for Canada")).toBeInTheDocument();
   });
 
+  it("shows a jurisdiction icon on each artifact card", () => {
+    render(<PolicyWithSourceFilter artifacts={[govArtifact, intlArtifact]} />);
+    expect(screen.getAllByRole("img", { name: "Canada" })[0]).toHaveTextContent("🇨🇦");
+    expect(screen.getAllByRole("img", { name: "International" })[0]).toHaveTextContent("🌐");
+  });
+
   it("shows only government artifacts after clicking Government", async () => {
     render(<PolicyWithSourceFilter artifacts={[govArtifact, civilArtifact]} />);
     await userEvent.click(screen.getByRole("button", { name: "Government" }));

--- a/src/components/PolicyWithSourceFilter.tsx
+++ b/src/components/PolicyWithSourceFilter.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import type { SourceCategory } from "../lib/sourceCategory";
 import { sourceBadge, sourceCardStyle } from "../lib/sourceCategory";
 import type { Jurisdiction } from "../lib/jurisdiction";
+import { jurisdictionLabels, jurisdictionIcons } from "../lib/jurisdiction";
 import SourceFilter from "./SourceFilter";
 import JurisdictionFilter from "./JurisdictionFilter";
 import { fmtDate } from "../lib/format";
@@ -132,6 +133,14 @@ export default function PolicyWithSourceFilter({ artifacts }: Props) {
                           style={src.style}
                         >
                           {src.label}
+                        </span>
+                        <span
+                          role="img"
+                          aria-label={jurisdictionLabels[artifact.jurisdiction]}
+                          title={jurisdictionLabels[artifact.jurisdiction]}
+                          className="text-xs"
+                        >
+                          {jurisdictionIcons[artifact.jurisdiction]}
                         </span>
                       </div>
                     </div>

--- a/src/components/TimelineList.test.tsx
+++ b/src/components/TimelineList.test.tsx
@@ -15,6 +15,7 @@ const baseItem: TimelineItem = {
   orgs: [{ id: "senate", label: "Senate SOCI" }],
   links: [],
   sourceCategory: "government",
+  jurisdiction: "canada",
 };
 
 describe("TimelineList", () => {
@@ -63,5 +64,15 @@ describe("TimelineList", () => {
   it("renders CIVIL SOCIETY badge for civil_society items", () => {
     render(<TimelineList items={[{ ...baseItem, sourceCategory: "civil_society" }]} />);
     expect(screen.getByText("CIVIL SOCIETY")).toBeInTheDocument();
+  });
+
+  it("renders a Canada flag icon on canadian items", () => {
+    render(<TimelineList items={[baseItem]} />);
+    expect(screen.getByRole("img", { name: "Canada" })).toHaveTextContent("🇨🇦");
+  });
+
+  it("renders a world icon on international items", () => {
+    render(<TimelineList items={[{ ...baseItem, jurisdiction: "international" }]} />);
+    expect(screen.getByRole("img", { name: "International" })).toHaveTextContent("🌐");
   });
 });

--- a/src/components/TimelineList.tsx
+++ b/src/components/TimelineList.tsx
@@ -1,5 +1,6 @@
 import type { TimelineItem } from "../lib/timeline";
 import { sourceBadge, sourceDotColor } from "../lib/sourceCategory";
+import { jurisdictionLabels, jurisdictionIcons } from "../lib/jurisdiction";
 import { fmtDate } from "../lib/format";
 
 type Props = {
@@ -79,6 +80,14 @@ export default function TimelineList({ items }: Props) {
                 style={badge.style}
               >
                 {badge.label}
+              </span>
+              <span
+                role="img"
+                aria-label={jurisdictionLabels[item.jurisdiction]}
+                title={jurisdictionLabels[item.jurisdiction]}
+                className="text-xs"
+              >
+                {jurisdictionIcons[item.jurisdiction]}
               </span>
             </div>
             {item.description && (

--- a/src/lib/country.ts
+++ b/src/lib/country.ts
@@ -1,0 +1,14 @@
+// Org records carry a `country` (ca | uk | international) rather than a
+// `jurisdiction`; labels and icons for both live in their own modules so the
+// two vocabularies don't get conflated.
+export const countryLabels: Record<string, string> = {
+  ca: "Canada",
+  uk: "UK",
+  international: "International",
+};
+
+export const countryIcons: Record<string, string> = {
+  ca: "🇨🇦",
+  uk: "🇬🇧",
+  international: "🌐",
+};

--- a/src/lib/jurisdiction.ts
+++ b/src/lib/jurisdiction.ts
@@ -4,3 +4,8 @@ export const jurisdictionLabels: Record<Jurisdiction, string> = {
   canada: "Canada",
   international: "International",
 };
+
+export const jurisdictionIcons: Record<Jurisdiction, string> = {
+  canada: "🇨🇦",
+  international: "🌐",
+};

--- a/src/pages/artifacts/[id].astro
+++ b/src/pages/artifacts/[id].astro
@@ -3,6 +3,7 @@ import { getCollection, getEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { marked } from "marked";
 import { fmtDate, leadText } from "../../lib/format";
+import { jurisdictionLabels, jurisdictionIcons } from "../../lib/jurisdiction";
 import { buildCreativeWorkJsonLd, type OrgRef } from "../../lib/jsonld";
 
 export async function getStaticPaths() {
@@ -94,6 +95,11 @@ const jsonLd = buildCreativeWorkJsonLd({
     </time>
     <span>·</span>
     <span>{data.type}</span>
+    <span>·</span>
+    <span>
+      <span aria-hidden="true">{jurisdictionIcons[data.jurisdiction]}</span>
+      {" "}{jurisdictionLabels[data.jurisdiction]}
+    </span>
   </div>
 
   {descriptionHtml && (

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -2,6 +2,7 @@
 import { getCollection, getEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { fmtDate, humanizeType, leadText } from "../../lib/format";
+import { jurisdictionLabels, jurisdictionIcons } from "../../lib/jurisdiction";
 import { buildEventJsonLd, type OrgRef } from "../../lib/jsonld";
 
 export async function getStaticPaths() {
@@ -54,6 +55,11 @@ const jsonLd = buildEventJsonLd({
     <time datetime={data.date.toISOString()}>{fmtDate(data.date)}</time>
     <span>·</span>
     <span>{data.type}</span>
+    <span>·</span>
+    <span>
+      <span aria-hidden="true">{jurisdictionIcons[data.jurisdiction]}</span>
+      {" "}{jurisdictionLabels[data.jurisdiction]}
+    </span>
     {data.location && (
       <>
         <span>·</span>

--- a/src/pages/orgs/[id].astro
+++ b/src/pages/orgs/[id].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { countryLabels, countryIcons } from "../../lib/country";
 import { buildOrgJsonLd } from "../../lib/jsonld";
 
 export async function getStaticPaths() {
@@ -42,6 +43,10 @@ const jsonLd = buildOrgJsonLd({
   {data.short_name && (
     <p class="mt-1 text-faint">{data.short_name}</p>
   )}
+  <p class="mt-1 text-sm text-faint">
+    <span aria-hidden="true">{countryIcons[data.country]}</span>
+    {" "}{countryLabels[data.country] ?? data.country.toUpperCase()}
+  </p>
 
   <div class="mt-4 flex flex-wrap gap-4 text-sm">
     {data.url && (


### PR DESCRIPTION
## Summary
- Jurisdiction filter pills now show a 🇨🇦 flag on **Canada** and a 🌐 world icon on **International** (timeline + policy pages); the orgs country filter gets the same treatment, including 🇬🇧 for the UK pill.
- The jurisdiction icon also appears on each timeline event (in the chip row), each org card, and each artifact card on the policy page.
- Event, artifact, and org detail pages show the icon + label in their metadata line (org pages previously didn't surface country at all).
- Icons are emoji wrapped in `aria-hidden` spans inside labelled controls, and `role="img"` + `aria-label` when standing alone, so accessible names are unchanged.
- Org country labels/icons are extracted to `src/lib/country.ts`, shared by `OrgsWithCountryFilter` and the org detail page; jurisdiction icons live alongside the existing labels in `src/lib/jurisdiction.ts`.

## Test plan
- [x] `pnpm test` — 105 unit tests pass, including new icon assertions for `JurisdictionFilter`, `OrgsWithCountryFilter`, `TimelineList`, and `PolicyWithSourceFilter`
- [x] `pnpm build` — 64 pages build; verified icons in generated HTML for timeline, policy, org, event, and artifact pages
- [ ] `Test / e2e` in CI (Playwright unsupported on this sandbox's ubuntu-arm64; specs select pills by accessible name, which is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014X2bSFnj147md8nPvSYP2o