### PR TITLE
Add CAISI Question Period note and CAISI organization (#77)

### DIFF
--- a/data/artifacts/2025-09-15-caisi-question-period-note.yaml
+++ b/data/artifacts/2025-09-15-caisi-question-period-note.yaml
@@ -1,0 +1,50 @@
+# artifacts/2025-09-15-caisi-question-period-note.yaml
+
+id: caisi-question-period-note-2025
+type: PolicyDocument
+schema_type: CreativeWork
+
+title: "Question Period Note: Canadian Artificial Intelligence Safety Institute"
+published_date: 2025-09-15  # "date received" on the proactive-disclosure record
+
+organizations:
+  - id: ised-canada
+    role: author
+  - id: caisi
+    role: subject
+
+description: |
+  A Question Period note (reference AIDI-2026-QP-00001) prepared for Evan
+  Solomon, Minister of Artificial Intelligence and Digital Innovation, and
+  released through proactive disclosure. It answers why the Government of Canada
+  created the Canadian Artificial Intelligence Safety Institute (CAISI).
+
+  The note states that CAISI was created in November 2024 to advance scientific
+  understanding of the risks of the most advanced AI systems and to provide
+  tools to address them, leveraging Canada's research ecosystem through the
+  Canadian Institute for Advanced Research (CIFAR) and the National Research
+  Council (NRC). It records that CAISI is a founding member of the International
+  Network of AI Safety Institutes, that its 2025–26 research priorities cover
+  risk assessment, understanding how AI systems behave, and techniques to make
+  them safer, and that it has signed a $1-million research partnership with the
+  UK AI Security Institute (July 2025) and a memorandum of understanding with
+  the Canadian AI company Cohere.
+
+links:
+  - label: "Open Government — Question Period Note: Canadian Artificial Intelligence Safety Institute (AIDI-2026-QP-00001)"
+    url: https://search.open.canada.ca/qpnotes/record/ic,AIDI-2026-QP-00001
+    icon: document
+  - label: "ISED — Canadian Artificial Intelligence Safety Institute"
+    url: https://ised-isde.canada.ca/site/ised/en/canadian-artificial-intelligence-safety-institute
+    icon: document
+
+tags:
+  - caisi
+  - question-period
+  - proactive-disclosure
+  - cifar
+  - nrc
+  - international-network-of-ai-safety-institutes
+  - cohere
+  - evan-solomon
+  - federal-government

--- a/data/events/2025-09-15-caisi-question-period-note-disclosed.yaml
+++ b/data/events/2025-09-15-caisi-question-period-note-disclosed.yaml
@@ -1,0 +1,38 @@
+# events/2025-09-15-caisi-question-period-note-disclosed.yaml
+
+id: caisi-question-period-note-disclosed-2025
+type: Publication
+schema_type: Event
+
+title: "ISED discloses a Question Period note on the Canadian AI Safety Institute"
+date: 2025-09-15
+status: completed
+
+organizations:
+  - id: ised-canada
+    role: publisher
+  - id: caisi
+    role: subject
+
+description: >
+  Innovation, Science and Economic Development Canada releases, through
+  proactive disclosure, a Question Period note (reference AIDI-2026-QP-00001)
+  prepared for Evan Solomon, Minister of Artificial Intelligence and Digital
+  Innovation, explaining why the government created the Canadian Artificial
+  Intelligence Safety Institute (CAISI) and summarizing its mandate, partners,
+  and research priorities.
+
+related_artifacts:
+  - id: caisi-question-period-note-2025
+
+tags:
+  - caisi
+  - question-period
+  - proactive-disclosure
+  - ised
+  - federal-government
+
+links:
+  - label: "Open Government — Question Period Note: Canadian Artificial Intelligence Safety Institute (AIDI-2026-QP-00001)"
+    url: https://search.open.canada.ca/qpnotes/record/ic,AIDI-2026-QP-00001
+    icon: document

--- a/data/organizations/caisi.yaml
+++ b/data/organizations/caisi.yaml
@@ -1,0 +1,15 @@
+# organizations/caisi.yaml
+
+id: caisi
+type: GovernmentOrganization
+schema_type: GovernmentOrganization
+country: ca
+
+name: "Canadian Artificial Intelligence Safety Institute"
+short_name: "CAISI"
+url: https://ised-isde.canada.ca/site/ised/en/canadian-artificial-intelligence-safety-institute
+
+tags:
+  - ai-safety
+  - federal-government
+  - canadian


### PR DESCRIPTION
## Summary

Adds the CAISI Question Period note requested in issue #77.

The proactively disclosed note (**AIDI-2026-QP-00001**, prepared for Minister Solomon) answers why the government created the **Canadian Artificial Intelligence Safety Institute**. It records CAISI's November 2024 creation, its use of CIFAR and the NRC, its founding membership in the International Network of AI Safety Institutes, its 2025–26 research priorities, a $1M partnership with the UK AI Security Institute, and an MOU with Cohere.

Adds:
- `data/artifacts/2025-09-15-caisi-question-period-note.yaml` (`type: PolicyDocument`)
- `data/events/2025-09-15-caisi-question-period-note-disclosed.yaml` (`type: Publication`) — companion timeline event so the note appears on the timeline, consistent with the repo convention that every artifact is referenced by an event
- `data/organizations/caisi.yaml` — new organization record for CAISI, referenced by both the note and the event

Source: the Open Government proactive-disclosure record and CAISI's ISED page.

## Test plan

- [x] `pnpm build` passes (schema + cross-references resolve)
- [x] `pnpm test` passes
- [ ] CI `Test / e2e`

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
