### PR TITLE
Add People section with profiles for key AI-governance figures (#7)

### DIFF
--- a/data/people/evan-solomon.yaml
+++ b/data/people/evan-solomon.yaml
@@ -1,0 +1,24 @@
+# people/evan-solomon.yaml
+
+id: evan-solomon
+schema_type: Person
+
+name: "Evan Solomon"
+role: "Minister of Artificial Intelligence and Digital Innovation"
+affiliation: "Government of Canada"
+
+bio: >
+  Evan Solomon is Canada's first Minister of Artificial Intelligence and
+  Digital Innovation, appointed in 2025 in the government of Prime Minister
+  Mark Carney. A former broadcast journalist, he leads the federal AI file —
+  including the "AI for All" national strategy, the AI Compute Access Fund and
+  Sovereign AI Compute Strategy, privacy reform under Bill C-36, and the
+  government's engagement with frontier developers such as Anthropic.
+
+wikipedia: https://en.wikipedia.org/wiki/Evan_Solomon
+
+tags:
+  - minister
+  - federal-government
+  - ai-for-all
+  - evan-solomon

--- a/data/people/francois-philippe-champagne.yaml
+++ b/data/people/francois-philippe-champagne.yaml
@@ -1,0 +1,24 @@
+# people/francois-philippe-champagne.yaml
+
+id: francois-philippe-champagne
+schema_type: Person
+
+name: "François-Philippe Champagne"
+role: "Minister of Finance and National Revenue"
+affiliation: "Government of Canada"
+
+bio: >
+  François-Philippe Champagne is a Liberal Member of Parliament and, since 2025,
+  Minister of Finance and National Revenue. As Minister of Innovation, Science
+  and Industry from 2021 to 2025 he led Canada's industrial AI agenda and
+  introduced Bill C-27, the Digital Charter Implementation Act, whose Artificial
+  Intelligence and Data Act (AIDA) would have been Canada's first dedicated AI
+  law before the bill died on prorogation in January 2025.
+
+wikipedia: https://en.wikipedia.org/wiki/Fran%C3%A7ois-Philippe_Champagne
+
+tags:
+  - minister
+  - federal-government
+  - bill-c-27
+  - aida

--- a/data/people/michael-geist.yaml
+++ b/data/people/michael-geist.yaml
@@ -1,0 +1,26 @@
+# people/michael-geist.yaml
+
+id: michael-geist
+schema_type: Person
+
+name: "Michael Geist"
+role: "Canada Research Chair in Internet and E-Commerce Law"
+affiliation: "University of Ottawa"
+
+bio: >
+  Michael Geist is a law professor at the University of Ottawa, where he holds
+  the Canada Research Chair in Internet and E-Commerce Law. One of Canada's most
+  prominent commentators on digital, privacy, and technology policy, he writes
+  widely on AI regulation and has appeared before parliamentary committees on
+  AI and privacy issues — including on Bill C-27's AIDA, the privacy reforms in
+  Bill C-36, and proposals to restrict minors' access to social media and AI
+  chatbots.
+
+url: https://www.michaelgeist.ca
+wikipedia: https://en.wikipedia.org/wiki/Michael_Geist
+
+tags:
+  - academic
+  - commentator
+  - privacy
+  - civil-society

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -155,4 +155,19 @@ const organizations = defineCollection({
   }),
 });
 
-export const collections = { events, artifacts, organizations };
+const people = defineCollection({
+  loader: yamlGlob({ pattern: "*.yaml", base: dataDir("people") }),
+  schema: z.object({
+    id: z.string(),
+    schema_type: z.literal("Person"),
+    name: z.string(),
+    role: z.string().optional(),
+    affiliation: z.string().optional(),
+    bio: z.string().optional(),
+    url: z.string().url().optional(),
+    wikipedia: z.string().url().optional(),
+    tags: z.array(z.string()).default([]),
+  }),
+});
+
+export const collections = { events, artifacts, organizations, people };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,6 +22,7 @@ const BUTTONDOWN_USERNAME = "jhenderson";
 const navLinks = [
   { href: "/timeline/", label: "Timeline" },
   { href: "/orgs/", label: "Organizations" },
+  { href: "/people/", label: "People" },
   { href: "/policy/", label: "Policy" },
 ];
 ---

