### PR TITLE
Show short summaries on Policy page cards (#117)

### DIFF
--- a/.claude/skills/adding-legislation/SKILL.md
+++ b/.claude/skills/adding-legislation/SKILL.md
@@ -37,6 +37,8 @@ organizations:
   - id: <committee-or-sponsoring-dept-id>
     role: reviewed_by | sponsor
 
+summary: "1–2 plain-text sentences, ≤ 300 chars — shown on the Policy page card. No markdown."
+
 description: |          # literal block scalar (|), NOT folded (>). See "Description" below.
   A few paragraphs: what the bill is, what it would do, where it currently
   sits, and the key dates. This is the text a reader scanning the artifact
@@ -89,9 +91,11 @@ If it prints `1` for text you wrote as several paragraphs, you used `>` —
 switch to `|`. (Single-paragraph fields like a provision `summary:` are
 fine with `>`; the trap is only multi-paragraph `description`.)
 
-Note: the policy listing card (`PolicyWithSourceFilter.tsx`) renders the
-*same* `description` as raw text in one `<p>`, so it always shows as a
-single block there regardless — only the artifact detail page paragraph-breaks.
+Every artifact should also carry a one-to-two-sentence `summary` (≤ 300
+characters, plain text) — the policy listing card
+(`PolicyWithSourceFilter.tsx`) shows `summary` and only falls back to a
+clamped first paragraph of `description` when it is missing. Only the
+artifact detail page renders the full `description`.
 
 ### The two events
 

--- a/data/artifacts/2017-03-22-pan-canadian-ai-strategy.yaml
+++ b/data/artifacts/2017-03-22-pan-canadian-ai-strategy.yaml
@@ -14,6 +14,7 @@ organizations:
 lifecycle_status: active
 current_stage: "Phase 2 underway (2021–2031)"
 
+summary: "Federal funding program from Budget 2017 that made Canada an early mover in national AI strategy — administered by CIFAR and funding the Vector Institute, Mila, and Amii to build research talent."
 description: >
   The Pan-Canadian Artificial Intelligence Strategy (PCAIS) is a federal
   government funding program, first announced in Budget 2017, that established

--- a/data/artifacts/2021-04-19-scc-ai-program.yaml
+++ b/data/artifacts/2021-04-19-scc-ai-program.yaml
@@ -22,6 +22,7 @@ derives_from:
   - id: canada-national-ai-strategy-launched-2026
     relationship: renewed_by
 
+summary: "The Standards Council of Canada's federal program for AI and data governance standardization — the standards-and-certification layer of Canada's AI governance toolkit, complementing legislation and voluntary codes."
 description: |
   The Standards Council of Canada (SCC) runs the federal program to advance
   the development and adoption of standards and conformity assessment for

--- a/data/artifacts/2022-06-16-bill-c27-aida.yaml
+++ b/data/artifacts/2022-06-16-bill-c27-aida.yaml
@@ -14,6 +14,7 @@ organizations:
   - id: house-of-commons-indu-committee
     role: reviewed_by
 
+summary: "Bundled privacy reform with the Artificial Intelligence and Data Act (AIDA), Canada's first proposed federal AI-specific legislation. Died on the order paper when Parliament was prorogued in January 2025."
 description: |
   The Digital Charter Implementation Act, 2022 bundled three components: the
   Consumer Privacy Protection Act, the Personal Information and Data Protection

--- a/data/artifacts/2023-05-19-hiroshima-ai-process.yaml
+++ b/data/artifacts/2023-05-19-hiroshima-ai-process.yaml
@@ -14,6 +14,7 @@ organizations:
   - id: oecd
     role: implementing_partner
 
+summary: "The G7's initiative for international governance of advanced AI, launched in May 2023. Produced voluntary guiding principles, a code of conduct for advanced AI developers, and the OECD-run HAIP reporting framework."
 description: |
   The Hiroshima AI Process (HAIP) is the G7's initiative for international
   governance of advanced AI systems, launched at the G7 Hiroshima Summit in

--- a/data/artifacts/2023-08-16-ised-gen-ai-code-of-practice.yaml
+++ b/data/artifacts/2023-08-16-ised-gen-ai-code-of-practice.yaml
@@ -14,6 +14,7 @@ organizations:
 lifecycle_status: active
 current_stage: "Published; consultation closed September 2023"
 
+summary: "Principles framework defining six outcomes — safety, fairness, transparency, human oversight, robustness, and accountability — that Canadian developers and deployers of advanced generative AI should achieve."
 description: >
   The substantive principles framework underlying Canada's voluntary approach
   to generative AI governance. Defines six outcomes that developers and

--- a/data/artifacts/2023-09-27-ised-voluntary-code-of-conduct-gen-ai.yaml
+++ b/data/artifacts/2023-09-27-ised-voluntary-code-of-conduct-gen-ai.yaml
@@ -14,6 +14,7 @@ organizations:
 lifecycle_status: active
 current_stage: "Active; 51 signatories as of March 2025"
 
+summary: "The voluntary commitment instrument organizations sign to adopt the Guardrails for Generative AI outcomes. With AIDA dead, it remains the primary federal mechanism for AI accountability — 51 signatories as of March 2025."
 description: >
   The commitment instrument that Canadian organizations voluntarily sign to
   adopt the six outcomes defined in the Canadian Guardrails for Generative AI

--- a/data/artifacts/2023-10-18-aigs-governing-ai-2023.yaml
+++ b/data/artifacts/2023-10-18-aigs-governing-ai-2023.yaml
@@ -18,6 +18,7 @@ organizations:
   - id: aigs-canada
     role: publisher
 
+summary: "White paper by AI Governance and Safety Canada outlining five high-impact actions for the federal government to significantly advance AI governance by mid-2024."
 description: >
   White paper by AI Governance and Safety Canada (AIGS) outlining five
   high-impact actions for the Canadian government to significantly advance

--- a/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
+++ b/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
@@ -20,6 +20,7 @@ organizations:
   - id: aigs-canada
     role: publisher
 
+summary: "Updated AIGS white paper with five high-impact actions for mid-2025, recommending a Ministry of AI, improved legislation, and increased safety research investment."
 description: >
   Updated white paper by AI Governance and Safety Canada (AIGS) outlining
   five high-impact actions for the Canadian government to significantly advance

--- a/data/artifacts/2025-09-15-caisi-question-period-note.yaml
+++ b/data/artifacts/2025-09-15-caisi-question-period-note.yaml
@@ -13,6 +13,7 @@ organizations:
   - id: caisi
     role: subject
 
+summary: "Proactively disclosed Question Period note explaining why Canada created the Canadian AI Safety Institute (CAISI) in November 2024 and noting its role as a founding member of the International Network of AI Safety Institutes."
 description: |
   A Question Period note (reference AIDI-2026-QP-00001) prepared for Evan
   Solomon, Minister of Artificial Intelligence and Digital Innovation, and

--- a/data/artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
+++ b/data/artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
@@ -16,6 +16,7 @@ organizations:
   - id: aigs-canada
     role: publisher
 
+summary: "AIGS white paper warning that smarter-than-human AI may arrive within 18 months and urging Canada to lead global talks while building resilience at home."
 description: >
   White paper by AI Governance and Safety Canada (AIGS) warning that leading
   AI labs may develop smarter-than-human AI within 18 months and urging

--- a/data/artifacts/2025-12-08-canada-germany-digital-alliance.yaml
+++ b/data/artifacts/2025-12-08-canada-germany-digital-alliance.yaml
@@ -11,6 +11,7 @@ organizations:
   - id: ised-canada
     role: publisher
 
+summary: "Joint ministerial statement from the December 2025 G7 digital ministers' meeting in Montréal announcing a Canada-Germany Digital Alliance to deepen bilateral digital and AI cooperation."
 description: >
   Joint statement issued by Canada's Minister of Artificial Intelligence and
   Digital Innovation, the Honourable Evan Solomon, and Germany's Minister for

--- a/data/artifacts/2025-12-09-bill-c16-protecting-victims-act.yaml
+++ b/data/artifacts/2025-12-09-bill-c16-protecting-victims-act.yaml
@@ -14,6 +14,7 @@ organizations:
   - id: department-of-justice-canada
     role: sponsor
 
+summary: "Omnibus criminal-law bill that received royal assent in June 2026, tracked here because committee amendments extended the Criminal Code's non-consensual intimate-image provisions to images created or altered using AI."
 description: |
   Bill C-16, the Protecting Victims Act, is an omnibus criminal-law bill that
   amends the Criminal Code and related Acts on child protection, gender-based

--- a/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+++ b/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
@@ -18,6 +18,7 @@ organizations:
   - id: dsit-uk
     role: publisher
 
+summary: "Comprehensive assessment of AI capabilities, risks, and risk-management practices, led by Yoshua Bengio and produced by over 100 independent experts from more than 30 countries, commissioned by the UK government."
 description: >
   Comprehensive international assessment of AI safety, led by Yoshua Bengio and
   produced by over 100 independent experts from more than 30 countries. Commissioned

--- a/data/artifacts/2026-02-05-ai-strategy-summary-of-inputs.yaml
+++ b/data/artifacts/2026-02-05-ai-strategy-summary-of-inputs.yaml
@@ -15,6 +15,7 @@ derives_from:
   - id: ai-strategy-sprint-launched-2025
     relationship: summary_of
 
+summary: "ISED's synthesis of Canada's largest public consultation on AI policy — over 11,300 responses and nearly 300 submissions — identifying eight priority areas that informed the 2026 national AI strategy."
 description: >
   Synthesizes feedback from Canada's largest public consultation on AI policy.
   The report draws on over 11,300 responses from a 30-day online consultation

--- a/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
+++ b/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
@@ -20,6 +20,7 @@ organizations:
   - id: privy-council-office-canada
     role: co_host
 
+summary: "Workshop summary from CIGI and the Privy Council Office exploring five possible AI futures to 2030 and offering policy recommendations on the national-security implications of next-generation AI systems."
 description: >
   Summary report from the AI National Security Scenarios Workshop co-hosted
   by the Global AI Risks Initiative at CIGI and the Privy Council Office of

--- a/data/artifacts/2026-02-14-canada-germany-ai-joint-declaration.yaml
+++ b/data/artifacts/2026-02-14-canada-germany-ai-joint-declaration.yaml
@@ -11,6 +11,7 @@ organizations:
   - id: ised-canada
     role: publisher
 
+summary: "Declaration signed at the Munich Security Conference creating a practical framework for Canada-Germany cooperation on secure compute infrastructure and sovereign AI capabilities, building on the December 2025 Digital Alliance."
 description: >
   Joint Declaration of Intent on Artificial Intelligence signed by Canada's
   Minister of Artificial Intelligence and Digital Innovation, the Honourable

--- a/data/artifacts/2026-03-10-munk-sovereign-by-design.yaml
+++ b/data/artifacts/2026-03-10-munk-sovereign-by-design.yaml
@@ -18,6 +18,7 @@ organizations:
   - id: munk-school-uoft
     role: publisher
 
+summary: "Munk School report assessing Canada's position across the AI technology stack, warning that gaps in cloud infrastructure and compute hardware leave Canada vulnerable, and framing sovereignty as freedom from coercion rather than isolationism."
 description: |
   A report from the AI Competitiveness Project at the Munk School of Global
   Affairs & Public Policy (University of Toronto), authored by Senior Fellows

--- a/data/artifacts/2026-04-11-liberal-convention-ai-act-resolution.yaml
+++ b/data/artifacts/2026-04-11-liberal-convention-ai-act-resolution.yaml
@@ -11,6 +11,7 @@ organizations:
   - id: liberal-party-of-canada
     role: adopted_by
 
+summary: "Policy resolution adopted at the Liberal Party's 2026 National Convention calling for a Canadian Artificial Intelligence Act modelled on the EU AI Act, with risk-based regulation of high-risk AI systems."
 description: |
   A policy resolution adopted by Liberal Party of Canada members at the party's
   2026 National Convention in Montreal, calling for the introduction of a

--- a/data/artifacts/2026-04-14-canada-finland-joint-statement.yaml
+++ b/data/artifacts/2026-04-14-canada-finland-joint-statement.yaml
@@ -11,6 +11,7 @@ organizations:
   - id: ised-canada
     role: publisher
 
+summary: "Joint statement by Prime Minister Carney and President Stubb setting out a new phase of bilateral cooperation on sovereign technology, AI compute capacity, quantum research, Arctic issues, and defence."
 description: >
   Joint statement issued by Prime Minister Mark Carney and President of Finland
   Alexander Stubb following meetings in Ottawa on April 14, 2026. The statement

--- a/data/artifacts/2026-05-28-controlai-canada-superintelligence-statement.yaml
+++ b/data/artifacts/2026-05-28-controlai-canada-superintelligence-statement.yaml
@@ -11,6 +11,7 @@ organizations:
   - id: controlai
     role: publisher
 
+summary: "Campaign statement co-signed by a multipartisan group of MPs and senators calling for Canada to negotiate an international \"trust but verify\" regime to prohibit the development of superintelligent AI."
 description: >
   A short campaign statement, co-signed by a multipartisan group of Canadian
   MPs and senators and endorsed by leading AI researchers, calling for Canada

--- a/data/artifacts/2026-06-04-canada-national-ai-strategy-ai-for-all.yaml
+++ b/data/artifacts/2026-06-04-canada-national-ai-strategy-ai-for-all.yaml
@@ -18,6 +18,7 @@ derives_from:
   - id: ai-strategy-summary-of-inputs-published-2026
     relationship: informed_by
 
+summary: "Canada's renewed national AI strategy, launched by Prime Minister Carney in June 2026 and led by ISED. Builds on the 2017 Pan-Canadian AI Strategy and the AI Sprint consultations rather than replacing them."
 description: |
   "AI for All" is Canada's renewed national AI strategy, launched by Prime
   Minister Mark Carney in Toronto on 4 June 2026 and led by Innovation,

--- a/data/artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
+++ b/data/artifacts/2026-06-10-bill-c34-safe-social-media-act.yaml
@@ -14,6 +14,7 @@ organizations:
   - id: canadian-heritage
     role: sponsor
 
+summary: "Would create a federal online-safety regime aimed at protecting children: a minimum social-media age of 16, mandated age verification, platform duty-to-act-responsibly obligations, and a new Digital Safety Commission of Canada."
 description: |
   The Safe Social Media Act (Bill C-34) would enact two new statutes — the
   Digital Safety Act and the Digital Safety Commission of Canada Act — creating

--- a/data/artifacts/2026-06-15-bill-c36-ppcda.yaml
+++ b/data/artifacts/2026-06-15-bill-c36-ppcda.yaml
@@ -18,6 +18,7 @@ derives_from:
   - id: canada-national-ai-strategy-launched-2026
     relationship: advances
 
+summary: "The Carney government's successor to Bill C-27's privacy reforms. Recognizes privacy as a fundamental right and creates a Digital Safety and Data Protection Commission of Canada with enhanced enforcement powers."
 description: |
   Bill C-36 would enact the Protecting Privacy and Consumer Data Act (PPCDA),
   amend the Personal Information Protection and Electronic Documents Act

--- a/docs/superpowers/plans/2026-07-03-policy-card-summary.md
+++ b/docs/superpowers/plans/2026-07-03-policy-card-summary.md
@@ -1,0 +1,338 @@
+# Policy Card Summary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the full artifact description on Policy page cards with a short hand-written `summary`, fixing issue #117's wall of text.
+
+**Architecture:** A new optional `summary` field on the artifacts content collection flows through `src/pages/policy/index.astro` into `PolicyWithSourceFilter.tsx`, which renders it on the card. Artifacts without a summary fall back to the existing `leadText()` first-paragraph helper clamped to three lines. The artifact detail page keeps the full description.
+
+**Tech Stack:** Astro content collections (zod schema), React + Vitest + Testing Library, Tailwind 4 (`line-clamp-3`), YAML data files.
+
+**Spec:** `docs/superpowers/specs/2026-07-03-policy-card-summary-design.md`
+
+## Global Constraints
+
+- Summaries are 1–2 plain-text sentences, no markdown, ≤ 300 characters (enforced by `z.string().max(300)`).
+- In YAML files, `summary` sits directly above `description`.
+- Work happens on branch `feature/policy-card-summary`; merge to `main` via PR only (branch protection).
+- Test commands: `pnpm test` (Vitest unit), `pnpm build` (validates content schema), `pnpm test:e2e` (Playwright).
+
+---
+
+### Task 1: Summary rendering in PolicyWithSourceFilter (schema + component + pass-through)
+
+**Files:**
+- Modify: `src/content.config.ts` (artifacts collection schema, ~line 76)
+- Modify: `src/components/PolicyWithSourceFilter.tsx` (ArtifactEntry type ~line 22, card body ~line 150)
+- Modify: `src/pages/policy/index.astro` (artifact mapping ~line 37)
+- Test: `src/components/PolicyWithSourceFilter.test.tsx`
+
+**Interfaces:**
+- Consumes: `leadText(markdown: string): string` from `src/lib/format.ts` (exists).
+- Produces: `ArtifactEntry.summary?: string`; artifacts schema accepts optional `summary` ≤ 300 chars. Task 2's YAML `summary:` fields validate against this schema.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the `describe("PolicyWithSourceFilter", ...)` block in `src/components/PolicyWithSourceFilter.test.tsx`:
+
+```tsx
+it("renders the summary instead of the description when a summary is present", () => {
+  const withSummary: ArtifactEntry = {
+    ...govArtifact,
+    summary: "Canada's first proposed federal AI law.",
+    description: "Part 3 of Bill C-27 contained AIDA.\n\nIt died on prorogation.",
+  };
+  render(<PolicyWithSourceFilter artifacts={[withSummary]} />);
+  expect(screen.getByText("Canada's first proposed federal AI law.")).toBeInTheDocument();
+  expect(screen.queryByText(/Part 3 of Bill C-27/)).not.toBeInTheDocument();
+});
+
+it("falls back to the description's first paragraph, clamped, when summary is absent", () => {
+  const noSummary: ArtifactEntry = {
+    ...govArtifact,
+    description: "First paragraph text.\n\nSecond paragraph text.",
+  };
+  render(<PolicyWithSourceFilter artifacts={[noSummary]} />);
+  const fallback = screen.getByText("First paragraph text.");
+  expect(fallback).toHaveClass("line-clamp-3");
+  expect(screen.queryByText(/Second paragraph text/)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- src/components/PolicyWithSourceFilter.test.tsx`
+Expected: the first new test FAILS (full description currently rendered, and `summary` is not in the `ArtifactEntry` type — TypeScript error is also acceptable evidence). The second FAILS on the `line-clamp-3` class assertion and on the second paragraph being visible.
+
+- [ ] **Step 3: Implement**
+
+In `src/content.config.ts`, in the `artifacts` collection schema, directly above `description`:
+
+```ts
+summary: z.string().max(300).optional(),
+description: z.string().optional(),
+```
+
+In `src/components/PolicyWithSourceFilter.tsx`:
+
+1. Add the import:
+
+```tsx
+import { fmtDate, leadText } from "../lib/format";
+```
+
+(replacing the existing `import { fmtDate } from "../lib/format";`)
+
+2. Add `summary?: string;` to `ArtifactEntry` directly above `description?: string;`.
+
+3. Replace the description paragraph:
+
+```tsx
+{artifact.description && (
+  <p className="mt-2 text-sm text-muted">{artifact.description}</p>
+)}
+```
+
+with:
+
+```tsx
+{artifact.summary ? (
+  <p className="mt-2 text-sm text-muted">{artifact.summary}</p>
+) : artifact.description ? (
+  <p className="mt-2 text-sm text-muted line-clamp-3">
+    {leadText(artifact.description)}
+  </p>
+) : null}
+```
+
+In `src/pages/policy/index.astro`, add to the returned object in the `.map()` (below `description`):
+
+```ts
+summary: a.data.summary,
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test`
+Expected: all unit tests PASS (the two new ones plus all pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/content.config.ts src/components/PolicyWithSourceFilter.tsx src/components/PolicyWithSourceFilter.test.tsx src/pages/policy/index.astro
+git commit -m "Show summary on policy cards, clamped lead paragraph as fallback (#117)"
+```
+
+---
+
+### Task 2: Write summaries for all 23 artifacts
+
+**Files:**
+- Modify: every file in `data/artifacts/` (23 YAML files)
+
+**Interfaces:**
+- Consumes: the `summary: z.string().max(300).optional()` schema from Task 1.
+- Produces: card-ready `summary` values rendered by Task 1's component.
+
+- [ ] **Step 1: Add `summary` to each YAML file, directly above `description`**
+
+Use exactly these values (each is a quoted single-line YAML string):
+
+`2017-03-22-pan-canadian-ai-strategy.yaml`:
+```yaml
+summary: "Federal funding program from Budget 2017 that made Canada an early mover in national AI strategy — administered by CIFAR and funding the Vector Institute, Mila, and Amii to build research talent."
+```
+
+`2021-04-19-scc-ai-program.yaml`:
+```yaml
+summary: "The Standards Council of Canada's federal program for AI and data governance standardization — the standards-and-certification layer of Canada's AI governance toolkit, complementing legislation and voluntary codes."
+```
+
+`2022-06-16-bill-c27-aida.yaml`:
+```yaml
+summary: "Bundled privacy reform with the Artificial Intelligence and Data Act (AIDA), Canada's first proposed federal AI-specific legislation. Died on the order paper when Parliament was prorogued in January 2025."
+```
+
+`2023-05-19-hiroshima-ai-process.yaml`:
+```yaml
+summary: "The G7's initiative for international governance of advanced AI, launched in May 2023. Produced voluntary guiding principles, a code of conduct for advanced AI developers, and the OECD-run HAIP reporting framework."
+```
+
+`2023-08-16-ised-gen-ai-code-of-practice.yaml`:
+```yaml
+summary: "Principles framework defining six outcomes — safety, fairness, transparency, human oversight, robustness, and accountability — that Canadian developers and deployers of advanced generative AI should achieve."
+```
+
+`2023-09-27-ised-voluntary-code-of-conduct-gen-ai.yaml`:
+```yaml
+summary: "The voluntary commitment instrument organizations sign to adopt the Guardrails for Generative AI outcomes. With AIDA dead, it remains the primary federal mechanism for AI accountability — 51 signatories as of March 2025."
+```
+
+`2023-10-18-aigs-governing-ai-2023.yaml`:
+```yaml
+summary: "White paper by AI Governance and Safety Canada outlining five high-impact actions for the federal government to significantly advance AI governance by mid-2024."
+```
+
+`2024-06-26-aigs-governing-ai-2024.yaml`:
+```yaml
+summary: "Updated AIGS white paper with five high-impact actions for mid-2025, recommending a Ministry of AI, improved legislation, and increased safety research investment."
+```
+
+`2025-09-15-caisi-question-period-note.yaml`:
+```yaml
+summary: "Proactively disclosed Question Period note explaining why Canada created the Canadian AI Safety Institute (CAISI) in November 2024 and noting its role as a founding member of the International Network of AI Safety Institutes."
+```
+
+`2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml`:
+```yaml
+summary: "AIGS white paper warning that smarter-than-human AI may arrive within 18 months and urging Canada to lead global talks while building resilience at home."
+```
+
+`2025-12-08-canada-germany-digital-alliance.yaml`:
+```yaml
+summary: "Joint ministerial statement from the December 2025 G7 digital ministers' meeting in Montréal announcing a Canada-Germany Digital Alliance to deepen bilateral digital and AI cooperation."
+```
+
+`2025-12-09-bill-c16-protecting-victims-act.yaml`:
+```yaml
+summary: "Omnibus criminal-law bill that received royal assent in June 2026, tracked here because committee amendments extended the Criminal Code's non-consensual intimate-image provisions to images created or altered using AI."
+```
+
+`2026-02-01-international-ai-safety-report-2026.yaml`:
+```yaml
+summary: "Comprehensive assessment of AI capabilities, risks, and risk-management practices, led by Yoshua Bengio and produced by over 100 independent experts from more than 30 countries, commissioned by the UK government."
+```
+
+`2026-02-05-ai-strategy-summary-of-inputs.yaml`:
+```yaml
+summary: "ISED's synthesis of Canada's largest public consultation on AI policy — over 11,300 responses and nearly 300 submissions — identifying eight priority areas that informed the 2026 national AI strategy."
+```
+
+`2026-02-06-cigi-pco-ai-national-security-report.yaml`:
+```yaml
+summary: "Workshop summary from CIGI and the Privy Council Office exploring five possible AI futures to 2030 and offering policy recommendations on the national-security implications of next-generation AI systems."
+```
+
+`2026-02-14-canada-germany-ai-joint-declaration.yaml`:
+```yaml
+summary: "Declaration signed at the Munich Security Conference creating a practical framework for Canada-Germany cooperation on secure compute infrastructure and sovereign AI capabilities, building on the December 2025 Digital Alliance."
+```
+
+`2026-03-10-munk-sovereign-by-design.yaml`:
+```yaml
+summary: "Munk School report assessing Canada's position across the AI technology stack, warning that gaps in cloud infrastructure and compute hardware leave Canada vulnerable, and framing sovereignty as freedom from coercion rather than isolationism."
+```
+
+`2026-04-11-liberal-convention-ai-act-resolution.yaml`:
+```yaml
+summary: "Policy resolution adopted at the Liberal Party's 2026 National Convention calling for a Canadian Artificial Intelligence Act modelled on the EU AI Act, with risk-based regulation of high-risk AI systems."
+```
+
+`2026-04-14-canada-finland-joint-statement.yaml`:
+```yaml
+summary: "Joint statement by Prime Minister Carney and President Stubb setting out a new phase of bilateral cooperation on sovereign technology, AI compute capacity, quantum research, Arctic issues, and defence."
+```
+
+`2026-05-28-controlai-canada-superintelligence-statement.yaml`:
+```yaml
+summary: "Campaign statement co-signed by a multipartisan group of MPs and senators calling for Canada to negotiate an international \"trust but verify\" regime to prohibit the development of superintelligent AI."
+```
+
+`2026-06-04-canada-national-ai-strategy-ai-for-all.yaml`:
+```yaml
+summary: "Canada's renewed national AI strategy, launched by Prime Minister Carney in June 2026 and led by ISED. Builds on the 2017 Pan-Canadian AI Strategy and the AI Sprint consultations rather than replacing them."
+```
+
+`2026-06-10-bill-c34-safe-social-media-act.yaml`:
+```yaml
+summary: "Would create a federal online-safety regime aimed at protecting children: a minimum social-media age of 16, mandated age verification, platform duty-to-act-responsibly obligations, and a new Digital Safety Commission of Canada."
+```
+
+`2026-06-15-bill-c36-ppcda.yaml`:
+```yaml
+summary: "The Carney government's successor to Bill C-27's privacy reforms. Recognizes privacy as a fundamental right and creates a Digital Safety and Data Protection Commission of Canada with enhanced enforcement powers."
+```
+
+- [ ] **Step 2: Verify every artifact has a summary within limits**
+
+Run:
+
+```bash
+node -e "
+const fs=require('fs');
+let fail=false;
+for(const f of fs.readdirSync('data/artifacts')){
+  const t=fs.readFileSync('data/artifacts/'+f,'utf8');
+  const m=t.match(/^summary: \"(.*)\"$/m);
+  if(!m){console.log('MISSING',f);fail=true;continue;}
+  const s=m[1].replace(/\\\\\"/g,'\"');
+  if(s.length>300){console.log('TOO LONG ('+s.length+')',f);fail=true;}
+}
+console.log(fail?'FAIL':'OK: all 23 summaries present and <=300 chars');
+process.exit(fail?1:0)"
+```
+
+Expected: `OK: all 23 summaries present and <=300 chars`
+
+- [ ] **Step 3: Build to validate against the schema**
+
+Run: `pnpm build`
+Expected: build succeeds; zod rejects nothing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/artifacts/
+git commit -m "Add card summaries to all 23 artifacts (#117)"
+```
+
+---
+
+### Task 3: Update contributor docs and run the full suite
+
+**Files:**
+- Modify: `.claude/skills/adding-legislation/SKILL.md` (artifact fields section, near the `description: |` guidance around line 40)
+
+**Interfaces:**
+- Consumes: the `summary` field conventions from Tasks 1–2.
+- Produces: nothing consumed by other tasks; final verification gate for the branch.
+
+- [ ] **Step 1: Document the `summary` field**
+
+In `.claude/skills/adding-legislation/SKILL.md`, directly above the `description: |` line in the artifact template, add:
+
+```yaml
+summary: "1–2 plain-text sentences, ≤ 300 chars — shown on the Policy page card. No markdown."
+```
+
+And in the prose near the Description guidance, add one sentence:
+
+> Every artifact should also carry a one-to-two-sentence `summary` (≤ 300 characters, plain text) — the Policy page shows `summary` on the card and only falls back to a clamped first paragraph of `description` when it is missing.
+
+- [ ] **Step 2: Run the full verification suite**
+
+Run: `pnpm test && pnpm test:e2e`
+Expected: all Vitest unit tests PASS; build succeeds; all Playwright e2e specs PASS (policy specs assert titles, badges, stage text, and hrefs — none of which change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/adding-legislation/SKILL.md
+git commit -m "Document artifact summary field in adding-legislation skill (#117)"
+```
+
+---
+
+### Task 4: Open the PR
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+git push -u origin feature/policy-card-summary
+```
+
+Then create a PR against `main` titled "Show short summaries on Policy page cards (#117)" whose body links the spec (`docs/superpowers/specs/2026-07-03-policy-card-summary-design.md`), this plan, and issue #117 (use "Closes #117"), and includes a Test plan checklist (unit tests, build, e2e).
+
+- [ ] **Step 2: Confirm CI**
+
+Wait for `Test / unit` and `Test / e2e` checks to pass on the PR.

--- a/docs/superpowers/specs/2026-07-03-policy-card-summary-design.md
+++ b/docs/superpowers/specs/2026-07-03-policy-card-summary-design.md
@@ -1,0 +1,77 @@
+# Policy Card Summary — Design
+
+**Date:** 2026-07-03
+**Issue:** [#117 — Fix Policy page wall of text](https://github.com/jrhender/ai-governance-tracker/issues/117)
+
+## Problem
+
+Every card on the Policy page renders the artifact's full `description`. Descriptions
+run 342–2,400 characters of multi-paragraph text across the 19 artifacts, so the page
+reads as a wall of text. Each card already links to a detail page
+(`/artifacts/{id}/`) that renders the full description, so the card copy is redundant.
+
+## Decision
+
+Add an optional `summary` field to the artifact schema and show it on Policy cards
+instead of `description`. When an artifact has no `summary`, fall back to
+`leadText(description)` (the existing first-paragraph helper in `src/lib/format.ts`)
+clamped to three lines, so future artifacts degrade gracefully rather than regressing
+to a wall of text.
+
+Alternatives considered:
+
+- **CSS `line-clamp` only** — zero data work, but cuts text mid-sentence and the
+  opening sentences of existing descriptions were not written to stand alone.
+- **First-sentence extraction** — no schema change, but quality depends on how each
+  description happens to open, and sentence splitting is fragile.
+
+Hand-written summaries give the best card reading quality for a one-time cost of
+writing 19 short summaries; the fallback covers anything unsummarized.
+
+## Changes
+
+### Schema (`src/content.config.ts`)
+
+Add to the `artifacts` collection schema:
+
+```ts
+summary: z.string().max(300).optional(),
+```
+
+The `max(300)` keeps summaries card-sized — a longer "summary" defeats the purpose
+and fails the build with a clear error.
+
+### Data (`data/artifacts/*.yaml`)
+
+Add a `summary` to each of the 19 artifacts: 1–2 plain-text sentences (no markdown),
+≤ 300 characters, stating what the artifact is and why it matters. Place it directly
+above `description`.
+
+### Policy page (`src/pages/policy/index.astro`, `src/components/PolicyWithSourceFilter.tsx`)
+
+- Pass `summary` through in the `ArtifactEntry` mapping and type.
+- On the card, replace the full-description paragraph with:
+  - `artifact.summary` when present, or
+  - `leadText(artifact.description)` with Tailwind `line-clamp-3` otherwise.
+
+Everything else on the card (title, badges, stage line, date) is unchanged. The
+artifact detail page is unchanged and keeps the full description.
+
+### Docs (`.claude/skills/adding-legislation/SKILL.md`)
+
+Note the `summary` field and its conventions where the skill describes artifact
+fields, so future entries include one.
+
+## Testing
+
+- **Unit (`PolicyWithSourceFilter.test.tsx`):** a card with a `summary` renders the
+  summary and not the description body; a card without one renders the description's
+  first paragraph with the clamp class.
+- **e2e (`e2e/policy.spec.ts`):** existing specs assert titles, badges, and stage
+  text, none of which change; run to confirm. No new e2e needed — the behavior is
+  covered at unit level.
+
+## Out of scope
+
+- Summaries on other pages (timeline, event detail) — they already use `leadText`.
+- Any change to the artifact detail page.

--- a/docs/superpowers/specs/2026-07-03-policy-card-summary-design.md
+++ b/docs/superpowers/specs/2026-07-03-policy-card-summary-design.md
@@ -6,7 +6,7 @@
 ## Problem
 
 Every card on the Policy page renders the artifact's full `description`. Descriptions
-run 342–2,400 characters of multi-paragraph text across the 19 artifacts, so the page
+run 342–2,400 characters of multi-paragraph text across the 23 artifacts, so the page
 reads as a wall of text. Each card already links to a detail page
 (`/artifacts/{id}/`) that renders the full description, so the card copy is redundant.
 
@@ -26,7 +26,7 @@ Alternatives considered:
   description happens to open, and sentence splitting is fragile.
 
 Hand-written summaries give the best card reading quality for a one-time cost of
-writing 19 short summaries; the fallback covers anything unsummarized.
+writing 23 short summaries; the fallback covers anything unsummarized.
 
 ## Changes
 
@@ -43,7 +43,7 @@ and fails the build with a clear error.
 
 ### Data (`data/artifacts/*.yaml`)
 
-Add a `summary` to each of the 19 artifacts: 1–2 plain-text sentences (no markdown),
+Add a `summary` to each of the 23 artifacts: 1–2 plain-text sentences (no markdown),
 ≤ 300 characters, stating what the artifact is and why it matters. Place it directly
 above `description`.
 

--- a/src/components/PolicyWithSourceFilter.test.tsx
+++ b/src/components/PolicyWithSourceFilter.test.tsx
@@ -106,6 +106,28 @@ describe("PolicyWithSourceFilter", () => {
     expect(screen.queryByText("Governing AI: A Plan for Canada")).not.toBeInTheDocument();
   });
 
+  it("renders the summary instead of the description when a summary is present", () => {
+    const withSummary: ArtifactEntry = {
+      ...govArtifact,
+      summary: "Canada's first proposed federal AI law.",
+      description: "Part 3 of Bill C-27 contained AIDA.\n\nIt died on prorogation.",
+    };
+    render(<PolicyWithSourceFilter artifacts={[withSummary]} />);
+    expect(screen.getByText("Canada's first proposed federal AI law.")).toBeInTheDocument();
+    expect(screen.queryByText(/Part 3 of Bill C-27/)).not.toBeInTheDocument();
+  });
+
+  it("falls back to the description's first paragraph, clamped, when summary is absent", () => {
+    const noSummary: ArtifactEntry = {
+      ...govArtifact,
+      description: "First paragraph text.\n\nSecond paragraph text.",
+    };
+    render(<PolicyWithSourceFilter artifacts={[noSummary]} />);
+    const fallback = screen.getByText("First paragraph text.");
+    expect(fallback).toHaveClass("line-clamp-3");
+    expect(screen.queryByText(/Second paragraph text/)).not.toBeInTheDocument();
+  });
+
   it("renders lifecycle status badge alongside source badge for Legislation", () => {
     const bill: ArtifactEntry = {
       ...govArtifact,

--- a/src/components/PolicyWithSourceFilter.tsx
+++ b/src/components/PolicyWithSourceFilter.tsx
@@ -5,7 +5,7 @@ import type { Jurisdiction } from "../lib/jurisdiction";
 import { jurisdictionLabels, jurisdictionIcons } from "../lib/jurisdiction";
 import SourceFilter from "./SourceFilter";
 import JurisdictionFilter from "./JurisdictionFilter";
-import { fmtDate } from "../lib/format";
+import { fmtDate, leadText } from "../lib/format";
 import { badgeClass, statusLabel } from "../lib/legislation";
 
 export type ArtifactEntry = {
@@ -19,6 +19,7 @@ export type ArtifactEntry = {
     | "WhitePaper";
   title: string;
   publishedDate: string; // ISO string
+  summary?: string;
   description?: string;
   lifecycleStatus?: string;
   currentStage?: string;
@@ -147,9 +148,13 @@ export default function PolicyWithSourceFilter({ artifacts }: Props) {
                     {artifact.type === "Legislation" && artifact.currentStage && (
                       <p className="mt-2 text-sm text-muted">{artifact.currentStage}</p>
                     )}
-                    {artifact.description && (
-                      <p className="mt-2 text-sm text-muted">{artifact.description}</p>
-                    )}
+                    {artifact.summary ? (
+                      <p className="mt-2 text-sm text-muted">{artifact.summary}</p>
+                    ) : artifact.description ? (
+                      <p className="mt-2 text-sm text-muted line-clamp-3">
+                        {leadText(artifact.description)}
+                      </p>
+                    ) : null}
                     <p className="mt-2 text-xs text-faint">
                       {artifact.type === "Legislation" ? "Introduced" : "Published"}:{" "}
                       {fmtDate(artifact.publishedDate)}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -73,6 +73,7 @@ const artifacts = defineCollection({
     schema_type: z.literal("CreativeWork"),
     title: z.string(),
     published_date: z.coerce.date(),
+    summary: z.string().max(300).optional(),
     description: z.string().optional(),
     lifecycle_status: z
       .enum(["active", "enacted", "died", "withdrawn"])

--- a/src/pages/policy/index.astro
+++ b/src/pages/policy/index.astro
@@ -34,6 +34,7 @@ const artifacts: ArtifactEntry[] = artifactCollection
       type: a.data.type,
       title: a.data.title,
       publishedDate: a.data.published_date.toISOString(),
+      summary: a.data.summary,
       description: a.data.description,
       lifecycleStatus: a.data.lifecycle_status,
       currentStage: a.data.current_stage,


### PR DESCRIPTION
Closes #117.

Policy page cards previously rendered each artifact's full multi-paragraph `description` (342–2,400 chars), making the page a wall of text. Cards now show a short hand-written `summary`; the artifact detail page keeps the full description.

- **Spec:** `docs/superpowers/specs/2026-07-03-policy-card-summary-design.md`
- **Plan:** `docs/superpowers/plans/2026-07-03-policy-card-summary.md`

## Changes

- New optional `summary` field on the artifacts collection schema (`z.string().max(300)` so summaries stay card-sized).
- `PolicyWithSourceFilter` renders `summary` on the card; artifacts without one fall back to the description's first paragraph (`leadText`) clamped to three lines.
- Hand-written 1–2 sentence summaries for all 23 artifacts.
- `adding-legislation` skill documents the new field (and its now-outdated note about cards rendering raw descriptions is fixed).

## Notes for review

- The full `description` is still passed to the island as hydration props (it powers the fallback), so page *weight* is unchanged — this PR fixes the rendered wall of text. Happy to precompute the fallback server-side in a follow-up if we'd rather trim the payload.

## Test plan

- [x] Unit: two new `PolicyWithSourceFilter` tests (summary shown, description suppressed; clamped `leadText` fallback) — 107/107 pass
- [x] `pnpm build` validates all 23 summaries against the schema; also probed that a >300-char summary fails the build with a clear zod error
- [x] Manually drove the built site via `astro preview`: rendered cards max 246 chars, no description text in visible markup, artifact detail page unchanged, fallback verified end-to-end by rebuilding with one summary removed
- [ ] `Test / e2e` on CI (Playwright can't run in this sandbox — ubuntu26.04-arm64 unsupported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)