### PR TITLE
Add Munk School "Sovereign by Design" AI sovereignty report (#67)

### DIFF
--- a/data/artifacts/2026-03-10-munk-sovereign-by-design.yaml
+++ b/data/artifacts/2026-03-10-munk-sovereign-by-design.yaml
@@ -1,0 +1,63 @@
+# artifacts/2026-03-10-munk-sovereign-by-design.yaml
+
+id: munk-sovereign-by-design-2026
+type: Report
+schema_type: CreativeWork
+
+title: "Sovereign by Design: Strategic Options for Canadian AI Sovereignty"
+published_date: 2026-03-10
+
+authors:
+  # Individual authors — no people files created yet
+  - name: "Sean Mullin"
+    role: author
+  - name: "Jaxson Khan"
+    role: author
+
+organizations:
+  - id: munk-school-uoft
+    role: publisher
+
+description: |
+  A report from the AI Competitiveness Project at the Munk School of Global
+  Affairs & Public Policy (University of Toronto), authored by Senior Fellows
+  Sean Mullin and Jaxson Khan. It offers a systematic, layer-by-layer
+  assessment of Canada's position across the AI technology stack and warns that
+  critical gaps in cloud infrastructure and compute hardware leave the country
+  vulnerable at a moment of geopolitical uncertainty.
+
+  The report frames sovereignty as "freedom from coercion, not digital
+  isolationism or technological self-sufficiency." It identifies Canadian
+  strengths — clean energy attractive to data-centre investment, valuable
+  public and private datasets, globally competitive firms such as Cohere, and a
+  strong open-source ecosystem — alongside acute weaknesses, most notably
+  limited domestic control over foundation models and cloud infrastructure and
+  the extraterritorial legal reach that undermines data-residency protections.
+
+  Its central argument is that "the architecture is not yet settled": Canada
+  should make deliberate infrastructure and standards choices during this
+  formative period to reduce foreign leverage while building sovereign capacity
+  through coalition-building and hybrid technology strategies.
+
+links:
+  - label: "AI Competitiveness Project — Sovereign by Design"
+    url: https://aicompetitiveness.ca/
+    icon: document
+  - label: "Full report (PDF)"
+    url: https://aicompetitiveness.ca/assets/Sovereign-by-Design-Full-Report-2026.pdf
+    icon: document
+  - label: "Policy briefing note (PDF)"
+    url: https://aicompetitiveness.ca/assets/Sovereign-by-Design-Briefing-Note-2026.pdf
+    icon: document
+  - label: "Munk School — AI Competitiveness Project"
+    url: https://munkschool.utoronto.ca/ai-competitiveness-project
+    icon: document
+
+tags:
+  - ai-sovereignty
+  - compute
+  - cloud-infrastructure
+  - foundation-models
+  - competitiveness
+  - munk-school
+  - cohere

--- a/data/events/2026-03-10-munk-sovereign-by-design-published.yaml
+++ b/data/events/2026-03-10-munk-sovereign-by-design-published.yaml
@@ -1,0 +1,36 @@
+# events/2026-03-10-munk-sovereign-by-design-published.yaml
+
+id: munk-sovereign-by-design-published-2026
+type: Publication
+schema_type: Event
+
+title: "Munk School publishes \"Sovereign by Design\" on Canadian AI sovereignty"
+date: 2026-03-10
+status: completed
+
+organizations:
+  - id: munk-school-uoft
+    role: publisher
+
+description: >
+  The AI Competitiveness Project at the University of Toronto's Munk School of
+  Global Affairs & Public Policy publishes "Sovereign by Design: Strategic
+  Options for Canadian AI Sovereignty," a layer-by-layer assessment of Canada's
+  position across the AI technology stack that warns of vulnerabilities in
+  cloud infrastructure and compute and sets out strategic options for reducing
+  foreign leverage.
+
+related_artifacts:
+  - id: munk-sovereign-by-design-2026
+
+tags:
+  - ai-sovereignty
+  - compute
+  - competitiveness
+  - munk-school
+  - civil-society
+
+links:
+  - label: "Newswire — New Munk School report maps Canada's AI sovereignty vulnerabilities"
+    url: https://www.newswire.ca/news-releases/new-munk-school-report-maps-canada-s-ai-sovereignty-vulnerabilities-offers-strategic-options-for-action-872511205.html
+    icon: document

--- a/data/organizations/munk-school-uoft.yaml
+++ b/data/organizations/munk-school-uoft.yaml
@@ -1,0 +1,17 @@
+# organizations/munk-school-uoft.yaml
+
+id: munk-school-uoft
+type: EducationalOrganization
+schema_type: Organization
+country: ca
+
+name: "Munk School of Global Affairs & Public Policy"
+short_name: "Munk School"
+url: https://munkschool.utoronto.ca
+wikipedia: https://en.wikipedia.org/wiki/Munk_School_of_Global_Affairs_%26_Public_Policy
+
+tags:
+  - academic
+  - university-of-toronto
+  - think-tank
+  - canadian


### PR DESCRIPTION
## Summary

Adds the Munk School competitiveness report requested in issue #67.

**"Sovereign by Design: Strategic Options for Canadian AI Sovereignty"** was published **March 10, 2026** by the AI Competitiveness Project at the University of Toronto's Munk School (authors: Senior Fellows Sean Mullin and Jaxson Khan). It assesses Canada's position layer-by-layer across the AI stack, warns of vulnerabilities in cloud infrastructure and compute, and frames sovereignty as "freedom from coercion, not digital isolationism."

Adds:
- `data/artifacts/2026-03-10-munk-sovereign-by-design.yaml` (`type: Report`)
- `data/events/2026-03-10-munk-sovereign-by-design-published.yaml` (`type: Publication`) so it appears on the timeline
- `data/organizations/munk-school-uoft.yaml` — new organization record

Sources: full report + policy briefing note PDFs, the AI Competitiveness Project site, and the Newswire release.

## Test plan

- [x] `pnpm build` passes (schema + cross-references resolve)
- [x] `pnpm test` passes
- [ ] CI `Test / e2e`

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)