--- a/src/lib/jsonld.test.ts
+++ b/src/lib/jsonld.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildEventJsonLd, buildCreativeWorkJsonLd, buildOrgJsonLd } from "./jsonld";
+import {
+  buildEventJsonLd,
+  buildCreativeWorkJsonLd,
+  buildOrgJsonLd,
+  buildPersonJsonLd,
+} from "./jsonld";
 
 describe("buildEventJsonLd", () => {
   it("sets context, type, name, startDate, url", () => {
@@ -188,5 +193,53 @@ describe("buildOrgJsonLd", () => {
       sameAs: "https://en.wikipedia.org/wiki/Senate_of_Canada",
     });
     expect(result.sameAs).toBe("https://en.wikipedia.org/wiki/Senate_of_Canada");
+  });
+});
+
+describe("buildPersonJsonLd", () => {
+  it("sets context, type, name", () => {
+    const result = buildPersonJsonLd({ name: "Evan Solomon" });
+    expect(result["@context"]).toBe("https://schema.org");
+    expect(result["@type"]).toBe("Person");
+    expect(result.name).toBe("Evan Solomon");
+  });
+
+  it("omits jobTitle, affiliation, url, sameAs when not provided", () => {
+    const result = buildPersonJsonLd({ name: "N" });
+    expect("jobTitle" in result).toBe(false);
+    expect("affiliation" in result).toBe(false);
+    expect("url" in result).toBe(false);
+    expect("sameAs" in result).toBe(false);
+  });
+
+  it("includes jobTitle when provided", () => {
+    const result = buildPersonJsonLd({
+      name: "Evan Solomon",
+      jobTitle: "Minister of Artificial Intelligence and Digital Innovation",
+    });
+    expect(result.jobTitle).toBe(
+      "Minister of Artificial Intelligence and Digital Innovation",
+    );
+  });
+
+  it("wraps affiliation as an Organization", () => {
+    const result = buildPersonJsonLd({
+      name: "Michael Geist",
+      affiliation: "University of Ottawa",
+    });
+    expect(result.affiliation).toEqual({
+      "@type": "Organization",
+      name: "University of Ottawa",
+    });
+  });
+
+  it("includes url and sameAs when provided", () => {
+    const result = buildPersonJsonLd({
+      name: "Michael Geist",
+      url: "https://www.michaelgeist.ca",
+      sameAs: "https://en.wikipedia.org/wiki/Michael_Geist",
+    });
+    expect(result.url).toBe("https://www.michaelgeist.ca");
+    expect(result.sameAs).toBe("https://en.wikipedia.org/wiki/Michael_Geist");
   });
 });

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -61,3 +61,23 @@ export function buildOrgJsonLd(params: {
   if (params.sameAs) ld.sameAs = params.sameAs;
   return ld;
 }
+
+export function buildPersonJsonLd(params: {
+  name: string;
+  jobTitle?: string;
+  affiliation?: string;
+  url?: string;
+  sameAs?: string;
+}): Record<string, unknown> {
+  const ld: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: params.name,
+  };
+  if (params.jobTitle) ld.jobTitle = params.jobTitle;
+  if (params.affiliation)
+    ld.affiliation = { "@type": "Organization", name: params.affiliation };
+  if (params.url) ld.url = params.url;
+  if (params.sameAs) ld.sameAs = params.sameAs;
+  return ld;
+}

--- a/src/pages/people/[id].astro
+++ b/src/pages/people/[id].astro
@@ -1,0 +1,70 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { buildPersonJsonLd } from "../../lib/jsonld";
+
+export async function getStaticPaths() {
+  const people = await getCollection("people");
+  return people.map((person) => ({
+    params: { id: person.id },
+    props: { person },
+  }));
+}
+
+const { person } = Astro.props;
+const { data } = person;
+
+const jsonLd = buildPersonJsonLd({
+  name: data.name,
+  jobTitle: data.role,
+  affiliation: data.affiliation,
+  url: data.url,
+  sameAs: data.wikipedia,
+});
+---
+
+<BaseLayout title={data.name} description={`Person: ${data.name}`} jsonLd={jsonLd}>
+  <p class="text-sm text-faint">
+    <a href="/people/" class="hover:underline text-accent-dark">← People</a>
+  </p>
+  <h1 class="mt-4 font-display text-3xl text-header">{data.name}</h1>
+  {data.role && <p class="mt-1 text-muted">{data.role}</p>}
+  {data.affiliation && <p class="mt-0.5 text-sm text-faint">{data.affiliation}</p>}
+
+  {data.bio && (
+    <p class="mt-6 max-w-2xl text-base text-ink leading-relaxed">{data.bio}</p>
+  )}
+
+  <div class="mt-4 flex flex-wrap gap-4 text-sm">
+    {data.url && (
+      <a
+        href={data.url}
+        class="text-accent-dark hover:underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Website ↗
+      </a>
+    )}
+    {data.wikipedia && (
+      <a
+        href={data.wikipedia}
+        class="text-accent-dark hover:underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Wikipedia ↗
+      </a>
+    )}
+  </div>
+
+  {data.tags.length > 0 && (
+    <section class="mt-8 flex flex-wrap gap-2">
+      {data.tags.map((t) => (
+        <span class="rounded bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+          #{t}
+        </span>
+      ))}
+    </section>
+  )}
+</BaseLayout>

--- a/src/pages/people/index.astro
+++ b/src/pages/people/index.astro
@@ -1,0 +1,41 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const people = [...(await getCollection("people"))].sort((a, b) =>
+  a.data.name.localeCompare(b.data.name),
+);
+---
+
+<BaseLayout
+  title="People"
+  description="Ministers, officials, academics, and advocates shaping AI governance in Canada."
+>
+  <h1 class="font-display text-4xl text-header">People</h1>
+  <p class="mt-2 max-w-2xl text-muted">
+    Ministers, officials, academics, and advocates shaping AI governance in Canada.
+  </p>
+
+  {people.length === 0 ? (
+    <p class="mt-10 text-faint">No people tracked yet.</p>
+  ) : (
+    <ul class="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {people.map((person) => (
+        <li>
+          <a
+            href={`/people/${person.id}/`}
+            class="block h-full rounded-r-lg border border-border border-l-4 border-l-accent bg-surface p-5 hover:border-l-accent-dark hover:shadow-sm transition-all no-underline"
+          >
+            <h2 class="font-display text-lg text-header">{person.data.name}</h2>
+            {person.data.role && (
+              <p class="mt-1 text-sm text-muted">{person.data.role}</p>
+            )}
+            {person.data.affiliation && (
+              <p class="mt-0.5 text-xs text-faint">{person.data.affiliation}</p>
+            )}
+          </a>
+        </li>
+      ))}
+    </ul>
+  )}
+</BaseLayout>


### PR DESCRIPTION
## Summary

Adds the People section requested in issue #7 — profiles of the individuals shaping AI governance in Canada.

This introduces a new content collection and pages (mirroring the existing `organizations` pattern):

- **New `people` collection** in `src/content.config.ts` (`schema.org/Person`: `name`, `role`, `affiliation`, `bio`, `url`, `wikipedia`, `tags`).
- **Pages**: `/people/` listing and `/people/[id]/` detail, plus a **"People" header nav link**.
- **`buildPersonJsonLd`** helper in `src/lib/jsonld.ts` (with unit tests) emitting Person structured data on detail pages.
- **Seed profiles**: Evan Solomon (Minister of AI and Digital Innovation), François-Philippe Champagne (ex-ISED minister who introduced Bill C-27/AIDA; now Minister of Finance), and Michael Geist (University of Ottawa; prominent AI/privacy commentator) — the three named in the issue.

### Scope notes

- This is a self-contained first version. Existing artifact `authors` remain free-text; wiring structured event/artifact ↔ person cross-references (like the org `role` links) is a natural follow-up.
- More profiles (e.g. Mark Carney, Sean Fraser, report authors) can be added as plain data files with no code changes.

## Test plan

- [x] `pnpm build` — new collection validates; `/people/` and all three detail pages generate
- [x] `pnpm test` — unit tests pass, including new `buildPersonJsonLd` tests
- [ ] CI `Test / e2e` (Playwright chromium is not installable in the dev sandbox; relying on CI)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)