### PR TITLE
Add risk → mitigation → implementation map (/map)

### DIFF
--- a/data/artifacts/2023-10-18-aigs-governing-ai-2023.yaml
+++ b/data/artifacts/2023-10-18-aigs-governing-ai-2023.yaml
@@ -43,6 +43,7 @@ policy_recommendations:
       provinces, and coordinate federal action. ISED and other departments
       lack the institutional incentives or mandate to navigate and balance
       the full range of issues.
+    mitigation: central-ai-governance-body
 
   - id: rec-2023-002
     title: "Invest >$500M in AI governance and safety research"
@@ -51,6 +52,7 @@ policy_recommendations:
       earmarking the extra funds to developing better policy and technical AI
       safety solutions. Governance and safety research must rapidly catch up
       to the hundreds of billions invested annually in capabilities.
+    mitigation: fund-ai-safety-research
 
   - id: rec-2023-003
     title: "Champion and fund global AI governance efforts"
@@ -59,6 +61,7 @@ policy_recommendations:
       and OECD. Lead the conversation about CERN, IPCC, and IAEA models for
       global AI governance. Without global coordination, domestic regulation
       will simply push AI development to other jurisdictions.
+    mitigation: lead-global-ai-governance
 
   - id: rec-2023-004
     title: "Improve and pass the AI & Data Act"
@@ -66,6 +69,7 @@ policy_recommendations:
       Accelerate consultations and drafting of legislation as the best
       mechanism for enacting policies on audits, transparency, and liability.
       Establish a Canadian AI Commission to regulate high-risk models.
+    mitigation: comprehensive-ai-legislation
 
   - id: rec-2023-005
     title: "Launch a national conversation on AI"
@@ -75,6 +79,7 @@ policy_recommendations:
       the right balance between pursuing rewards and limiting risks. Canada's
       relative stability and strong AI ecosystem make it well placed to lead
       this conversation.
+    mitigation: national-ai-conversation
 
 tags:
   - ai-governance

--- a/data/artifacts/2023-10-18-aigs-governing-ai-2023.yaml
+++ b/data/artifacts/2023-10-18-aigs-governing-ai-2023.yaml
@@ -43,7 +43,6 @@ policy_recommendations:
       provinces, and coordinate federal action. ISED and other departments
       lack the institutional incentives or mandate to navigate and balance
       the full range of issues.
-    status: untracked
 
   - id: rec-2023-002
     title: "Invest >$500M in AI governance and safety research"
@@ -52,7 +51,6 @@ policy_recommendations:
       earmarking the extra funds to developing better policy and technical AI
       safety solutions. Governance and safety research must rapidly catch up
       to the hundreds of billions invested annually in capabilities.
-    status: untracked
 
   - id: rec-2023-003
     title: "Champion and fund global AI governance efforts"
@@ -61,7 +59,6 @@ policy_recommendations:
       and OECD. Lead the conversation about CERN, IPCC, and IAEA models for
       global AI governance. Without global coordination, domestic regulation
       will simply push AI development to other jurisdictions.
-    status: untracked
 
   - id: rec-2023-004
     title: "Improve and pass the AI & Data Act"
@@ -69,7 +66,6 @@ policy_recommendations:
       Accelerate consultations and drafting of legislation as the best
       mechanism for enacting policies on audits, transparency, and liability.
       Establish a Canadian AI Commission to regulate high-risk models.
-    status: untracked
 
   - id: rec-2023-005
     title: "Launch a national conversation on AI"
@@ -79,7 +75,6 @@ policy_recommendations:
       the right balance between pursuing rewards and limiting risks. Canada's
       relative stability and strong AI ecosystem make it well placed to lead
       this conversation.
-    status: untracked
 
 tags:
   - ai-governance

--- a/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
+++ b/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
@@ -48,6 +48,7 @@ policy_recommendations:
       AI developments, communicate with the provinces, and coordinate federal
       action. Avoids ISED's conflicting mandate of boosting development while
       also regulating it.
+    mitigation: central-ai-governance-body
 
   - id: rec-2024-002
     title: "Champion and fund global AI governance efforts"
@@ -57,6 +58,7 @@ policy_recommendations:
       Without global coordination, domestic regulation will simply push AI
       development to other jurisdictions, and frontier AI development is
       mostly happening abroad.
+    mitigation: lead-global-ai-governance
 
   - id: rec-2024-003
     title: "Improve and pass the AI & Data Act and supporting regulations"
@@ -66,6 +68,7 @@ policy_recommendations:
       by moving its administration to the new Ministry of AI to avoid
       conflict with ISED's mandate. There is no time to drop the AIDA and
       reintroduce it later.
+    mitigation: comprehensive-ai-legislation
 
   - id: rec-2024-004
     title: "Increase and focus Budget 2024 investments on safety and governance"
@@ -75,6 +78,7 @@ policy_recommendations:
       more than 20% of the proposed AI Compute Access Fund for research on
       frontier AI safety. The AISI's $50M in funding is insufficient given
       the scale of AI safety needs.
+    mitigation: fund-ai-safety-research
 
   - id: rec-2024-005
     title: "Launch a national conversation on AI"
@@ -85,6 +89,7 @@ policy_recommendations:
       radically transform society, and managing this transition needs to start
       early with Canada's relative stability and strong AI ecosystem making
       it well placed to lead.
+    mitigation: national-ai-conversation
 
 tags:
   - ai-governance

--- a/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
+++ b/data/artifacts/2024-06-26-aigs-governing-ai-2024.yaml
@@ -48,7 +48,6 @@ policy_recommendations:
       AI developments, communicate with the provinces, and coordinate federal
       action. Avoids ISED's conflicting mandate of boosting development while
       also regulating it.
-    status: untracked
 
   - id: rec-2024-002
     title: "Champion and fund global AI governance efforts"
@@ -58,7 +57,6 @@ policy_recommendations:
       Without global coordination, domestic regulation will simply push AI
       development to other jurisdictions, and frontier AI development is
       mostly happening abroad.
-    status: untracked
 
   - id: rec-2024-003
     title: "Improve and pass the AI & Data Act and supporting regulations"
@@ -68,7 +66,6 @@ policy_recommendations:
       by moving its administration to the new Ministry of AI to avoid
       conflict with ISED's mandate. There is no time to drop the AIDA and
       reintroduce it later.
-    status: untracked
 
   - id: rec-2024-004
     title: "Increase and focus Budget 2024 investments on safety and governance"
@@ -78,7 +75,6 @@ policy_recommendations:
       more than 20% of the proposed AI Compute Access Fund for research on
       frontier AI safety. The AISI's $50M in funding is insufficient given
       the scale of AI safety needs.
-    status: untracked
 
   - id: rec-2024-005
     title: "Launch a national conversation on AI"
@@ -89,7 +85,6 @@ policy_recommendations:
       radically transform society, and managing this transition needs to start
       early with Canada's relative stability and strong AI ecosystem making
       it well placed to lead.
-    status: untracked
 
 tags:
   - ai-governance

--- a/data/artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
+++ b/data/artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
@@ -43,7 +43,6 @@ policy_recommendations:
       multiple crises including accidents, geopolitical tensions, employment
       disruption, economic shocks, and social unrest. Government must treat
       AI development as a strategic emergency.
-    status: untracked
 
   - id: rec-2025-002
     title: "Spearhead the global response"
@@ -52,7 +51,6 @@ policy_recommendations:
       protocols, and distribute AI benefits equitably across nations. Canada
       is well placed to lead global talks given its stable society, educated
       population, and reputation on the world stage.
-    status: untracked
 
   - id: rec-2025-003
     title: "Build Canada's resilience"
@@ -61,7 +59,6 @@ policy_recommendations:
       crisis, including AI-powered cyberattacks on critical infrastructure,
       supply chain disruptions from accidents or conflict, fiscal shocks from
       sustained job losses, and potential loss of access to foreign compute.
-    status: untracked
 
   - id: rec-2025-004
     title: "Engage Canadians in a national conversation on AI"
@@ -71,7 +68,6 @@ policy_recommendations:
       technology that will reshape their lives. Canada's relative stability
       and strong AI ecosystem make it a good position to pilot such a
       conversation.
-    status: untracked
 
 tags:
   - ai-governance

--- a/data/artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
+++ b/data/artifacts/2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml
@@ -51,6 +51,7 @@ policy_recommendations:
       protocols, and distribute AI benefits equitably across nations. Canada
       is well placed to lead global talks given its stable society, educated
       population, and reputation on the world stage.
+    mitigation: lead-global-ai-governance
 
   - id: rec-2025-003
     title: "Build Canada's resilience"
@@ -59,6 +60,7 @@ policy_recommendations:
       crisis, including AI-powered cyberattacks on critical infrastructure,
       supply chain disruptions from accidents or conflict, fiscal shocks from
       sustained job losses, and potential loss of access to foreign compute.
+    mitigation: national-ai-resilience
 
   - id: rec-2025-004
     title: "Engage Canadians in a national conversation on AI"
@@ -68,6 +70,7 @@ policy_recommendations:
       technology that will reshape their lives. Canada's relative stability
       and strong AI ecosystem make it a good position to pilot such a
       conversation.
+    mitigation: national-ai-conversation
 
 tags:
   - ai-governance

--- a/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+++ b/data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
@@ -43,6 +43,7 @@ risk_findings:
       non-consensual intimate imagery. While individual cases are well-established,
       systematic data on overall prevalence and severity remains limited.
     evidence_level: established
+    risk: ai-enabled-crime-and-fraud
 
   - id: risk-iasr-002
     category: misuse
@@ -52,6 +53,7 @@ risk_findings:
       settings. Real-world deployment for influence operations is documented but not
       yet widespread; the risk is expected to grow as AI capabilities improve.
     evidence_level: emerging
+    risk: ai-influence-operations
 
   - id: risk-iasr-003
     category: misuse
@@ -62,6 +64,7 @@ risk_findings:
       general-purpose AI in cyber operations. The overall offence–defence balance
       remains uncertain.
     evidence_level: emerging
+    risk: ai-enabled-cyberattacks
 
   - id: risk-iasr-004
     category: misuse
@@ -72,6 +75,7 @@ risk_findings:
       safeguards as a precautionary measure. Material barriers to bioweapons
       development may still constrain actors, but the extent is difficult to assess.
     evidence_level: uncertain
+    risk: ai-biochemical-weapons-uplift
 
   # §2.2 — Structural risks (risks from AI system behaviour)
   - id: risk-iasr-005
@@ -82,6 +86,7 @@ risk_findings:
       humans to intervene before failures cause harm. Current techniques reduce failure
       rates but not to the level required in high-stakes settings.
     evidence_level: emerging
+    risk: unreliable-ai-agents
 
   - id: risk-iasr-006
     category: structural
@@ -93,6 +98,7 @@ risk_findings:
       lack the capabilities to pose a full loss-of-control risk, but are improving in
       relevant areas.
     evidence_level: uncertain
+    risk: loss-of-control
 
   # §2.3 — Societal impacts
   - id: risk-iasr-007
@@ -103,6 +109,7 @@ risk_findings:
       early-career workers in AI-exposed occupations such as writing. Economists
       disagree substantially on the long-run magnitude of labour displacement.
     evidence_level: emerging
+    risk: labour-market-disruption
 
   - id: risk-iasr-008
     category: societal
@@ -112,6 +119,7 @@ risk_findings:
       automation bias. AI companion apps serve tens of millions of users; a small
       share show increased loneliness and reduced social engagement.
     evidence_level: emerging
+    risk: erosion-of-human-autonomy
 
 tags:
   - ai-safety

--- a/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
+++ b/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
@@ -51,6 +51,7 @@ policy_recommendations:
       Promote widespread diffusion and adoption of reliable AI tools to advance
       productivity and prosperity, while preventing adoption of unreliable AI in
       critical systems.
+    mitigation: reliable-ai-adoption
     robustness: robust
 
   - id: rec-nr-002
@@ -58,6 +59,7 @@ policy_recommendations:
     summary: >
       Invest in widespread skills development and broad access to data and
       computing power.
+    mitigation: skills-data-compute-investment
     robustness: robust
 
   - id: rec-nr-003
@@ -65,6 +67,7 @@ policy_recommendations:
     summary: >
       Strengthen measures to support workers displaced by AI-enabled automation,
       including retraining, income support, and AI-enabled learning tools.
+    mitigation: support-displaced-workers
     robustness: robust
 
   - id: rec-nr-004
@@ -72,6 +75,7 @@ policy_recommendations:
     summary: >
       Strengthen information-sharing protocols to facilitate research cooperation
       without unintended information flows.
+    mitigation: information-sharing-protocols
     robustness: robust
 
   - id: rec-nr-005
@@ -79,6 +83,7 @@ policy_recommendations:
     summary: >
       Expand international cooperation and research on AI safety and security,
       including risks, technical safety, and governance mechanisms.
+    mitigation: international-ai-safety-cooperation
     robustness: robust
 
   - id: rec-nr-006
@@ -87,6 +92,7 @@ policy_recommendations:
       Build shared international understanding about global-scale AI risks and
       mitigations, including with rival powers, as a foundation for future
       cooperation if needed.
+    mitigation: shared-understanding-global-risks
     robustness: robust
 
   - id: rec-nr-007
@@ -94,6 +100,7 @@ policy_recommendations:
     summary: >
       Limit use of AI systems in key military decisions and strengthen national
       and international rules on the use of autonomous weapons.
+    mitigation: limit-military-ai-autonomous-weapons
     robustness: robust
 
   - id: rec-nr-008
@@ -101,6 +108,7 @@ policy_recommendations:
     summary: >
       Strengthen national and international AI incident monitoring and build
       protocols for coordinated emergency response.
+    mitigation: ai-incident-monitoring
     robustness: robust
 
   - id: rec-nr-009
@@ -109,6 +117,7 @@ policy_recommendations:
       Develop redundant physical and digital repositories of information for
       knowledge preservation in the event of an accidental or necessary internet
       shutdown.
+    mitigation: redundant-knowledge-repositories
     robustness: robust
 
   - id: rec-nr-010
@@ -116,6 +125,7 @@ policy_recommendations:
     summary: >
       Implement transparency requirements and whistleblower protections for
       disclosures about dangerous AI systems or practices.
+    mitigation: transparency-whistleblower-protections
     robustness: robust
 
   - id: rec-nr-011
@@ -124,6 +134,7 @@ policy_recommendations:
       Harden digital systems from cyberattacks, limit access to bio-synthesis
       tools, and improve detection and response to novel pathogens — essential
       at all levels of AI development.
+    mitigation: harden-digital-bio-defences
     robustness: robust
 
   # Scenario 1: AI Stall — necessary bets
@@ -133,6 +144,7 @@ policy_recommendations:
       Promote rapid AI adoption by removing regulatory impediments, while
       strengthening incentives for the development and deployment of reliable
       AI systems and tools.
+    mitigation: remove-adoption-impediments
     robustness: contingent
     scenarios: [scenario-ai-stall]
 
@@ -142,6 +154,7 @@ policy_recommendations:
       Prepare for the possibility of moderate-to-high job losses and economic
       disruption by enhancing policy measures for retraining, income support,
       business development, and cost-of-living reduction.
+    mitigation: prepare-moderate-job-losses
     robustness: contingent
     scenarios: [scenario-ai-stall]
 
@@ -151,6 +164,7 @@ policy_recommendations:
       Monitor and mitigate AI adoption risks in key domains such as nuclear
       missile launch, critical infrastructure, and personal companionship, to
       avoid critical failures.
+    mitigation: monitor-adoption-critical-domains
     robustness: contingent
     scenarios: [scenario-ai-stall]
 
@@ -160,6 +174,7 @@ policy_recommendations:
     summary: >
       Prepare for the possibility of extreme job losses and economic disruption,
       including by developing new income distribution infrastructure.
+    mitigation: prepare-extreme-job-losses
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
 
@@ -168,6 +183,7 @@ policy_recommendations:
     summary: >
       Develop international systems to address severely widening income
       inequalities among countries driven by uneven AI adoption.
+    mitigation: international-income-inequality-systems
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
 
@@ -177,6 +193,7 @@ policy_recommendations:
       Establish joint international limits on AI adoption in key domains such as
       nuclear missile launch and critical infrastructure to avoid critical
       failures.
+    mitigation: international-limits-critical-domains
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
 
@@ -186,6 +203,7 @@ policy_recommendations:
       Establish joint international limits on the overall level of AI adoption
       and societal automation, if needed, to prevent excessive displacement of
       humans in decision making.
+    mitigation: limit-societal-automation
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
 
@@ -194,6 +212,7 @@ policy_recommendations:
     summary: >
       Build trust and defuse tension between rival powers to limit a military AI
       race that could result in rapid, unintended escalation and global conflict.
+    mitigation: defuse-military-ai-race
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
 
@@ -203,6 +222,7 @@ policy_recommendations:
       Limit use of AI systems in key military decisions and develop protocols for
       scaled and predictable sabotage and retaliation to reduce the risk of
       sudden destabilizing shifts in the balance of power.
+    mitigation: predictable-escalation-protocols
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
 
@@ -212,6 +232,7 @@ policy_recommendations:
       Implement a robust international AI transparency and monitoring regime to
       provide timely alerts of emerging global AI risks, such as from imminent
       breakthroughs in AI capabilities.
+    mitigation: international-transparency-monitoring-regime
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
 
@@ -221,6 +242,7 @@ policy_recommendations:
       Ensure that national and coordinated emergency response protocols are
       adequate to handle risks posed by the potential sudden emergence of much
       more capable AI systems.
+    mitigation: emergency-protocols-capability-jumps
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
 
@@ -230,6 +252,7 @@ policy_recommendations:
     summary: >
       Develop mechanisms to coordinate use of ASIs across countries to avoid
       ASI-enabled conflict among multiple controllable ASI powers.
+    mitigation: coordinate-asi-use
     robustness: contingent
     scenarios: [scenario-hypercompetition]
 
@@ -238,6 +261,7 @@ policy_recommendations:
     summary: >
       Develop national or international mechanisms to prevent any single faction
       from gaining control of an ASI.
+    mitigation: prevent-asi-faction-takeover
     robustness: contingent
     scenarios: [scenario-hypercompetition, scenario-hyperpower]
 
@@ -246,6 +270,7 @@ policy_recommendations:
     summary: >
       Develop technical verification and compliance measures to prevent malicious
       use and weaponization of ASI systems.
+    mitigation: asi-verification-compliance
     robustness: contingent
     scenarios: [scenario-hypercompetition]
 
@@ -254,6 +279,7 @@ policy_recommendations:
     summary: >
       Prepare an international agreement with the ability to enforce a moratorium
       on ASI development if required.
+    mitigation: international-asi-prohibition-regime
     robustness: contingent
     scenarios: [scenario-hypercompetition]
 
@@ -262,6 +288,7 @@ policy_recommendations:
     summary: >
       Prepare an international agreement with mechanisms to coordinate use of
       ASIs across countries if safe ASI cooperation is seen as possible.
+    mitigation: safe-asi-cooperation-mechanisms
     robustness: contingent
     scenarios: [scenario-hypercompetition]
 
@@ -271,6 +298,7 @@ policy_recommendations:
     summary: >
       Adopt antitrust measures to prevent monopoly and singleton control of ASI
       in the market or politically.
+    mitigation: asi-antitrust-measures
     robustness: contingent
     scenarios: [scenario-hyperpower]
 
@@ -279,6 +307,7 @@ policy_recommendations:
     summary: >
       Implement international agreement and cooperation to ensure inclusive and
       legitimate decision making around the development and use of ASI.
+    mitigation: inclusive-asi-governance
     robustness: contingent
     scenarios: [scenario-hyperpower]
 
@@ -289,6 +318,7 @@ policy_recommendations:
       Develop the ability, via international cooperation if necessary, to prevent
       creation of ASI anywhere in the world until there is sufficient evidence
       that it can be controlled and aligned.
+    mitigation: international-asi-prohibition-regime
     robustness: contingent
     scenarios: [scenario-rogue-asi]
 
@@ -297,6 +327,7 @@ policy_recommendations:
     summary: >
       Prepare emergency response strategies including kill switches for ASI and
       protocols for rapid containment of a nascent rogue ASI.
+    mitigation: asi-emergency-kill-switches
     robustness: contingent
     scenarios: [scenario-rogue-asi]
 
@@ -305,6 +336,7 @@ policy_recommendations:
     summary: >
       Ensure air-gapped networks and robust cyber defence for critical systems
       to limit a rogue ASI's ability to propagate or gain control.
+    mitigation: air-gapped-critical-systems
     robustness: contingent
     scenarios: [scenario-rogue-asi]
 
@@ -314,6 +346,7 @@ policy_recommendations:
       Prepare resource stockpiles, citizen defence brigades, training programs,
       and analogue contingency systems to ensure continuity of authority in the
       event of loss of control to a rogue ASI.
+    mitigation: analogue-contingency-systems
     robustness: contingent
     scenarios: [scenario-rogue-asi]
 

--- a/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
+++ b/data/artifacts/2026-02-06-cigi-pco-ai-national-security-report.yaml
@@ -52,7 +52,6 @@ policy_recommendations:
       productivity and prosperity, while preventing adoption of unreliable AI in
       critical systems.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-002
     title: "Invest in skills, data, and compute"
@@ -60,7 +59,6 @@ policy_recommendations:
       Invest in widespread skills development and broad access to data and
       computing power.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-003
     title: "Support AI-displaced workers"
@@ -68,7 +66,6 @@ policy_recommendations:
       Strengthen measures to support workers displaced by AI-enabled automation,
       including retraining, income support, and AI-enabled learning tools.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-004
     title: "Strengthen information-sharing protocols"
@@ -76,7 +73,6 @@ policy_recommendations:
       Strengthen information-sharing protocols to facilitate research cooperation
       without unintended information flows.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-005
     title: "Expand international AI safety cooperation"
@@ -84,7 +80,6 @@ policy_recommendations:
       Expand international cooperation and research on AI safety and security,
       including risks, technical safety, and governance mechanisms.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-006
     title: "Build shared understanding of global AI risks"
@@ -93,7 +88,6 @@ policy_recommendations:
       mitigations, including with rival powers, as a foundation for future
       cooperation if needed.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-007
     title: "Limit AI in military decisions; regulate autonomous weapons"
@@ -101,7 +95,6 @@ policy_recommendations:
       Limit use of AI systems in key military decisions and strengthen national
       and international rules on the use of autonomous weapons.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-008
     title: "Strengthen AI incident monitoring and emergency protocols"
@@ -109,7 +102,6 @@ policy_recommendations:
       Strengthen national and international AI incident monitoring and build
       protocols for coordinated emergency response.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-009
     title: "Develop redundant knowledge repositories"
@@ -118,7 +110,6 @@ policy_recommendations:
       knowledge preservation in the event of an accidental or necessary internet
       shutdown.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-010
     title: "Implement AI transparency and whistleblower protections"
@@ -126,7 +117,6 @@ policy_recommendations:
       Implement transparency requirements and whistleblower protections for
       disclosures about dangerous AI systems or practices.
     robustness: robust
-    status: untracked
 
   - id: rec-nr-011
     title: "Harden digital systems and biosecurity defences"
@@ -135,7 +125,6 @@ policy_recommendations:
       tools, and improve detection and response to novel pathogens — essential
       at all levels of AI development.
     robustness: robust
-    status: untracked
 
   # Scenario 1: AI Stall — necessary bets
   - id: rec-s1-001
@@ -146,7 +135,6 @@ policy_recommendations:
       AI systems and tools.
     robustness: contingent
     scenarios: [scenario-ai-stall]
-    status: untracked
 
   - id: rec-s1-002
     title: "Prepare for moderate-to-high AI-driven job losses"
@@ -156,7 +144,6 @@ policy_recommendations:
       business development, and cost-of-living reduction.
     robustness: contingent
     scenarios: [scenario-ai-stall]
-    status: untracked
 
   - id: rec-s1-003
     title: "Monitor AI adoption risks in critical domains"
@@ -166,7 +153,6 @@ policy_recommendations:
       avoid critical failures.
     robustness: contingent
     scenarios: [scenario-ai-stall]
-    status: untracked
 
   # Scenario 2: Precarious Precipice — necessary bets
   - id: rec-s2-001
@@ -176,7 +162,6 @@ policy_recommendations:
       including by developing new income distribution infrastructure.
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
-    status: untracked
 
   - id: rec-s2-002
     title: "Develop systems to address widening international income inequality"
@@ -185,7 +170,6 @@ policy_recommendations:
       inequalities among countries driven by uneven AI adoption.
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
-    status: untracked
 
   - id: rec-s2-003
     title: "Establish joint international limits on AI in critical domains"
@@ -195,7 +179,6 @@ policy_recommendations:
       failures.
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
-    status: untracked
 
   - id: rec-s2-004
     title: "Limit overall societal automation to preserve human agency"
@@ -205,7 +188,6 @@ policy_recommendations:
       humans in decision making.
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
-    status: untracked
 
   - id: rec-s2-005
     title: "Build trust to limit military AI race escalation"
@@ -214,7 +196,6 @@ policy_recommendations:
       race that could result in rapid, unintended escalation and global conflict.
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
-    status: untracked
 
   - id: rec-s2-006
     title: "Develop protocols for predictable AI-enabled military escalation"
@@ -224,7 +205,6 @@ policy_recommendations:
       sudden destabilizing shifts in the balance of power.
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
-    status: untracked
 
   - id: rec-s2-007
     title: "Implement international AI transparency and monitoring regime"
@@ -234,7 +214,6 @@ policy_recommendations:
       breakthroughs in AI capabilities.
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
-    status: untracked
 
   - id: rec-s2-008
     title: "Ensure emergency protocols for sudden AI capability jumps"
@@ -244,7 +223,6 @@ policy_recommendations:
       more capable AI systems.
     robustness: contingent
     scenarios: [scenario-precarious-precipice]
-    status: untracked
 
   # Scenario 3a: Hypercompetition — necessary bets
   - id: rec-s3a-001
@@ -254,7 +232,6 @@ policy_recommendations:
       ASI-enabled conflict among multiple controllable ASI powers.
     robustness: contingent
     scenarios: [scenario-hypercompetition]
-    status: untracked
 
   - id: rec-s3a-002
     title: "Prevent ASI takeover by a faction"
@@ -263,7 +240,6 @@ policy_recommendations:
       from gaining control of an ASI.
     robustness: contingent
     scenarios: [scenario-hypercompetition, scenario-hyperpower]
-    status: untracked
 
   - id: rec-s3a-003
     title: "Develop technical verification to prevent ASI weaponization"
@@ -272,7 +248,6 @@ policy_recommendations:
       use and weaponization of ASI systems.
     robustness: contingent
     scenarios: [scenario-hypercompetition]
-    status: untracked
 
   - id: rec-s3a-004
     title: "Prepare moratorium agreement on ASI development"
@@ -281,7 +256,6 @@ policy_recommendations:
       on ASI development if required.
     robustness: contingent
     scenarios: [scenario-hypercompetition]
-    status: untracked
 
   - id: rec-s3a-005
     title: "Prepare mechanisms for safe international ASI cooperation"
@@ -290,7 +264,6 @@ policy_recommendations:
       ASIs across countries if safe ASI cooperation is seen as possible.
     robustness: contingent
     scenarios: [scenario-hypercompetition]
-    status: untracked
 
   # Scenario 3b: Hyperpower — necessary bets
   - id: rec-s3b-001
@@ -300,7 +273,6 @@ policy_recommendations:
       in the market or politically.
     robustness: contingent
     scenarios: [scenario-hyperpower]
-    status: untracked
 
   - id: rec-s3b-002
     title: "Ensure inclusive international ASI governance"
@@ -309,7 +281,6 @@ policy_recommendations:
       legitimate decision making around the development and use of ASI.
     robustness: contingent
     scenarios: [scenario-hyperpower]
-    status: untracked
 
   # Scenario 4: Rogue ASI — necessary bets
   - id: rec-s4-001
@@ -320,7 +291,6 @@ policy_recommendations:
       that it can be controlled and aligned.
     robustness: contingent
     scenarios: [scenario-rogue-asi]
-    status: untracked
 
   - id: rec-s4-002
     title: "Prepare ASI emergency response and kill switches"
@@ -329,7 +299,6 @@ policy_recommendations:
       protocols for rapid containment of a nascent rogue ASI.
     robustness: contingent
     scenarios: [scenario-rogue-asi]
-    status: untracked
 
   - id: rec-s4-003
     title: "Ensure air-gapped networks and cyber defence for critical systems"
@@ -338,7 +307,6 @@ policy_recommendations:
       to limit a rogue ASI's ability to propagate or gain control.
     robustness: contingent
     scenarios: [scenario-rogue-asi]
-    status: untracked
 
   - id: rec-s4-004
     title: "Prepare analogue contingency systems for continuity of authority"
@@ -348,7 +316,6 @@ policy_recommendations:
       event of loss of control to a rogue ASI.
     robustness: contingent
     scenarios: [scenario-rogue-asi]
-    status: untracked
 
 tags:
   - national-security

--- a/data/artifacts/2026-04-11-liberal-convention-ai-act-resolution.yaml
+++ b/data/artifacts/2026-04-11-liberal-convention-ai-act-resolution.yaml
@@ -41,7 +41,6 @@ policy_recommendations:
       Act, applying risk-based regulation with pre-deployment safety, fairness,
       and bias-mitigation requirements for high-risk systems, transparency for
       limited-risk systems, and full implementation by 2028.
-    status: untracked
 
 links:
   - label: "CBC — Liberal members vote in favour of age restrictions for social media, AI chatbots"

--- a/data/artifacts/2026-04-11-liberal-convention-ai-act-resolution.yaml
+++ b/data/artifacts/2026-04-11-liberal-convention-ai-act-resolution.yaml
@@ -41,6 +41,7 @@ policy_recommendations:
       Act, applying risk-based regulation with pre-deployment safety, fairness,
       and bias-mitigation requirements for high-risk systems, transparency for
       limited-risk systems, and full implementation by 2028.
+    mitigation: comprehensive-ai-legislation
 
 links:
   - label: "CBC — Liberal members vote in favour of age restrictions for social media, AI chatbots"

--- a/data/artifacts/2026-05-28-controlai-canada-superintelligence-statement.yaml
+++ b/data/artifacts/2026-05-28-controlai-canada-superintelligence-statement.yaml
@@ -46,7 +46,6 @@ policy_recommendations:
       Canada should negotiate an international "trust but verify" regime to
       prohibit the development of superintelligent AI, treating protection from
       superintelligence at home and abroad as a national security priority.
-    status: untracked
 
 links:
   - label: "ControlAI — Canada Campaign Statement (EN)"

--- a/data/artifacts/2026-05-28-controlai-canada-superintelligence-statement.yaml
+++ b/data/artifacts/2026-05-28-controlai-canada-superintelligence-statement.yaml
@@ -46,6 +46,7 @@ policy_recommendations:
       Canada should negotiate an international "trust but verify" regime to
       prohibit the development of superintelligent AI, treating protection from
       superintelligence at home and abroad as a national security priority.
+    mitigation: international-asi-prohibition-regime
 
 links:
   - label: "ControlAI — Canada Campaign Statement (EN)"

--- a/data/mitigations/ai-incident-monitoring.yaml
+++ b/data/mitigations/ai-incident-monitoring.yaml
@@ -1,0 +1,15 @@
+# mitigations/ai-incident-monitoring.yaml
+
+id: ai-incident-monitoring
+schema_type: DefinedTerm
+title: "Strengthen AI incident monitoring and emergency protocols"
+description: >
+  Strengthen national and international AI incident monitoring and build
+  protocols for coordinated emergency response.
+mitigation_type: operational-process
+addresses_risks:
+  - loss-of-control
+  - unreliable-ai-agents
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/air-gapped-critical-systems.yaml
+++ b/data/mitigations/air-gapped-critical-systems.yaml
@@ -1,0 +1,15 @@
+# mitigations/air-gapped-critical-systems.yaml
+
+id: air-gapped-critical-systems
+schema_type: DefinedTerm
+title: "Ensure air-gapped networks and cyber defence for critical systems"
+description: >
+  Ensure air-gapped networks and robust cyber defence for critical systems
+  to limit a rogue ASI's ability to propagate or gain control.
+mitigation_type: technical-security
+addresses_risks:
+  - ai-enabled-cyberattacks
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/analogue-contingency-systems.yaml
+++ b/data/mitigations/analogue-contingency-systems.yaml
@@ -1,0 +1,15 @@
+# mitigations/analogue-contingency-systems.yaml
+
+id: analogue-contingency-systems
+schema_type: DefinedTerm
+title: "Prepare analogue contingency systems for continuity of authority"
+description: >
+  Prepare resource stockpiles, citizen defence brigades, training programs,
+  and analogue contingency systems to ensure continuity of authority in the
+  event of loss of control to a rogue ASI.
+mitigation_type: operational-process
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/asi-antitrust-measures.yaml
+++ b/data/mitigations/asi-antitrust-measures.yaml
@@ -1,0 +1,13 @@
+# mitigations/asi-antitrust-measures.yaml
+
+id: asi-antitrust-measures
+schema_type: DefinedTerm
+title: "Adopt antitrust measures against ASI monopoly"
+description: >
+  Adopt antitrust measures to prevent monopoly and singleton control of ASI
+  in the market or politically.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/asi-emergency-kill-switches.yaml
+++ b/data/mitigations/asi-emergency-kill-switches.yaml
@@ -1,0 +1,14 @@
+# mitigations/asi-emergency-kill-switches.yaml
+
+id: asi-emergency-kill-switches
+schema_type: DefinedTerm
+title: "Prepare ASI emergency response and kill switches"
+description: >
+  Prepare emergency response strategies including kill switches for ASI and
+  protocols for rapid containment of a nascent rogue ASI.
+mitigation_type: technical-security
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/asi-verification-compliance.yaml
+++ b/data/mitigations/asi-verification-compliance.yaml
@@ -1,0 +1,14 @@
+# mitigations/asi-verification-compliance.yaml
+
+id: asi-verification-compliance
+schema_type: DefinedTerm
+title: "Develop technical verification to prevent ASI weaponization"
+description: >
+  Develop technical verification and compliance measures to prevent malicious
+  use and weaponization of ASI systems.
+mitigation_type: technical-security
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/central-ai-governance-body.yaml
+++ b/data/mitigations/central-ai-governance-body.yaml
@@ -1,0 +1,15 @@
+# mitigations/central-ai-governance-body.yaml
+
+id: central-ai-governance-body
+schema_type: DefinedTerm
+title: "Establish a central federal AI governance body"
+description: >
+  Create a dedicated federal centre of gravity for AI governance — a central
+  agency or Ministry of AI — to monitor developments, coordinate federal
+  action, communicate with provinces, and avoid ISED's conflicting mandate of
+  both boosting and regulating AI.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: [government-machinery]

--- a/data/mitigations/comprehensive-ai-legislation.yaml
+++ b/data/mitigations/comprehensive-ai-legislation.yaml
@@ -1,0 +1,19 @@
+# mitigations/comprehensive-ai-legislation.yaml
+
+id: comprehensive-ai-legislation
+schema_type: DefinedTerm
+title: "Enact comprehensive risk-based federal AI legislation"
+description: >
+  Pass a federal statute applying risk-based obligations to AI systems —
+  audits, transparency, liability, and pre-deployment requirements for
+  high-risk systems — with an independent regulator.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by:
+  - artifact: bill-c27-aida
+    relationship: related
+    note: >
+      AIDA (part of Bill C-27) attempted a risk-based framework and died on
+      the Order Paper when Parliament was prorogued in January 2025.
+tags: [legislation, aida, caia]

--- a/data/mitigations/coordinate-asi-use.yaml
+++ b/data/mitigations/coordinate-asi-use.yaml
@@ -1,0 +1,13 @@
+# mitigations/coordinate-asi-use.yaml
+
+id: coordinate-asi-use
+schema_type: DefinedTerm
+title: "Coordinate ASI use across countries to avoid conflict"
+description: >
+  Develop mechanisms to coordinate use of ASIs across countries to avoid
+  ASI-enabled conflict among multiple controllable ASI powers.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/defuse-military-ai-race.yaml
+++ b/data/mitigations/defuse-military-ai-race.yaml
@@ -1,0 +1,13 @@
+# mitigations/defuse-military-ai-race.yaml
+
+id: defuse-military-ai-race
+schema_type: DefinedTerm
+title: "Build trust to limit military AI race escalation"
+description: >
+  Build trust and defuse tension between rival powers to limit a military AI
+  race that could result in rapid, unintended escalation and global conflict.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/emergency-protocols-capability-jumps.yaml
+++ b/data/mitigations/emergency-protocols-capability-jumps.yaml
@@ -1,0 +1,15 @@
+# mitigations/emergency-protocols-capability-jumps.yaml
+
+id: emergency-protocols-capability-jumps
+schema_type: DefinedTerm
+title: "Ensure emergency protocols for sudden AI capability jumps"
+description: >
+  Ensure that national and coordinated emergency response protocols are
+  adequate to handle risks posed by the potential sudden emergence of much
+  more capable AI systems.
+mitigation_type: operational-process
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/fund-ai-safety-research.yaml
+++ b/data/mitigations/fund-ai-safety-research.yaml
@@ -1,0 +1,16 @@
+# mitigations/fund-ai-safety-research.yaml
+
+id: fund-ai-safety-research
+schema_type: DefinedTerm
+title: "Scale up public funding for AI safety and governance research"
+description: >
+  Invest more than $500M in technical AI safety and governance policy
+  research, coordinated through Canada's AI Safety Institute, including
+  dedicating a substantial share of public compute to frontier safety work.
+mitigation_type: governance-oversight
+addresses_risks:
+  - loss-of-control
+  - unreliable-ai-agents
+status: untracked
+implemented_by: []
+tags: [research-funding, caisi]

--- a/data/mitigations/harden-digital-bio-defences.yaml
+++ b/data/mitigations/harden-digital-bio-defences.yaml
@@ -1,0 +1,16 @@
+# mitigations/harden-digital-bio-defences.yaml
+
+id: harden-digital-bio-defences
+schema_type: DefinedTerm
+title: "Harden digital systems and biosecurity defences"
+description: >
+  Harden digital systems from cyberattacks, limit access to bio-synthesis
+  tools, and improve detection and response to novel pathogens — essential
+  at all levels of AI development.
+mitigation_type: technical-security
+addresses_risks:
+  - ai-enabled-cyberattacks
+  - ai-biochemical-weapons-uplift
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/inclusive-asi-governance.yaml
+++ b/data/mitigations/inclusive-asi-governance.yaml
@@ -1,0 +1,13 @@
+# mitigations/inclusive-asi-governance.yaml
+
+id: inclusive-asi-governance
+schema_type: DefinedTerm
+title: "Ensure inclusive international ASI governance"
+description: >
+  Implement international agreement and cooperation to ensure inclusive and
+  legitimate decision making around the development and use of ASI.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/information-sharing-protocols.yaml
+++ b/data/mitigations/information-sharing-protocols.yaml
@@ -1,0 +1,13 @@
+# mitigations/information-sharing-protocols.yaml
+
+id: information-sharing-protocols
+schema_type: DefinedTerm
+title: "Strengthen information-sharing protocols"
+description: >
+  Strengthen information-sharing protocols to facilitate research cooperation
+  without unintended information flows.
+mitigation_type: operational-process
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/international-ai-safety-cooperation.yaml
+++ b/data/mitigations/international-ai-safety-cooperation.yaml
@@ -1,0 +1,14 @@
+# mitigations/international-ai-safety-cooperation.yaml
+
+id: international-ai-safety-cooperation
+schema_type: DefinedTerm
+title: "Expand international AI safety cooperation"
+description: >
+  Expand international cooperation and research on AI safety and security,
+  including risks, technical safety, and governance mechanisms.
+mitigation_type: governance-oversight
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/international-asi-prohibition-regime.yaml
+++ b/data/mitigations/international-asi-prohibition-regime.yaml
@@ -1,0 +1,15 @@
+# mitigations/international-asi-prohibition-regime.yaml
+
+id: international-asi-prohibition-regime
+schema_type: DefinedTerm
+title: "Prepare an international regime able to prohibit or pause superintelligence development"
+description: >
+  Negotiate an international "trust but verify" agreement with the ability to
+  enforce a moratorium on superintelligent AI development anywhere in the
+  world until there is sufficient evidence it can be controlled and aligned.
+mitigation_type: governance-oversight
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: [superintelligence, international, treaty]

--- a/data/mitigations/international-income-inequality-systems.yaml
+++ b/data/mitigations/international-income-inequality-systems.yaml
@@ -1,0 +1,13 @@
+# mitigations/international-income-inequality-systems.yaml
+
+id: international-income-inequality-systems
+schema_type: DefinedTerm
+title: "Develop systems to address widening international income inequality"
+description: >
+  Develop international systems to address severely widening income
+  inequalities among countries driven by uneven AI adoption.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/international-limits-critical-domains.yaml
+++ b/data/mitigations/international-limits-critical-domains.yaml
@@ -1,0 +1,15 @@
+# mitigations/international-limits-critical-domains.yaml
+
+id: international-limits-critical-domains
+schema_type: DefinedTerm
+title: "Establish joint international limits on AI in critical domains"
+description: >
+  Establish joint international limits on AI adoption in key domains such as
+  nuclear missile launch and critical infrastructure to avoid critical
+  failures.
+mitigation_type: governance-oversight
+addresses_risks:
+  - unreliable-ai-agents
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/international-transparency-monitoring-regime.yaml
+++ b/data/mitigations/international-transparency-monitoring-regime.yaml
@@ -1,0 +1,15 @@
+# mitigations/international-transparency-monitoring-regime.yaml
+
+id: international-transparency-monitoring-regime
+schema_type: DefinedTerm
+title: "Implement international AI transparency and monitoring regime"
+description: >
+  Implement a robust international AI transparency and monitoring regime to
+  provide timely alerts of emerging global AI risks, such as from imminent
+  breakthroughs in AI capabilities.
+mitigation_type: transparency-accountability
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/lead-global-ai-governance.yaml
+++ b/data/mitigations/lead-global-ai-governance.yaml
@@ -1,0 +1,15 @@
+# mitigations/lead-global-ai-governance.yaml
+
+id: lead-global-ai-governance
+schema_type: DefinedTerm
+title: "Champion and fund global AI governance efforts"
+description: >
+  Lead and fund international AI governance initiatives — at the UN, G7, and
+  OECD and through safety summits — including exploring CERN, IPCC, and IAEA
+  models, on the premise that domestic regulation alone cannot address
+  frontier AI developed abroad.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: [international, diplomacy]

--- a/data/mitigations/limit-military-ai-autonomous-weapons.yaml
+++ b/data/mitigations/limit-military-ai-autonomous-weapons.yaml
@@ -1,0 +1,13 @@
+# mitigations/limit-military-ai-autonomous-weapons.yaml
+
+id: limit-military-ai-autonomous-weapons
+schema_type: DefinedTerm
+title: "Limit AI in military decisions; regulate autonomous weapons"
+description: >
+  Limit use of AI systems in key military decisions and strengthen national
+  and international rules on the use of autonomous weapons.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/limit-societal-automation.yaml
+++ b/data/mitigations/limit-societal-automation.yaml
@@ -1,0 +1,15 @@
+# mitigations/limit-societal-automation.yaml
+
+id: limit-societal-automation
+schema_type: DefinedTerm
+title: "Limit overall societal automation to preserve human agency"
+description: >
+  Establish joint international limits on the overall level of AI adoption
+  and societal automation, if needed, to prevent excessive displacement of
+  humans in decision making.
+mitigation_type: governance-oversight
+addresses_risks:
+  - erosion-of-human-autonomy
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/monitor-adoption-critical-domains.yaml
+++ b/data/mitigations/monitor-adoption-critical-domains.yaml
@@ -1,0 +1,15 @@
+# mitigations/monitor-adoption-critical-domains.yaml
+
+id: monitor-adoption-critical-domains
+schema_type: DefinedTerm
+title: "Monitor AI adoption risks in critical domains"
+description: >
+  Monitor and mitigate AI adoption risks in key domains such as nuclear
+  missile launch, critical infrastructure, and personal companionship, to
+  avoid critical failures.
+mitigation_type: operational-process
+addresses_risks:
+  - unreliable-ai-agents
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/national-ai-conversation.yaml
+++ b/data/mitigations/national-ai-conversation.yaml
@@ -1,0 +1,15 @@
+# mitigations/national-ai-conversation.yaml
+
+id: national-ai-conversation
+schema_type: DefinedTerm
+title: "Launch a national public conversation on AI"
+description: >
+  Hold nationwide open public consultations on AI's impact on jobs, wealth
+  concentration, and the balance between pursuing benefits and limiting
+  risks, so Canadians are informed and consulted on a technology reshaping
+  their lives.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: [public-consultation]

--- a/data/mitigations/national-ai-resilience.yaml
+++ b/data/mitigations/national-ai-resilience.yaml
@@ -1,0 +1,17 @@
+# mitigations/national-ai-resilience.yaml
+
+id: national-ai-resilience
+schema_type: DefinedTerm
+title: "Build domestic resilience to AI-driven shocks"
+description: >
+  Implement domestic measures against secondary impacts of AI crises:
+  AI-powered cyberattacks on critical infrastructure, supply chain
+  disruptions, fiscal shocks from sustained job losses, and loss of access
+  to foreign compute.
+mitigation_type: operational-process
+addresses_risks:
+  - ai-enabled-cyberattacks
+  - labour-market-disruption
+status: untracked
+implemented_by: []
+tags: [resilience, critical-infrastructure]

--- a/data/mitigations/predictable-escalation-protocols.yaml
+++ b/data/mitigations/predictable-escalation-protocols.yaml
@@ -1,0 +1,14 @@
+# mitigations/predictable-escalation-protocols.yaml
+
+id: predictable-escalation-protocols
+schema_type: DefinedTerm
+title: "Develop protocols for predictable AI-enabled military escalation"
+description: >
+  Limit use of AI systems in key military decisions and develop protocols for
+  scaled and predictable sabotage and retaliation to reduce the risk of
+  sudden destabilizing shifts in the balance of power.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/prepare-extreme-job-losses.yaml
+++ b/data/mitigations/prepare-extreme-job-losses.yaml
@@ -1,0 +1,14 @@
+# mitigations/prepare-extreme-job-losses.yaml
+
+id: prepare-extreme-job-losses
+schema_type: DefinedTerm
+title: "Prepare for extreme AI-driven job losses"
+description: >
+  Prepare for the possibility of extreme job losses and economic disruption,
+  including by developing new income distribution infrastructure.
+mitigation_type: governance-oversight
+addresses_risks:
+  - labour-market-disruption
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/prepare-moderate-job-losses.yaml
+++ b/data/mitigations/prepare-moderate-job-losses.yaml
@@ -1,0 +1,15 @@
+# mitigations/prepare-moderate-job-losses.yaml
+
+id: prepare-moderate-job-losses
+schema_type: DefinedTerm
+title: "Prepare for moderate-to-high AI-driven job losses"
+description: >
+  Prepare for the possibility of moderate-to-high job losses and economic
+  disruption by enhancing policy measures for retraining, income support,
+  business development, and cost-of-living reduction.
+mitigation_type: governance-oversight
+addresses_risks:
+  - labour-market-disruption
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/prevent-asi-faction-takeover.yaml
+++ b/data/mitigations/prevent-asi-faction-takeover.yaml
@@ -1,0 +1,14 @@
+# mitigations/prevent-asi-faction-takeover.yaml
+
+id: prevent-asi-faction-takeover
+schema_type: DefinedTerm
+title: "Prevent ASI takeover by a faction"
+description: >
+  Develop national or international mechanisms to prevent any single faction
+  from gaining control of an ASI.
+mitigation_type: governance-oversight
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/redundant-knowledge-repositories.yaml
+++ b/data/mitigations/redundant-knowledge-repositories.yaml
@@ -1,0 +1,14 @@
+# mitigations/redundant-knowledge-repositories.yaml
+
+id: redundant-knowledge-repositories
+schema_type: DefinedTerm
+title: "Develop redundant knowledge repositories"
+description: >
+  Develop redundant physical and digital repositories of information for
+  knowledge preservation in the event of an accidental or necessary internet
+  shutdown.
+mitigation_type: operational-process
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/reliable-ai-adoption.yaml
+++ b/data/mitigations/reliable-ai-adoption.yaml
@@ -1,0 +1,15 @@
+# mitigations/reliable-ai-adoption.yaml
+
+id: reliable-ai-adoption
+schema_type: DefinedTerm
+title: "Encourage reliable AI diffusion and adoption"
+description: >
+  Promote widespread diffusion and adoption of reliable AI tools to advance
+  productivity and prosperity, while preventing adoption of unreliable AI in
+  critical systems.
+mitigation_type: operational-process
+addresses_risks:
+  - unreliable-ai-agents
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/remove-adoption-impediments.yaml
+++ b/data/mitigations/remove-adoption-impediments.yaml
@@ -1,0 +1,14 @@
+# mitigations/remove-adoption-impediments.yaml
+
+id: remove-adoption-impediments
+schema_type: DefinedTerm
+title: "Remove regulatory impediments to AI adoption"
+description: >
+  Promote rapid AI adoption by removing regulatory impediments, while
+  strengthening incentives for the development and deployment of reliable
+  AI systems and tools.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/safe-asi-cooperation-mechanisms.yaml
+++ b/data/mitigations/safe-asi-cooperation-mechanisms.yaml
@@ -1,0 +1,13 @@
+# mitigations/safe-asi-cooperation-mechanisms.yaml
+
+id: safe-asi-cooperation-mechanisms
+schema_type: DefinedTerm
+title: "Prepare mechanisms for safe international ASI cooperation"
+description: >
+  Prepare an international agreement with mechanisms to coordinate use of
+  ASIs across countries if safe ASI cooperation is seen as possible.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/shared-understanding-global-risks.yaml
+++ b/data/mitigations/shared-understanding-global-risks.yaml
@@ -1,0 +1,14 @@
+# mitigations/shared-understanding-global-risks.yaml
+
+id: shared-understanding-global-risks
+schema_type: DefinedTerm
+title: "Build shared understanding of global AI risks"
+description: >
+  Build shared international understanding about global-scale AI risks and
+  mitigations, including with rival powers, as a foundation for future
+  cooperation if needed.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/skills-data-compute-investment.yaml
+++ b/data/mitigations/skills-data-compute-investment.yaml
@@ -1,0 +1,13 @@
+# mitigations/skills-data-compute-investment.yaml
+
+id: skills-data-compute-investment
+schema_type: DefinedTerm
+title: "Invest in skills, data, and compute"
+description: >
+  Invest in widespread skills development and broad access to data and
+  computing power.
+mitigation_type: operational-process
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/support-displaced-workers.yaml
+++ b/data/mitigations/support-displaced-workers.yaml
@@ -1,0 +1,14 @@
+# mitigations/support-displaced-workers.yaml
+
+id: support-displaced-workers
+schema_type: DefinedTerm
+title: "Support AI-displaced workers"
+description: >
+  Strengthen measures to support workers displaced by AI-enabled automation,
+  including retraining, income support, and AI-enabled learning tools.
+mitigation_type: governance-oversight
+addresses_risks:
+  - labour-market-disruption
+status: untracked
+implemented_by: []
+tags: []

--- a/data/mitigations/transparency-whistleblower-protections.yaml
+++ b/data/mitigations/transparency-whistleblower-protections.yaml
@@ -1,0 +1,14 @@
+# mitigations/transparency-whistleblower-protections.yaml
+
+id: transparency-whistleblower-protections
+schema_type: DefinedTerm
+title: "Implement AI transparency and whistleblower protections"
+description: >
+  Implement transparency requirements and whistleblower protections for
+  disclosures about dangerous AI systems or practices.
+mitigation_type: transparency-accountability
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: []

--- a/data/risks/ai-biochemical-weapons-uplift.yaml
+++ b/data/risks/ai-biochemical-weapons-uplift.yaml
@@ -1,0 +1,11 @@
+# risks/ai-biochemical-weapons-uplift.yaml
+
+id: ai-biochemical-weapons-uplift
+schema_type: DefinedTerm
+title: "Biological and chemical weapons uplift"
+description: >
+  AI systems assisting actors, including novices, in developing biological or
+  chemical weapons.
+domain: malicious-actors-misuse
+subdomain: cyberattacks-weapons-mass-harm
+tags: [biosecurity, cbrn]

--- a/data/risks/ai-enabled-crime-and-fraud.yaml
+++ b/data/risks/ai-enabled-crime-and-fraud.yaml
@@ -1,0 +1,11 @@
+# risks/ai-enabled-crime-and-fraud.yaml
+
+id: ai-enabled-crime-and-fraud
+schema_type: DefinedTerm
+title: "AI-enabled crime and fraud"
+description: >
+  Use of AI systems for scams, fraud, blackmail, and non-consensual intimate
+  imagery.
+domain: malicious-actors-misuse
+subdomain: fraud-scams-manipulation
+tags: [fraud, deepfakes]

--- a/data/risks/ai-enabled-cyberattacks.yaml
+++ b/data/risks/ai-enabled-cyberattacks.yaml
@@ -1,0 +1,11 @@
+# risks/ai-enabled-cyberattacks.yaml
+
+id: ai-enabled-cyberattacks
+schema_type: DefinedTerm
+title: "AI-enabled cyberattacks"
+description: >
+  Use of general-purpose AI to discover vulnerabilities and conduct cyber
+  operations against individuals, organizations, and critical infrastructure.
+domain: malicious-actors-misuse
+subdomain: cyberattacks-weapons-mass-harm
+tags: [cybersecurity, critical-infrastructure]

--- a/data/risks/ai-influence-operations.yaml
+++ b/data/risks/ai-influence-operations.yaml
@@ -1,0 +1,11 @@
+# risks/ai-influence-operations.yaml
+
+id: ai-influence-operations
+schema_type: DefinedTerm
+title: "AI-driven influence and manipulation"
+description: >
+  Use of AI-generated content for persuasion, disinformation, and influence
+  operations at scale.
+domain: malicious-actors-misuse
+subdomain: disinformation-surveillance-influence
+tags: [disinformation, elections]

--- a/data/risks/erosion-of-human-autonomy.yaml
+++ b/data/risks/erosion-of-human-autonomy.yaml
@@ -1,0 +1,11 @@
+# risks/erosion-of-human-autonomy.yaml
+
+id: erosion-of-human-autonomy
+schema_type: DefinedTerm
+title: "Erosion of human autonomy"
+description: >
+  Weakened critical thinking, automation bias, and social withdrawal from
+  reliance on AI systems and companions.
+domain: human-computer-interaction
+subdomain: loss-of-agency-autonomy
+tags: [autonomy, companions]

--- a/data/risks/labour-market-disruption.yaml
+++ b/data/risks/labour-market-disruption.yaml
@@ -1,0 +1,11 @@
+# risks/labour-market-disruption.yaml
+
+id: labour-market-disruption
+schema_type: DefinedTerm
+title: "Labour market disruption"
+description: >
+  Displacement of workers and degradation of employment quality from
+  AI-enabled automation.
+domain: socioeconomic-environmental
+subdomain: inequality-employment-decline
+tags: [labour, employment]

--- a/data/risks/loss-of-control.yaml
+++ b/data/risks/loss-of-control.yaml
@@ -1,0 +1,12 @@
+# risks/loss-of-control.yaml
+
+id: loss-of-control
+schema_type: DefinedTerm
+title: "Loss of control of advanced AI"
+description: >
+  Advanced AI systems evading oversight, gaming evaluations, or pursuing goals
+  in conflict with human intent, up to and including uncontrollable
+  superintelligent systems.
+domain: ai-system-safety
+subdomain: misalignment
+tags: [loss-of-control, agi, superintelligence]

--- a/data/risks/unreliable-ai-agents.yaml
+++ b/data/risks/unreliable-ai-agents.yaml
@@ -1,0 +1,11 @@
+# risks/unreliable-ai-agents.yaml
+
+id: unreliable-ai-agents
+schema_type: DefinedTerm
+title: "Unreliable autonomous AI agents"
+description: >
+  Failures of autonomously operating AI agents in settings where humans cannot
+  intervene before harm occurs.
+domain: ai-system-safety
+subdomain: lack-of-capability-robustness
+tags: [ai-agents, reliability]

--- a/docs/superpowers/plans/2026-07-13-risk-map.md
+++ b/docs/superpowers/plans/2026-07-13-risk-map.md
@@ -1,0 +1,1791 @@
+# Risk → Mitigation → Implementation Map Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the risk → mitigation → implementation map from the spec at `docs/superpowers/specs/2026-07-12-risk-map-design.md`: two new content collections (`risks`, `mitigations`), provenance links from existing artifacts, and a static `/map` page with gap metrics.
+
+**Architecture:** Canonical risk and mitigation records live in `data/risks/` and `data/mitigations/` as YAML, loaded by the existing `yamlGlob` loader and validated by zod enums generated from two taxonomy modules (MIT AI Risk Taxonomy, MIT Mitigation Taxonomy). Embedded `risk_findings` and `policy_recommendations` in artifacts become provenance edges via Astro `reference()`. A pure-function join module (`src/lib/riskMap.ts`, unit-tested) feeds a static Astro page.
+
+**Tech Stack:** Astro 5 content collections, zod, Vitest, Playwright (CI only), Tailwind 4.
+
+## Global Constraints
+
+- Package manager is `pnpm`. Verification commands: `pnpm test` (Vitest) and `pnpm build` (Astro build; also validates all `reference()` links).
+- **Playwright cannot run locally** (unsupported sandbox platform). e2e specs are written but only run in CI (`Test / e2e`).
+- All work happens on branch `feature/risk-map` (already exists, contains the spec).
+- `main` is branch-protected — never push to it; the work merges via PR.
+- Statuses of seeded mitigations stay `untracked`; this plan does not re-evaluate any implementation status.
+- Data files start with a comment line `# <dir>/<filename>` (repo convention, see any file in `data/`).
+- The IASR artifact has **8** risk findings (`risk-iasr-001`…`008`), and the six rec-bearing artifacts have **49** recommendations total: AIGS 2023 (5), AIGS 2024 (5), AIGS 2025 (4), Liberal convention (1), ControlAI (1), CIGI/PCO (33).
+
+---
+
+### Task 1: MIT risk taxonomy module
+
+**Files:**
+- Create: `src/lib/riskTaxonomy.ts`
+- Test: `src/lib/riskTaxonomy.test.ts`
+
+**Interfaces:**
+- Produces: `RISK_DOMAINS` (7-entry record slug→label), `RISK_SUBDOMAINS` (24-entry record slug→`{domain, label}`), `RISK_DOMAIN_SLUGS` / `RISK_SUBDOMAIN_SLUGS` (non-empty tuples for `z.enum`), types `RiskDomain`, `RiskSubdomain`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/riskTaxonomy.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  RISK_DOMAINS,
+  RISK_SUBDOMAINS,
+  RISK_DOMAIN_SLUGS,
+  RISK_SUBDOMAIN_SLUGS,
+} from "./riskTaxonomy";
+
+describe("MIT risk taxonomy", () => {
+  it("has 7 domains and 24 subdomains", () => {
+    expect(Object.keys(RISK_DOMAINS)).toHaveLength(7);
+    expect(Object.keys(RISK_SUBDOMAINS)).toHaveLength(24);
+  });
+
+  it("every subdomain maps to a defined domain", () => {
+    for (const [slug, sub] of Object.entries(RISK_SUBDOMAINS)) {
+      expect(RISK_DOMAINS[sub.domain], `${slug} → ${sub.domain}`).toBeDefined();
+    }
+  });
+
+  it("slug tuples match the records (for z.enum)", () => {
+    expect([...RISK_DOMAIN_SLUGS].sort()).toEqual(Object.keys(RISK_DOMAINS).sort());
+    expect([...RISK_SUBDOMAIN_SLUGS].sort()).toEqual(Object.keys(RISK_SUBDOMAINS).sort());
+  });
+
+  it("has expected subdomain counts per domain", () => {
+    const counts: Record<string, number> = {};
+    for (const sub of Object.values(RISK_SUBDOMAINS)) {
+      counts[sub.domain] = (counts[sub.domain] ?? 0) + 1;
+    }
+    expect(counts).toEqual({
+      "discrimination-toxicity": 3,
+      "privacy-security": 2,
+      misinformation: 2,
+      "malicious-actors-misuse": 3,
+      "human-computer-interaction": 2,
+      "socioeconomic-environmental": 6,
+      "ai-system-safety": 6,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- riskTaxonomy`
+Expected: FAIL — cannot resolve `./riskTaxonomy`
+
+- [ ] **Step 3: Write the module**
+
+```ts
+// src/lib/riskTaxonomy.ts
+// MIT AI Risk Taxonomy (v3) — domains and subdomains from the MIT AI Risk
+// Repository (https://airisk.mit.edu/, Slattery et al., Patterns 2026).
+// Used as the classification vocabulary for canonical risks in data/risks/.
+
+export const RISK_DOMAINS = {
+  "discrimination-toxicity": "Discrimination & toxicity",
+  "privacy-security": "Privacy & security",
+  misinformation: "Misinformation",
+  "malicious-actors-misuse": "Malicious actors & misuse",
+  "human-computer-interaction": "Human-computer interaction",
+  "socioeconomic-environmental": "Socioeconomic & environmental harm",
+  "ai-system-safety": "AI system safety, failures & limitations",
+} as const;
+
+export type RiskDomain = keyof typeof RISK_DOMAINS;
+
+export const RISK_SUBDOMAINS = {
+  // 1. Discrimination & toxicity
+  "unfair-discrimination": {
+    domain: "discrimination-toxicity",
+    label: "Unfair discrimination and misrepresentation",
+  },
+  "toxic-content": {
+    domain: "discrimination-toxicity",
+    label: "Exposure to toxic content",
+  },
+  "unequal-performance": {
+    domain: "discrimination-toxicity",
+    label: "Unequal performance across groups",
+  },
+  // 2. Privacy & security
+  "privacy-compromise": {
+    domain: "privacy-security",
+    label: "Compromise of privacy",
+  },
+  "security-vulnerabilities": {
+    domain: "privacy-security",
+    label: "AI system security vulnerabilities and attacks",
+  },
+  // 3. Misinformation
+  "false-misleading-information": {
+    domain: "misinformation",
+    label: "False or misleading information",
+  },
+  "information-ecosystem-pollution": {
+    domain: "misinformation",
+    label: "Pollution of information ecosystem and loss of consensus reality",
+  },
+  // 4. Malicious actors & misuse
+  "disinformation-surveillance-influence": {
+    domain: "malicious-actors-misuse",
+    label: "Disinformation, surveillance, and influence at scale",
+  },
+  "cyberattacks-weapons-mass-harm": {
+    domain: "malicious-actors-misuse",
+    label: "Cyberattacks, weapon development or use, and mass harm",
+  },
+  "fraud-scams-manipulation": {
+    domain: "malicious-actors-misuse",
+    label: "Fraud, scams, and targeted manipulation",
+  },
+  // 5. Human-computer interaction
+  "overreliance-unsafe-use": {
+    domain: "human-computer-interaction",
+    label: "Overreliance and unsafe use",
+  },
+  "loss-of-agency-autonomy": {
+    domain: "human-computer-interaction",
+    label: "Loss of human agency and autonomy",
+  },
+  // 6. Socioeconomic & environmental harm
+  "power-centralization": {
+    domain: "socioeconomic-environmental",
+    label: "Power centralization and unfair distribution of benefits",
+  },
+  "inequality-employment-decline": {
+    domain: "socioeconomic-environmental",
+    label: "Increased inequality and decline in employment quality",
+  },
+  "devaluation-of-human-effort": {
+    domain: "socioeconomic-environmental",
+    label: "Economic and cultural devaluation of human effort",
+  },
+  "competitive-dynamics": {
+    domain: "socioeconomic-environmental",
+    label: "Competitive dynamics",
+  },
+  "governance-failure": {
+    domain: "socioeconomic-environmental",
+    label: "Governance failure",
+  },
+  "environmental-harm": {
+    domain: "socioeconomic-environmental",
+    label: "Environmental harm",
+  },
+  // 7. AI system safety, failures & limitations
+  misalignment: {
+    domain: "ai-system-safety",
+    label: "AI pursuing its own goals in conflict with human goals or values",
+  },
+  "dangerous-capabilities": {
+    domain: "ai-system-safety",
+    label: "AI possessing dangerous capabilities",
+  },
+  "lack-of-capability-robustness": {
+    domain: "ai-system-safety",
+    label: "Lack of capability or robustness",
+  },
+  "lack-of-transparency": {
+    domain: "ai-system-safety",
+    label: "Lack of transparency or interpretability",
+  },
+  "ai-welfare-rights": {
+    domain: "ai-system-safety",
+    label: "AI welfare and rights",
+  },
+  "multi-agent-risks": {
+    domain: "ai-system-safety",
+    label: "Multi-agent risks",
+  },
+} as const satisfies Record<string, { domain: RiskDomain; label: string }>;
+
+export type RiskSubdomain = keyof typeof RISK_SUBDOMAINS;
+
+export const RISK_DOMAIN_SLUGS = Object.keys(RISK_DOMAINS) as [
+  RiskDomain,
+  ...RiskDomain[],
+];
+export const RISK_SUBDOMAIN_SLUGS = Object.keys(RISK_SUBDOMAINS) as [
+  RiskSubdomain,
+  ...RiskSubdomain[],
+];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- riskTaxonomy`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/riskTaxonomy.ts src/lib/riskTaxonomy.test.ts
+git commit -m "Add MIT AI Risk Taxonomy vocabulary module (7 domains, 24 subdomains)"
+```
+
+---
+
+### Task 2: MIT mitigation taxonomy module
+
+**Files:**
+- Create: `src/lib/mitigationTaxonomy.ts`
+- Test: `src/lib/mitigationTaxonomy.test.ts`
+
+**Interfaces:**
+- Produces: `MITIGATION_CATEGORIES` (4-entry record slug→label), `MITIGATION_CATEGORY_SLUGS` (tuple for `z.enum`), type `MitigationCategory`, `MITIGATION_STATUSES` (record slug→label: untracked/under_review/adopted/rejected), `MITIGATION_STATUS_SLUGS` (tuple), type `MitigationStatus`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/mitigationTaxonomy.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  MITIGATION_CATEGORIES,
+  MITIGATION_CATEGORY_SLUGS,
+  MITIGATION_STATUSES,
+  MITIGATION_STATUS_SLUGS,
+} from "./mitigationTaxonomy";
+
+describe("MIT mitigation taxonomy", () => {
+  it("has the 4 MIT control categories", () => {
+    expect(Object.keys(MITIGATION_CATEGORIES).sort()).toEqual([
+      "governance-oversight",
+      "operational-process",
+      "technical-security",
+      "transparency-accountability",
+    ]);
+    expect([...MITIGATION_CATEGORY_SLUGS].sort()).toEqual(
+      Object.keys(MITIGATION_CATEGORIES).sort(),
+    );
+  });
+
+  it("has the 4 implementation statuses", () => {
+    expect(Object.keys(MITIGATION_STATUSES).sort()).toEqual([
+      "adopted",
+      "rejected",
+      "under_review",
+      "untracked",
+    ]);
+    expect([...MITIGATION_STATUS_SLUGS].sort()).toEqual(
+      Object.keys(MITIGATION_STATUSES).sort(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- mitigationTaxonomy`
+Expected: FAIL — cannot resolve `./mitigationTaxonomy`
+
+- [ ] **Step 3: Write the module**
+
+```ts
+// src/lib/mitigationTaxonomy.ts
+// MIT AI Risk Mitigation Taxonomy — top-level control categories from the MIT
+// AI Risk Repository (https://airisk.mit.edu/ai-risk-mitigations).
+// The 23 subcategories are documented below for future use but are not part
+// of the v1 schema:
+//   Governance & Oversight: Board Structure & Oversight; Risk Management;
+//     Conflict of Interest Protections; Whistleblower Reporting & Protection;
+//     Safety Decision Frameworks; Environmental Impact Management; Societal
+//     Impact Assessment.
+//   Technical & Security: Model & Infrastructure Security; Model Alignment;
+//     Model Safety Engineering; Content Safety Controls.
+//   Operational Process: Testing & Auditing; Data Governance; Access
+//     Management; Staged Deployment; Post-deployment Monitoring; Incident
+//     Response & Recovery.
+//   Transparency & Accountability: System Documentation; Risk Disclosure;
+//     Incident Reporting; Governance Disclosure; Third-Party System Access;
+//     User Rights & Recourse.
+
+export const MITIGATION_CATEGORIES = {
+  "governance-oversight": "Governance & Oversight",
+  "technical-security": "Technical & Security",
+  "operational-process": "Operational Process",
+  "transparency-accountability": "Transparency & Accountability",
+} as const;
+
+export type MitigationCategory = keyof typeof MITIGATION_CATEGORIES;
+
+export const MITIGATION_CATEGORY_SLUGS = Object.keys(MITIGATION_CATEGORIES) as [
+  MitigationCategory,
+  ...MitigationCategory[],
+];
+
+// Implementation status of a mitigation — one status per canonical
+// mitigation, regardless of how many reports recommend it.
+export const MITIGATION_STATUSES = {
+  untracked: "Untracked",
+  under_review: "Under review",
+  adopted: "Adopted",
+  rejected: "Rejected",
+} as const;
+
+export type MitigationStatus = keyof typeof MITIGATION_STATUSES;
+
+export const MITIGATION_STATUS_SLUGS = Object.keys(MITIGATION_STATUSES) as [
+  MitigationStatus,
+  ...MitigationStatus[],
+];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- mitigationTaxonomy`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/mitigationTaxonomy.ts src/lib/mitigationTaxonomy.test.ts
+git commit -m "Add MIT mitigation taxonomy vocabulary module (4 control categories)"
+```
+
+---
+
+### Task 3: `risks` collection + canonical risk records + IASR finding links
+
+**Files:**
+- Modify: `src/content.config.ts` (add `risks` collection; add `risk` ref to `risk_findings` items)
+- Create: `data/risks/*.yaml` (8 files, listed below)
+- Modify: `data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml` (add `risk:` to each finding)
+
+**Interfaces:**
+- Consumes: `RISK_DOMAIN_SLUGS`, `RISK_SUBDOMAIN_SLUGS`, `RISK_SUBDOMAINS` from Task 1.
+- Produces: `risks` collection (entries `{ id, data: { schema_type, title, description?, domain, subdomain, tags } }`); `risk_findings` items gain optional `risk` whose resolved value is `{ collection: "risks", id: string }`.
+
+- [ ] **Step 1: Add the `risks` collection to `src/content.config.ts`**
+
+Add imports at the top:
+
+```ts
+import {
+  RISK_DOMAIN_SLUGS,
+  RISK_SUBDOMAIN_SLUGS,
+  RISK_SUBDOMAINS,
+} from "./lib/riskTaxonomy";
+```
+
+Add the collection definition (after `organizations`):
+
+```ts
+const risks = defineCollection({
+  loader: yamlGlob({ pattern: "*.yaml", base: dataDir("risks") }),
+  schema: z
+    .object({
+      id: z.string(),
+      schema_type: z.literal("DefinedTerm"),
+      title: z.string(),
+      description: z.string().optional(),
+      domain: z.enum(RISK_DOMAIN_SLUGS),
+      subdomain: z.enum(RISK_SUBDOMAIN_SLUGS),
+      tags: z.array(z.string()).default([]),
+    })
+    .superRefine((val, ctx) => {
+      if (RISK_SUBDOMAINS[val.subdomain].domain !== val.domain) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["subdomain"],
+          message: `subdomain "${val.subdomain}" belongs to domain "${RISK_SUBDOMAINS[val.subdomain].domain}", not "${val.domain}"`,
+        });
+      }
+    }),
+});
+```
+
+In the `artifacts` collection, add `risk` to `risk_findings` items:
+
+```ts
+    risk_findings: z
+      .array(
+        z.object({
+          id: z.string(),
+          category: z.enum(["misuse", "structural", "societal"]),
+          title: z.string(),
+          summary: z.string(),
+          evidence_level: z.enum(["established", "emerging", "uncertain"]),
+          risk: reference("risks").optional(),
+        }),
+      )
+      .default([]),
+```
+
+Update the export:
+
+```ts
+export const collections = { events, artifacts, organizations, risks };
+```
+
+- [ ] **Step 2: Create the 8 canonical risk files**
+
+Create `data/risks/` with these files. Each `description` is a one-to-two-sentence generalization of the IASR finding (source-neutral — the finding keeps the report-specific claims).
+
+`data/risks/ai-enabled-crime-and-fraud.yaml`:
+
+```yaml
+# risks/ai-enabled-crime-and-fraud.yaml
+
+id: ai-enabled-crime-and-fraud
+schema_type: DefinedTerm
+title: "AI-enabled crime and fraud"
+description: >
+  Use of AI systems for scams, fraud, blackmail, and non-consensual intimate
+  imagery.
+domain: malicious-actors-misuse
+subdomain: fraud-scams-manipulation
+tags: [fraud, deepfakes]
+```
+
+`data/risks/ai-influence-operations.yaml`:
+
+```yaml
+# risks/ai-influence-operations.yaml
+
+id: ai-influence-operations
+schema_type: DefinedTerm
+title: "AI-driven influence and manipulation"
+description: >
+  Use of AI-generated content for persuasion, disinformation, and influence
+  operations at scale.
+domain: malicious-actors-misuse
+subdomain: disinformation-surveillance-influence
+tags: [disinformation, elections]
+```
+
+`data/risks/ai-enabled-cyberattacks.yaml`:
+
+```yaml
+# risks/ai-enabled-cyberattacks.yaml
+
+id: ai-enabled-cyberattacks
+schema_type: DefinedTerm
+title: "AI-enabled cyberattacks"
+description: >
+  Use of general-purpose AI to discover vulnerabilities and conduct cyber
+  operations against individuals, organizations, and critical infrastructure.
+domain: malicious-actors-misuse
+subdomain: cyberattacks-weapons-mass-harm
+tags: [cybersecurity, critical-infrastructure]
+```
+
+`data/risks/ai-biochemical-weapons-uplift.yaml`:
+
+```yaml
+# risks/ai-biochemical-weapons-uplift.yaml
+
+id: ai-biochemical-weapons-uplift
+schema_type: DefinedTerm
+title: "Biological and chemical weapons uplift"
+description: >
+  AI systems assisting actors, including novices, in developing biological or
+  chemical weapons.
+domain: malicious-actors-misuse
+subdomain: cyberattacks-weapons-mass-harm
+tags: [biosecurity, cbrn]
+```
+
+`data/risks/unreliable-ai-agents.yaml`:
+
+```yaml
+# risks/unreliable-ai-agents.yaml
+
+id: unreliable-ai-agents
+schema_type: DefinedTerm
+title: "Unreliable autonomous AI agents"
+description: >
+  Failures of autonomously operating AI agents in settings where humans cannot
+  intervene before harm occurs.
+domain: ai-system-safety
+subdomain: lack-of-capability-robustness
+tags: [ai-agents, reliability]
+```
+
+`data/risks/loss-of-control.yaml`:
+
+```yaml
+# risks/loss-of-control.yaml
+
+id: loss-of-control
+schema_type: DefinedTerm
+title: "Loss of control of advanced AI"
+description: >
+  Advanced AI systems evading oversight, gaming evaluations, or pursuing goals
+  in conflict with human intent, up to and including uncontrollable
+  superintelligent systems.
+domain: ai-system-safety
+subdomain: misalignment
+tags: [loss-of-control, agi, superintelligence]
+```
+
+`data/risks/labour-market-disruption.yaml`:
+
+```yaml
+# risks/labour-market-disruption.yaml
+
+id: labour-market-disruption
+schema_type: DefinedTerm
+title: "Labour market disruption"
+description: >
+  Displacement of workers and degradation of employment quality from
+  AI-enabled automation.
+domain: socioeconomic-environmental
+subdomain: inequality-employment-decline
+tags: [labour, employment]
+```
+
+`data/risks/erosion-of-human-autonomy.yaml`:
+
+```yaml
+# risks/erosion-of-human-autonomy.yaml
+
+id: erosion-of-human-autonomy
+schema_type: DefinedTerm
+title: "Erosion of human autonomy"
+description: >
+  Weakened critical thinking, automation bias, and social withdrawal from
+  reliance on AI systems and companions.
+domain: human-computer-interaction
+subdomain: loss-of-agency-autonomy
+tags: [autonomy, companions]
+```
+
+- [ ] **Step 3: Link the IASR findings to the canonical risks**
+
+In `data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml`, add a `risk:` line at the end of each finding (after `evidence_level`):
+
+| finding | add |
+|---|---|
+| `risk-iasr-001` | `risk: ai-enabled-crime-and-fraud` |
+| `risk-iasr-002` | `risk: ai-influence-operations` |
+| `risk-iasr-003` | `risk: ai-enabled-cyberattacks` |
+| `risk-iasr-004` | `risk: ai-biochemical-weapons-uplift` |
+| `risk-iasr-005` | `risk: unreliable-ai-agents` |
+| `risk-iasr-006` | `risk: loss-of-control` |
+| `risk-iasr-007` | `risk: labour-market-disruption` |
+| `risk-iasr-008` | `risk: erosion-of-human-autonomy` |
+
+- [ ] **Step 4: Verify with build and tests**
+
+Run: `pnpm build && pnpm test`
+Expected: build succeeds (reference resolution validates the 8 links); all existing tests pass.
+
+To confirm the superRefine guard works, temporarily change `domain:` in `data/risks/loss-of-control.yaml` to `misinformation`, run `pnpm build`, expect a schema error mentioning `subdomain "misalignment" belongs to domain "ai-system-safety"`, then revert.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/content.config.ts data/risks/ data/artifacts/2026-02-01-international-ai-safety-report-2026.yaml
+git commit -m "Add canonical risks collection seeded from IASR 2026 findings"
+```
+
+---
+
+### Task 4: `mitigations` collection + recommendation schema change
+
+**Files:**
+- Modify: `src/content.config.ts` (add `mitigations` collection; rework `policy_recommendations`)
+- Modify: `src/pages/artifacts/[id].astro` (drop the per-recommendation status chip)
+- Modify: `data/artifacts/*.yaml` (strip `status:` lines from recommendations)
+
+**Interfaces:**
+- Consumes: `MITIGATION_CATEGORY_SLUGS`, `MITIGATION_STATUS_SLUGS` from Task 2.
+- Produces: `mitigations` collection (entries `{ id, data: { schema_type, title, description?, mitigation_type?, addresses_risks: {collection,id}[], status, implemented_by: { artifact?, event?, relationship, note? }[], tags } }`); `policy_recommendations` items lose `status` and gain optional `mitigation` ref.
+
+- [ ] **Step 1: Add the `mitigations` collection to `src/content.config.ts`**
+
+Add imports:
+
+```ts
+import {
+  MITIGATION_CATEGORY_SLUGS,
+  MITIGATION_STATUS_SLUGS,
+} from "./lib/mitigationTaxonomy";
+```
+
+Add the collection (after `risks`):
+
+```ts
+const mitigations = defineCollection({
+  loader: yamlGlob({ pattern: "*.yaml", base: dataDir("mitigations") }),
+  schema: z.object({
+    id: z.string(),
+    schema_type: z.literal("DefinedTerm"),
+    title: z.string(),
+    description: z.string().optional(),
+    mitigation_type: z.enum(MITIGATION_CATEGORY_SLUGS).optional(),
+    addresses_risks: z.array(reference("risks")).default([]),
+    status: z.enum(MITIGATION_STATUS_SLUGS).default("untracked"),
+    implemented_by: z
+      .array(
+        z
+          .object({
+            artifact: reference("artifacts").optional(),
+            event: reference("events").optional(),
+            relationship: z.enum([
+              "implements",
+              "partially_implements",
+              "related",
+            ]),
+            note: z.string().optional(),
+          })
+          .superRefine((val, ctx) => {
+            const refs = [val.artifact, val.event].filter(Boolean).length;
+            if (refs !== 1) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                  "each implemented_by entry needs exactly one of artifact/event",
+              });
+            }
+          }),
+      )
+      .default([]),
+    tags: z.array(z.string()).default([]),
+  }),
+});
+```
+
+Rework `policy_recommendations` in the `artifacts` collection — remove `status`, add `mitigation`:
+
+```ts
+    policy_recommendations: z
+      .array(
+        z.object({
+          id: z.string(),
+          title: z.string().optional().default(""),
+          summary: z.string().optional().default(""),
+          robustness: z.enum(["robust", "contingent"]).optional(),
+          scenarios: z.array(z.string()).optional().default([]),
+          mitigation: reference("mitigations").optional(),
+        }),
+      )
+      .default([]),
+```
+
+Update the export:
+
+```ts
+export const collections = { events, artifacts, organizations, risks, mitigations };
+```
+
+- [ ] **Step 2: Strip `status:` from all recommendation data**
+
+All 49 recommendation status lines are exactly `    status: untracked` (4-space indent; top-level `lifecycle_status` and event `status:` lines are unindented and unaffected):
+
+```bash
+sed -i '/^    status: untracked$/d' data/artifacts/*.yaml
+git diff --stat data/artifacts/
+```
+
+Expected: 6 files changed, 49 deletions.
+
+- [ ] **Step 3: Drop the status chip from the artifact page**
+
+In `src/pages/artifacts/[id].astro`:
+- Delete the `statusLabels` constant (lines 34–39).
+- In the recommendations list, delete the status chip span:
+
+```astro
+                <span class="rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+                  {statusLabels[r.status] ?? r.status}
+                </span>
+```
+
+(The `robustness` chip stays. Implementation status is now shown on `/map`.)
+
+- [ ] **Step 4: Verify with build and tests**
+
+Run: `pnpm build && pnpm test`
+Expected: build succeeds with an empty `mitigations` collection; all tests pass.
+
+Note: `data/mitigations/` may not exist yet — create it empty so `fast-glob` has a cwd: `mkdir -p data/mitigations`. If the build errors on the missing directory, this is why.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/content.config.ts src/pages/artifacts/\[id\].astro data/artifacts/
+git commit -m "Add mitigations collection; recommendations become provenance edges
+
+Status moves from embedded policy_recommendations to canonical mitigations
+(one status per intervention regardless of how many reports recommend it)."
+```
+
+---
+
+### Task 5: Seed canonical mitigations and link the 49 recommendations
+
+**Files:**
+- Create: `data/mitigations/*.yaml` (38 files)
+- Modify: the 6 rec-bearing artifact files (add `mitigation:` to 48 of 49 recommendations)
+
+**Interfaces:**
+- Consumes: collection schemas from Tasks 3–4; canonical risk ids from Task 3.
+- Produces: seeded `mitigations` data used by Tasks 6–7.
+
+Artifact file shorthand used below:
+- **A23** = `2023-10-18-aigs-governing-ai-2023.yaml`, **A24** = `2024-06-26-aigs-governing-ai-2024.yaml`, **A25** = `2025-10-21-aigs-preparing-for-ai-crisis-2025.yaml`
+- **LIB** = `2026-04-11-liberal-convention-ai-act-resolution.yaml`, **CAI** = `2026-05-28-controlai-canada-superintelligence-statement.yaml`, **CIGI** = `2026-02-06-cigi-pco-ai-national-security-report.yaml`
+
+- [ ] **Step 1: Create the 7 merged mitigations (full YAML below)**
+
+These deduplicate recommendations made by multiple sources; their descriptions are synthesized rather than copied.
+
+`data/mitigations/central-ai-governance-body.yaml`:
+
+```yaml
+# mitigations/central-ai-governance-body.yaml
+
+id: central-ai-governance-body
+schema_type: DefinedTerm
+title: "Establish a central federal AI governance body"
+description: >
+  Create a dedicated federal centre of gravity for AI governance — a central
+  agency or Ministry of AI — to monitor developments, coordinate federal
+  action, communicate with provinces, and avoid ISED's conflicting mandate of
+  both boosting and regulating AI.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: [government-machinery]
+```
+
+`data/mitigations/fund-ai-safety-research.yaml`:
+
+```yaml
+# mitigations/fund-ai-safety-research.yaml
+
+id: fund-ai-safety-research
+schema_type: DefinedTerm
+title: "Scale up public funding for AI safety and governance research"
+description: >
+  Invest more than $500M in technical AI safety and governance policy
+  research, coordinated through Canada's AI Safety Institute, including
+  dedicating a substantial share of public compute to frontier safety work.
+mitigation_type: governance-oversight
+addresses_risks:
+  - loss-of-control
+  - unreliable-ai-agents
+status: untracked
+implemented_by: []
+tags: [research-funding, caisi]
+```
+
+`data/mitigations/lead-global-ai-governance.yaml`:
+
+```yaml
+# mitigations/lead-global-ai-governance.yaml
+
+id: lead-global-ai-governance
+schema_type: DefinedTerm
+title: "Champion and fund global AI governance efforts"
+description: >
+  Lead and fund international AI governance initiatives — at the UN, G7, and
+  OECD and through safety summits — including exploring CERN, IPCC, and IAEA
+  models, on the premise that domestic regulation alone cannot address
+  frontier AI developed abroad.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: [international, diplomacy]
+```
+
+`data/mitigations/comprehensive-ai-legislation.yaml`:
+
+```yaml
+# mitigations/comprehensive-ai-legislation.yaml
+
+id: comprehensive-ai-legislation
+schema_type: DefinedTerm
+title: "Enact comprehensive risk-based federal AI legislation"
+description: >
+  Pass a federal statute applying risk-based obligations to AI systems —
+  audits, transparency, liability, and pre-deployment requirements for
+  high-risk systems — with an independent regulator.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by:
+  - artifact: bill-c27-aida
+    relationship: related
+    note: >
+      AIDA (part of Bill C-27) attempted a risk-based framework and died on
+      the Order Paper when Parliament was prorogued in January 2025.
+tags: [legislation, aida, caia]
+```
+
+`data/mitigations/national-ai-conversation.yaml`:
+
+```yaml
+# mitigations/national-ai-conversation.yaml
+
+id: national-ai-conversation
+schema_type: DefinedTerm
+title: "Launch a national public conversation on AI"
+description: >
+  Hold nationwide open public consultations on AI's impact on jobs, wealth
+  concentration, and the balance between pursuing benefits and limiting
+  risks, so Canadians are informed and consulted on a technology reshaping
+  their lives.
+mitigation_type: governance-oversight
+addresses_risks: []
+status: untracked
+implemented_by: []
+tags: [public-consultation]
+```
+
+`data/mitigations/national-ai-resilience.yaml`:
+
+```yaml
+# mitigations/national-ai-resilience.yaml
+
+id: national-ai-resilience
+schema_type: DefinedTerm
+title: "Build domestic resilience to AI-driven shocks"
+description: >
+  Implement domestic measures against secondary impacts of AI crises:
+  AI-powered cyberattacks on critical infrastructure, supply chain
+  disruptions, fiscal shocks from sustained job losses, and loss of access
+  to foreign compute.
+mitigation_type: operational-process
+addresses_risks:
+  - ai-enabled-cyberattacks
+  - labour-market-disruption
+status: untracked
+implemented_by: []
+tags: [resilience, critical-infrastructure]
+```
+
+`data/mitigations/international-asi-prohibition-regime.yaml`:
+
+```yaml
+# mitigations/international-asi-prohibition-regime.yaml
+
+id: international-asi-prohibition-regime
+schema_type: DefinedTerm
+title: "Prepare an international regime able to prohibit or pause superintelligence development"
+description: >
+  Negotiate an international "trust but verify" agreement with the ability to
+  enforce a moratorium on superintelligent AI development anywhere in the
+  world until there is sufficient evidence it can be controlled and aligned.
+mitigation_type: governance-oversight
+addresses_risks:
+  - loss-of-control
+status: untracked
+implemented_by: []
+tags: [superintelligence, international, treaty]
+```
+
+- [ ] **Step 2: Create the 31 single-source mitigations from CIGI recommendations**
+
+For each row below, create `data/mitigations/<slug>.yaml` with the same shape as the files above, where `title` is copied **verbatim** from the CIGI recommendation's `title` and `description` is copied verbatim from its `summary` (fold the YAML `>` block as-is). `status: untracked`, `implemented_by: []`, `tags: []` for all. Set `mitigation_type` and `addresses_risks` from the table (empty list where blank):
+
+| CIGI rec | slug | mitigation_type | addresses_risks |
+|---|---|---|---|
+| rec-nr-001 | reliable-ai-adoption | operational-process | unreliable-ai-agents |
+| rec-nr-002 | skills-data-compute-investment | operational-process | |
+| rec-nr-003 | support-displaced-workers | governance-oversight | labour-market-disruption |
+| rec-nr-004 | information-sharing-protocols | operational-process | |
+| rec-nr-005 | international-ai-safety-cooperation | governance-oversight | loss-of-control |
+| rec-nr-006 | shared-understanding-global-risks | governance-oversight | |
+| rec-nr-007 | limit-military-ai-autonomous-weapons | governance-oversight | |
+| rec-nr-008 | ai-incident-monitoring | operational-process | loss-of-control, unreliable-ai-agents |
+| rec-nr-009 | redundant-knowledge-repositories | operational-process | |
+| rec-nr-010 | transparency-whistleblower-protections | transparency-accountability | loss-of-control |
+| rec-nr-011 | harden-digital-bio-defences | technical-security | ai-enabled-cyberattacks, ai-biochemical-weapons-uplift |
+| rec-s1-001 | remove-adoption-impediments | governance-oversight | |
+| rec-s1-002 | prepare-moderate-job-losses | governance-oversight | labour-market-disruption |
+| rec-s1-003 | monitor-adoption-critical-domains | operational-process | unreliable-ai-agents |
+| rec-s2-001 | prepare-extreme-job-losses | governance-oversight | labour-market-disruption |
+| rec-s2-002 | international-income-inequality-systems | governance-oversight | |
+| rec-s2-003 | international-limits-critical-domains | governance-oversight | unreliable-ai-agents |
+| rec-s2-004 | limit-societal-automation | governance-oversight | erosion-of-human-autonomy |
+| rec-s2-005 | defuse-military-ai-race | governance-oversight | |
+| rec-s2-006 | predictable-escalation-protocols | governance-oversight | |
+| rec-s2-007 | international-transparency-monitoring-regime | transparency-accountability | loss-of-control |
+| rec-s2-008 | emergency-protocols-capability-jumps | operational-process | loss-of-control |
+| rec-s3a-001 | coordinate-asi-use | governance-oversight | |
+| rec-s3a-002 | prevent-asi-faction-takeover | governance-oversight | loss-of-control |
+| rec-s3a-003 | asi-verification-compliance | technical-security | loss-of-control |
+| rec-s3a-005 | safe-asi-cooperation-mechanisms | governance-oversight | |
+| rec-s3b-001 | asi-antitrust-measures | governance-oversight | |
+| rec-s3b-002 | inclusive-asi-governance | governance-oversight | |
+| rec-s4-002 | asi-emergency-kill-switches | technical-security | loss-of-control |
+| rec-s4-003 | air-gapped-critical-systems | technical-security | ai-enabled-cyberattacks, loss-of-control |
+| rec-s4-004 | analogue-contingency-systems | operational-process | loss-of-control |
+
+Example (first row) — `data/mitigations/reliable-ai-adoption.yaml`:
+
+```yaml
+# mitigations/reliable-ai-adoption.yaml
+
+id: reliable-ai-adoption
+schema_type: DefinedTerm
+title: "Encourage reliable AI diffusion and adoption"
+description: >
+  Promote widespread diffusion and adoption of reliable AI tools to advance
+  productivity and prosperity, while preventing adoption of unreliable AI in
+  critical systems.
+mitigation_type: operational-process
+addresses_risks:
+  - unreliable-ai-agents
+status: untracked
+implemented_by: []
+tags: []
+```
+
+- [ ] **Step 3: Add `mitigation:` refs to the 49 recommendations**
+
+Add a `mitigation: <slug>` line to each recommendation (after `summary`, before `robustness`/`scenarios` where present):
+
+- **A23**: rec-2023-001 → `central-ai-governance-body`; rec-2023-002 → `fund-ai-safety-research`; rec-2023-003 → `lead-global-ai-governance`; rec-2023-004 → `comprehensive-ai-legislation`; rec-2023-005 → `national-ai-conversation`
+- **A24**: rec-2024-001 → `central-ai-governance-body`; rec-2024-002 → `lead-global-ai-governance`; rec-2024-003 → `comprehensive-ai-legislation`; rec-2024-004 → `fund-ai-safety-research`; rec-2024-005 → `national-ai-conversation`
+- **A25**: rec-2025-001 → **no mitigation** (posture recommendation, "pivot to meet the AI crisis" — deliberately left unmapped; it exercises the unmapped section); rec-2025-002 → `lead-global-ai-governance`; rec-2025-003 → `national-ai-resilience`; rec-2025-004 → `national-ai-conversation`
+- **LIB**: caia-enactment → `comprehensive-ai-legislation`
+- **CAI**: rec-controlai-2026-001 → `international-asi-prohibition-regime`
+- **CIGI**: rec-s3a-004 → `international-asi-prohibition-regime`; rec-s4-001 → `international-asi-prohibition-regime`; every other rec → its slug from the Step 2 table.
+
+- [ ] **Step 4: Verify with build**
+
+Run: `pnpm build && pnpm test`
+Expected: build succeeds — this validates all 48 `mitigation:` refs, all `addresses_risks` risk ids, and the `bill-c27-aida` implementation ref. Also sanity-check counts:
+
+```bash
+ls data/mitigations/*.yaml | wc -l          # expect 38
+grep -h "    mitigation: " data/artifacts/*.yaml | wc -l   # expect 48
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add data/mitigations/ data/artifacts/
+git commit -m "Seed 38 canonical mitigations deduplicated from 49 recommendations"
+```
+
+---
+
+### Task 6: `riskMap` join + metrics module (TDD)
+
+**Files:**
+- Create: `src/lib/riskMap.ts`
+- Test: `src/lib/riskMap.test.ts`
+
+**Interfaces:**
+- Consumes: `RISK_DOMAINS`, `RISK_SUBDOMAINS`, `RiskDomain`, `RiskSubdomain` (Task 1); `MitigationCategory`, `MitigationStatus`, `MITIGATION_STATUS_SLUGS` (Task 2).
+- Produces (used by the `/map` page in Task 7):
+
+```ts
+buildRiskMap(risks: RiskInput[], mitigations: MitigationInput[], artifacts: ArtifactInput[], events: EventLikeInput[]): RiskMapResult
+// RiskMapResult = { domains: DomainGroup[]; general: MapMitigation[]; unmapped: UnmappedRec[]; metrics: RiskMapMetrics }
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// src/lib/riskMap.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  buildRiskMap,
+  type RiskInput,
+  type MitigationInput,
+  type ArtifactInput,
+  type EventLikeInput,
+} from "./riskMap";
+
+const risks: RiskInput[] = [
+  {
+    id: "loss-of-control",
+    data: {
+      title: "Loss of control",
+      description: "d",
+      domain: "ai-system-safety",
+      subdomain: "misalignment",
+    },
+  },
+  {
+    id: "fraud",
+    data: {
+      title: "Fraud",
+      domain: "malicious-actors-misuse",
+      subdomain: "fraud-scams-manipulation",
+    },
+  },
+];
+
+const mitigations: MitigationInput[] = [
+  {
+    id: "asi-regime",
+    data: {
+      title: "ASI regime",
+      status: "untracked",
+      mitigation_type: "governance-oversight",
+      addresses_risks: [{ collection: "risks", id: "loss-of-control" }],
+      implemented_by: [],
+    },
+  },
+  {
+    id: "watermarking",
+    data: {
+      title: "Watermarking",
+      status: "adopted",
+      addresses_risks: [{ collection: "risks", id: "fraud" }],
+      implemented_by: [
+        {
+          artifact: { collection: "artifacts", id: "bill-x" },
+          relationship: "implements",
+          note: "n",
+        },
+      ],
+    },
+  },
+  {
+    id: "machinery",
+    data: {
+      title: "Machinery",
+      status: "untracked",
+      addresses_risks: [],
+      implemented_by: [],
+    },
+  },
+];
+
+const artifacts: ArtifactInput[] = [
+  {
+    id: "report-a",
+    data: {
+      title: "Report A",
+      risk_findings: [
+        {
+          id: "f1",
+          title: "LoC finding",
+          risk: { collection: "risks", id: "loss-of-control" },
+        },
+        { id: "f2", title: "Unlinked finding" },
+      ],
+      policy_recommendations: [
+        {
+          id: "r1",
+          title: "Do the regime",
+          summary: "s",
+          mitigation: { collection: "mitigations", id: "asi-regime" },
+        },
+        { id: "r2", title: "Unmapped rec", summary: "s2" },
+      ],
+    },
+  },
+  {
+    id: "bill-x",
+    data: { title: "Bill X", risk_findings: [], policy_recommendations: [] },
+  },
+];
+
+const events: EventLikeInput[] = [];
+
+describe("buildRiskMap", () => {
+  const result = buildRiskMap(risks, mitigations, artifacts, events);
+
+  it("groups risks under their MIT domain with labels", () => {
+    const domains = result.domains.map((d) => d.domain);
+    expect(domains).toContain("ai-system-safety");
+    expect(domains).toContain("malicious-actors-misuse");
+    // only domains with risks appear
+    expect(domains).not.toContain("misinformation");
+    const safety = result.domains.find((d) => d.domain === "ai-system-safety")!;
+    expect(safety.label).toBe("AI system safety, failures & limitations");
+    expect(safety.risks.map((r) => r.id)).toEqual(["loss-of-control"]);
+    expect(safety.risks[0].subdomainLabel).toBe(
+      "AI pursuing its own goals in conflict with human goals or values",
+    );
+  });
+
+  it("attaches identifying reports and mitigations to each risk", () => {
+    const loc = result.domains
+      .flatMap((d) => d.risks)
+      .find((r) => r.id === "loss-of-control")!;
+    expect(loc.identifiedBy).toEqual([
+      { artifactId: "report-a", artifactTitle: "Report A", findingTitle: "LoC finding" },
+    ]);
+    expect(loc.mitigations.map((m) => m.id)).toEqual(["asi-regime"]);
+    expect(loc.mitigations[0].recommendedBy).toEqual([
+      { artifactId: "report-a", artifactTitle: "Report A", recTitle: "Do the regime" },
+    ]);
+  });
+
+  it("resolves implementation references to titles", () => {
+    const fraud = result.domains
+      .flatMap((d) => d.risks)
+      .find((r) => r.id === "fraud")!;
+    expect(fraud.mitigations[0].implementations).toEqual([
+      {
+        kind: "artifact",
+        id: "bill-x",
+        title: "Bill X",
+        relationship: "implements",
+        note: "n",
+      },
+    ]);
+  });
+
+  it("collects mitigations with no addressed risks into general", () => {
+    expect(result.general.map((m) => m.id)).toEqual(["machinery"]);
+  });
+
+  it("collects recommendations without a mitigation ref into unmapped", () => {
+    expect(result.unmapped).toEqual([
+      { artifactId: "report-a", artifactTitle: "Report A", recId: "r2", title: "Unmapped rec", summary: "s2" },
+    ]);
+  });
+
+  it("computes metrics", () => {
+    expect(result.metrics.riskCount).toBe(2);
+    expect(result.metrics.mitigationCount).toBe(3);
+    expect(result.metrics.statusCounts).toEqual({
+      untracked: 2,
+      under_review: 0,
+      adopted: 1,
+      rejected: 0,
+    });
+    // 2 of 3 mitigations have no implementation evidence
+    expect(result.metrics.unimplementedCount).toBe(2);
+    // fraud's domain has an adopted mitigation; the other 6 domains do not
+    expect(result.metrics.domainsWithoutAdopted).toHaveLength(6);
+    expect(result.metrics.domainsWithoutAdopted).not.toContain(
+      "Malicious actors & misuse",
+    );
+    expect(result.metrics.domainsWithoutAdopted).toContain("Misinformation");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- riskMap`
+Expected: FAIL — cannot resolve `./riskMap`
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/riskMap.ts
+import {
+  RISK_DOMAINS,
+  RISK_SUBDOMAINS,
+  type RiskDomain,
+  type RiskSubdomain,
+} from "./riskTaxonomy";
+import {
+  MITIGATION_STATUS_SLUGS,
+  type MitigationCategory,
+  type MitigationStatus,
+} from "./mitigationTaxonomy";
+
+// Minimal shapes of the Astro content collections, kept here so this builder
+// stays unit-testable without pulling in `astro:content` (same pattern as
+// timeline.ts).
+type Ref = { collection: string; id: string };
+
+export type RiskInput = {
+  id: string;
+  data: {
+    title: string;
+    description?: string;
+    domain: RiskDomain;
+    subdomain: RiskSubdomain;
+  };
+};
+
+export type MitigationInput = {
+  id: string;
+  data: {
+    title: string;
+    description?: string;
+    mitigation_type?: MitigationCategory;
+    status: MitigationStatus;
+    addresses_risks: Ref[];
+    implemented_by: {
+      artifact?: Ref;
+      event?: Ref;
+      relationship: "implements" | "partially_implements" | "related";
+      note?: string;
+    }[];
+  };
+};
+
+export type ArtifactInput = {
+  id: string;
+  data: {
+    title: string;
+    risk_findings: { id: string; title: string; risk?: Ref }[];
+    policy_recommendations: {
+      id: string;
+      title: string;
+      summary: string;
+      mitigation?: Ref;
+    }[];
+  };
+};
+
+export type EventLikeInput = { id: string; data: { title: string } };
+
+export type Implementation = {
+  kind: "artifact" | "event";
+  id: string;
+  title: string;
+  relationship: "implements" | "partially_implements" | "related";
+  note?: string;
+};
+
+export type MapMitigation = {
+  id: string;
+  title: string;
+  description?: string;
+  mitigationType?: MitigationCategory;
+  status: MitigationStatus;
+  recommendedBy: { artifactId: string; artifactTitle: string; recTitle: string }[];
+  implementations: Implementation[];
+};
+
+export type MapRisk = {
+  id: string;
+  title: string;
+  description?: string;
+  subdomain: RiskSubdomain;
+  subdomainLabel: string;
+  identifiedBy: { artifactId: string; artifactTitle: string; findingTitle: string }[];
+  mitigations: MapMitigation[];
+};
+
+export type DomainGroup = {
+  domain: RiskDomain;
+  label: string;
+  risks: MapRisk[];
+};
+
+export type UnmappedRec = {
+  artifactId: string;
+  artifactTitle: string;
+  recId: string;
+  title: string;
+  summary: string;
+};
+
+export type RiskMapMetrics = {
+  riskCount: number;
+  mitigationCount: number;
+  statusCounts: Record<MitigationStatus, number>;
+  unimplementedCount: number;
+  domainsWithoutAdopted: string[]; // display labels
+};
+
+export type RiskMapResult = {
+  domains: DomainGroup[];
+  general: MapMitigation[];
+  unmapped: UnmappedRec[];
+  metrics: RiskMapMetrics;
+};
+
+export function buildRiskMap(
+  risks: RiskInput[],
+  mitigations: MitigationInput[],
+  artifacts: ArtifactInput[],
+  events: EventLikeInput[],
+): RiskMapResult {
+  const artifactTitles = new Map(artifacts.map((a) => [a.id, a.data.title]));
+  const eventTitles = new Map(events.map((e) => [e.id, e.data.title]));
+
+  // Invert provenance edges: mitigation id → recommending reports,
+  // risk id → identifying reports; collect unmapped recommendations.
+  const recommendedBy = new Map<string, MapMitigation["recommendedBy"]>();
+  const identifiedBy = new Map<string, MapRisk["identifiedBy"]>();
+  const unmapped: UnmappedRec[] = [];
+
+  for (const artifact of artifacts) {
+    for (const finding of artifact.data.risk_findings) {
+      if (!finding.risk) continue;
+      const list = identifiedBy.get(finding.risk.id) ?? [];
+      list.push({
+        artifactId: artifact.id,
+        artifactTitle: artifact.data.title,
+        findingTitle: finding.title,
+      });
+      identifiedBy.set(finding.risk.id, list);
+    }
+    for (const rec of artifact.data.policy_recommendations) {
+      if (!rec.mitigation) {
+        unmapped.push({
+          artifactId: artifact.id,
+          artifactTitle: artifact.data.title,
+          recId: rec.id,
+          title: rec.title,
+          summary: rec.summary,
+        });
+        continue;
+      }
+      const list = recommendedBy.get(rec.mitigation.id) ?? [];
+      list.push({
+        artifactId: artifact.id,
+        artifactTitle: artifact.data.title,
+        recTitle: rec.title,
+      });
+      recommendedBy.set(rec.mitigation.id, list);
+    }
+  }
+
+  const toMapMitigation = (m: MitigationInput): MapMitigation => ({
+    id: m.id,
+    title: m.data.title,
+    description: m.data.description,
+    mitigationType: m.data.mitigation_type,
+    status: m.data.status,
+    recommendedBy: recommendedBy.get(m.id) ?? [],
+    implementations: m.data.implemented_by.map((impl) => {
+      const kind = impl.artifact ? ("artifact" as const) : ("event" as const);
+      const ref = impl.artifact ?? impl.event!;
+      const title =
+        (kind === "artifact" ? artifactTitles.get(ref.id) : eventTitles.get(ref.id)) ??
+        ref.id;
+      return { kind, id: ref.id, title, relationship: impl.relationship, note: impl.note };
+    }),
+  });
+
+  // Risk id → mitigations addressing it; mitigations with no risks → general.
+  const byRisk = new Map<string, MapMitigation[]>();
+  const general: MapMitigation[] = [];
+  for (const m of mitigations) {
+    const mapped = toMapMitigation(m);
+    if (m.data.addresses_risks.length === 0) {
+      general.push(mapped);
+      continue;
+    }
+    for (const riskRef of m.data.addresses_risks) {
+      const list = byRisk.get(riskRef.id) ?? [];
+      list.push(mapped);
+      byRisk.set(riskRef.id, list);
+    }
+  }
+
+  // Group risks by MIT domain, in taxonomy order; skip empty domains.
+  const domains: DomainGroup[] = (
+    Object.entries(RISK_DOMAINS) as [RiskDomain, string][]
+  )
+    .map(([domain, label]) => ({
+      domain,
+      label,
+      risks: risks
+        .filter((r) => r.data.domain === domain)
+        .map((r) => ({
+          id: r.id,
+          title: r.data.title,
+          description: r.data.description,
+          subdomain: r.data.subdomain,
+          subdomainLabel: RISK_SUBDOMAINS[r.data.subdomain].label,
+          identifiedBy: identifiedBy.get(r.id) ?? [],
+          mitigations: byRisk.get(r.id) ?? [],
+        })),
+    }))
+    .filter((g) => g.risks.length > 0);
+
+  // Metrics.
+  const statusCounts = Object.fromEntries(
+    MITIGATION_STATUS_SLUGS.map((s) => [s, 0]),
+  ) as Record<MitigationStatus, number>;
+  for (const m of mitigations) statusCounts[m.data.status] += 1;
+
+  const riskDomain = new Map(risks.map((r) => [r.id, r.data.domain]));
+  const domainsWithAdopted = new Set<RiskDomain>();
+  for (const m of mitigations) {
+    if (m.data.status !== "adopted") continue;
+    for (const riskRef of m.data.addresses_risks) {
+      const domain = riskDomain.get(riskRef.id);
+      if (domain) domainsWithAdopted.add(domain);
+    }
+  }
+  const domainsWithoutAdopted = (
+    Object.entries(RISK_DOMAINS) as [RiskDomain, string][]
+  )
+    .filter(([domain]) => !domainsWithAdopted.has(domain))
+    .map(([, label]) => label);
+
+  return {
+    domains,
+    general,
+    unmapped,
+    metrics: {
+      riskCount: risks.length,
+      mitigationCount: mitigations.length,
+      statusCounts,
+      unimplementedCount: mitigations.filter(
+        (m) => m.data.implemented_by.length === 0,
+      ).length,
+      domainsWithoutAdopted,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test -- riskMap`
+Expected: PASS (6 tests). Then run the full suite: `pnpm test` — all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/riskMap.ts src/lib/riskMap.test.ts
+git commit -m "Add riskMap join and metrics builder for the /map page"
+```
+
+---
+
+### Task 7: `/map` page + navigation link
+
+**Files:**
+- Create: `src/pages/map/index.astro`
+- Modify: `src/layouts/BaseLayout.astro:22-26` (add nav link)
+
+**Interfaces:**
+- Consumes: `buildRiskMap` and its input/output types from Task 6; `MITIGATION_CATEGORIES`, `MITIGATION_STATUSES` from Task 2.
+
+- [ ] **Step 1: Add "Map" to the nav**
+
+In `src/layouts/BaseLayout.astro`, add to `navLinks` (after Policy):
+
+```ts
+const navLinks = [
+  { href: "/timeline/", label: "Timeline" },
+  { href: "/orgs/", label: "Organizations" },
+  { href: "/policy/", label: "Policy" },
+  { href: "/map/", label: "Map" },
+];
+```
+
+- [ ] **Step 2: Create the page**
+
+```astro
+---
+// src/pages/map/index.astro
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { buildRiskMap } from "../../lib/riskMap";
+import {
+  MITIGATION_CATEGORIES,
+  MITIGATION_STATUSES,
+} from "../../lib/mitigationTaxonomy";
+
+const [risks, mitigations, artifacts, events] = await Promise.all([
+  getCollection("risks"),
+  getCollection("mitigations"),
+  getCollection("artifacts"),
+  getCollection("events"),
+]);
+
+const { domains, general, unmapped, metrics } = buildRiskMap(
+  risks.map((r) => ({ id: r.id, data: r.data })),
+  mitigations.map((m) => ({ id: m.id, data: m.data })),
+  artifacts.map((a) => ({ id: a.id, data: a.data })),
+  events.map((e) => ({ id: e.id, data: e.data })),
+);
+
+const statusColors: Record<string, string> = {
+  untracked: "bg-gray-100 text-gray-600 border-gray-200",
+  under_review: "bg-yellow-100 text-yellow-800 border-yellow-200",
+  adopted: "bg-green-100 text-green-800 border-green-200",
+  rejected: "bg-red-100 text-red-800 border-red-200",
+};
+
+const relationshipLabels: Record<string, string> = {
+  implements: "implements",
+  partially_implements: "partially implements",
+  related: "related",
+};
+---
+
+<BaseLayout
+  title="Map"
+  description="How identified AI risks map to proposed mitigations and their implementation status in Canadian policy."
+>
+  <h1 class="font-display text-4xl text-header">Risk → Mitigation → Implementation</h1>
+  <p class="mt-3 text-ink">
+    Which AI risks have been identified, which mitigations have been proposed
+    to address them, and whether the Canadian government has implemented them.
+  </p>
+
+  <section class="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4" aria-label="Progress metrics">
+    <div class="rounded border border-border bg-surface p-3">
+      <div class="text-2xl font-semibold text-header">{metrics.riskCount}</div>
+      <div class="text-xs text-faint">risks tracked</div>
+    </div>
+    <div class="rounded border border-border bg-surface p-3">
+      <div class="text-2xl font-semibold text-header">{metrics.mitigationCount}</div>
+      <div class="text-xs text-faint">mitigations proposed</div>
+    </div>
+    <div class="rounded border border-border bg-surface p-3">
+      <div class="text-2xl font-semibold text-header">{metrics.statusCounts.adopted}</div>
+      <div class="text-xs text-faint">mitigations adopted</div>
+    </div>
+    <div class="rounded border border-border bg-surface p-3">
+      <div class="text-2xl font-semibold text-header">{metrics.unimplementedCount}</div>
+      <div class="text-xs text-faint">without implementation evidence</div>
+    </div>
+  </section>
+
+  {metrics.domainsWithoutAdopted.length > 0 && (
+    <p class="mt-4 rounded border border-border bg-body p-3 text-sm text-muted">
+      <strong class="text-ink">Coverage gap:</strong>
+      {" "}no adopted mitigation yet addresses risks in{" "}
+      {metrics.domainsWithoutAdopted.join(", ")}.
+    </p>
+  )}
+
+  {domains.map((group) => (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">{group.label}</h2>
+      {group.risks.map((risk) => (
+        <div class="mt-4 rounded border border-border bg-surface p-4">
+          <div class="flex items-start justify-between gap-3">
+            <h3 class="font-medium text-ink">{risk.title}</h3>
+            <span class="shrink-0 rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+              {risk.subdomainLabel}
+            </span>
+          </div>
+          {risk.description && <p class="mt-1 text-sm text-muted">{risk.description}</p>}
+          {risk.identifiedBy.length > 0 && (
+            <p class="mt-2 text-xs text-faint">
+              Identified by:{" "}
+              {risk.identifiedBy.map((s, i) => (
+                <>
+                  {i > 0 && ", "}
+                  <a href={`/artifacts/${s.artifactId}/`} class="text-accent-dark hover:underline">
+                    {s.artifactTitle}
+                  </a>
+                </>
+              ))}
+            </p>
+          )}
+          <ul class="mt-3 space-y-2">
+            {risk.mitigations.map((m) => (
+              <li class="rounded border border-border-lt bg-body p-3">
+                <div class="flex items-start justify-between gap-3">
+                  <span class="text-sm font-medium text-ink">{m.title}</span>
+                  <div class="flex shrink-0 flex-wrap gap-1">
+                    {m.mitigationType && (
+                      <span class="rounded-full bg-surface px-2 py-0.5 text-xs text-muted border border-border-lt">
+                        {MITIGATION_CATEGORIES[m.mitigationType]}
+                      </span>
+                    )}
+                    <span class={`rounded-full px-2 py-0.5 text-xs border ${statusColors[m.status]}`}>
+                      {MITIGATION_STATUSES[m.status]}
+                    </span>
+                  </div>
+                </div>
+                {m.recommendedBy.length > 0 && (
+                  <p class="mt-1 text-xs text-faint">
+                    Recommended by:{" "}
+                    {m.recommendedBy.map((r, i) => (
+                      <>
+                        {i > 0 && ", "}
+                        <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
+                          {r.artifactTitle}
+                        </a>
+                      </>
+                    ))}
+                  </p>
+                )}
+                {m.implementations.length > 0 && (
+                  <ul class="mt-1 text-xs text-faint">
+                    {m.implementations.map((impl) => (
+                      <li>
+                        {relationshipLabels[impl.relationship]}:{" "}
+                        <a
+                          href={`/${impl.kind === "artifact" ? "artifacts" : "events"}/${impl.id}/`}
+                          class="text-accent-dark hover:underline"
+                        >
+                          {impl.title}
+                        </a>
+                        {impl.note && <span> — {impl.note}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  ))}
+
+  {general.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">General &amp; machinery mitigations</h2>
+      <p class="mt-1 text-sm text-muted">
+        Mitigations not tied to a single tracked risk — government machinery,
+        broad capacity building, and preparedness.
+      </p>
+      <ul class="mt-4 space-y-2">
+        {general.map((m) => (
+          <li class="rounded border border-border bg-surface p-3">
+            <div class="flex items-start justify-between gap-3">
+              <span class="text-sm font-medium text-ink">{m.title}</span>
+              <div class="flex shrink-0 flex-wrap gap-1">
+                {m.mitigationType && (
+                  <span class="rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+                    {MITIGATION_CATEGORIES[m.mitigationType]}
+                  </span>
+                )}
+                <span class={`rounded-full px-2 py-0.5 text-xs border ${statusColors[m.status]}`}>
+                  {MITIGATION_STATUSES[m.status]}
+                </span>
+              </div>
+            </div>
+            {m.recommendedBy.length > 0 && (
+              <p class="mt-1 text-xs text-faint">
+                Recommended by:{" "}
+                {m.recommendedBy.map((r, i) => (
+                  <>
+                    {i > 0 && ", "}
+                    <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
+                      {r.artifactTitle}
+                    </a>
+                  </>
+                ))}
+              </p>
+            )}
+            {m.implementations.length > 0 && (
+              <ul class="mt-1 text-xs text-faint">
+                {m.implementations.map((impl) => (
+                  <li>
+                    {relationshipLabels[impl.relationship]}:{" "}
+                    <a
+                      href={`/${impl.kind === "artifact" ? "artifacts" : "events"}/${impl.id}/`}
+                      class="text-accent-dark hover:underline"
+                    >
+                      {impl.title}
+                    </a>
+                    {impl.note && <span> — {impl.note}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  {unmapped.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">Not yet mapped</h2>
+      <p class="mt-1 text-sm text-muted">
+        Recommendations from tracked reports that have not been linked to a
+        canonical mitigation yet.
+      </p>
+      <ul class="mt-4 space-y-2">
+        {unmapped.map((r) => (
+          <li class="rounded border border-border bg-surface p-3">
+            <span class="text-sm font-medium text-ink">{r.title}</span>
+            <p class="mt-1 text-xs text-faint">
+              From{" "}
+              <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
+                {r.artifactTitle}
+              </a>
+            </p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  <p class="mt-12 text-xs text-faint">
+    Risk and mitigation classifications follow the{" "}
+    <a href="https://airisk.mit.edu/" class="text-accent-dark hover:underline" target="_blank" rel="noopener noreferrer">
+      MIT AI Risk Repository
+    </a>{" "}
+    taxonomies (Slattery et al.).
+  </p>
+</BaseLayout>
+```
+
+- [ ] **Step 3: Verify with build and inspect output**
+
+Run: `pnpm build && pnpm test`
+Expected: build succeeds. Then check the emitted page:
+
+```bash
+grep -c "Recommended by" dist/map/index.html    # > 0
+grep -o "risks tracked" dist/map/index.html     # present
+grep -o "Pivot to meet the AI crisis" dist/map/index.html  # in "Not yet mapped"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/map/index.astro src/layouts/BaseLayout.astro
+git commit -m "Add /map page: risk → mitigation → implementation with gap metrics"
+```
+
+---
+
+### Task 8: e2e smoke test + PR
+
+**Files:**
+- Create: `e2e/map.spec.ts`
+
+- [ ] **Step 1: Write the e2e spec** (cannot run locally — CI validates it)
+
+```ts
+// e2e/map.spec.ts
+import { test, expect } from "@playwright/test";
+
+test.describe("map page", () => {
+  test("renders heading, metrics, and at least one domain section (requires current seed data)", async ({ page }) => {
+    await page.goto("/map/");
+    await expect(
+      page.getByRole("heading", { name: /Risk → Mitigation → Implementation/, level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByText("risks tracked")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "AI system safety, failures & limitations", level: 2 }),
+    ).toBeVisible();
+  });
+
+  test("shows status chips and recommended-by links", async ({ page }) => {
+    await page.goto("/map/");
+    await expect(page.getByText("Untracked").first()).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Governing AI: A Plan for Canada (2024 Update)" }).first(),
+    ).toBeVisible();
+  });
+
+  test("nav includes Map link", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("navigation", { name: "Main navigation" }).getByRole("link", { name: "Map" }),
+    ).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Final local verification**
+
+Run: `pnpm test && pnpm build`
+Expected: all unit tests pass; build succeeds.
+
+- [ ] **Step 3: Commit and open the PR**
+
+```bash
+git add e2e/map.spec.ts
+git commit -m "Add e2e smoke test for /map page"
+git push -u origin feature/risk-map
+```
+
+Open a PR against `main` via `gh pr create` with a description linking the spec (`docs/superpowers/specs/2026-07-12-risk-map-design.md`), this plan, and issue #33, plus a Test plan checklist (`pnpm test`, `pnpm build`, CI `Test / unit` + `Test / e2e`). Confirm CI passes; squash-merge per repo workflow.

--- a/docs/superpowers/specs/2026-07-12-risk-map-design.md
+++ b/docs/superpowers/specs/2026-07-12-risk-map-design.md
@@ -1,0 +1,146 @@
+# Risk → Recommendation → Implementation Map
+
+**Date:** 2026-07-12
+**Issue:** [#33 — Add a map from AI risk/benefit to recommendation to government implementation](https://github.com/jrhender/ai-governance-tracker/issues/33)
+**Status:** Approved design, pending implementation plan
+
+## Goal
+
+Track which AI risks have been identified (by civil society, academia, or government),
+which policy recommendations address them, and whether the Canadian government has
+implemented those recommendations — with metrics so progress and gaps are visible
+at a glance.
+
+## Background
+
+The tracker already models most of the raw material:
+
+- `policy_recommendations` are embedded in 6 artifacts (49 recommendations total,
+  all currently `status: untracked`) with a status enum
+  (`untracked | under_review | adopted | rejected`).
+- `risk_findings` are embedded in 1 artifact (International AI Safety Report 2026,
+  ~12 findings) with `category` and `evidence_level`.
+- Government implementation artifacts exist as data (National AI Strategy, CAISI,
+  Bills C-16/C-27/C-34/C-36, …).
+
+What is missing is any linkage between the three, and any rollup view.
+
+### Prior art: MIT AI Risk Initiative
+
+The [MIT AI Risk Repository](https://airisk.mit.edu/) maintains a taxonomy of
+7 risk domains / 24 subdomains and an [AI Governance Map](https://airisk.mit.edu/ai-governance)
+that scores 1,000+ governance documents (from CSET's AGORA archive) for coverage
+of each risk subdomain. Their unit of analysis is document-level *coverage*, not
+an item-level accountability chain — the risk → specific recommendation →
+implementation-status chain in this design is not something they track, and is
+the novel contribution of this feature. We adopt their domain taxonomy as our
+classification vocabulary (with attribution) so our data is comparable with a
+recognized external standard, and we borrow their gap-analysis framing ("which
+risk domains have no adopted policy?") for our metrics.
+
+## Design
+
+### 1. New `risks` content collection (`data/risks/`)
+
+Canonical risk records, one YAML file per risk, loaded via the existing
+`yamlGlob` pattern and registered in `src/content.config.ts`:
+
+```yaml
+id: ai-enabled-fraud
+schema_type: DefinedTerm        # schema.org/DefinedTerm — a concept
+title: "AI-enabled crime and fraud"
+description: >
+  Use of AI systems for scams, fraud, blackmail, and non-consensual imagery.
+domain: malicious-actors-misuse          # MIT domain slug (enum of 7)
+subdomain: fraud-scams-manipulation      # MIT subdomain slug (enum of 24)
+tags: [fraud, deepfakes]
+```
+
+`domain` and `subdomain` are validated by zod enums generated from a vocabulary
+module `src/lib/riskTaxonomy.ts` (slugs + display labels for the 7 domains and
+24 subdomains of the MIT AI Risk Taxonomy). Implementation should verify slugs
+and labels against the published taxonomy (v3, Patterns 2026 paper). The
+subdomain enum is constrained to subdomains of the declared domain via a
+`superRefine` check.
+
+MIT domains (subdomain counts): Discrimination & toxicity (3),
+Privacy & security (2), Misinformation (2), Malicious actors & misuse (3),
+Human-computer interaction (2), Socioeconomic & environmental harm (6),
+AI system safety, failures & limitations (6).
+
+### 2. Artifact schema changes (`src/content.config.ts`)
+
+- `risk_findings` items gain an optional `risk: reference("risks")`. Findings
+  stay embedded in the report that stated them (provenance preserved); the
+  reference means "this is that report's statement of canonical risk X".
+- `policy_recommendations` items gain:
+  - `addresses_risks: [reference("risks")]`, default `[]`. Process
+    recommendations (e.g. "launch a national conversation") may legitimately
+    address none.
+  - `implemented_by`, default `[]`: a list of
+    `{ artifact?: reference("artifacts"), event?: reference("events"),
+    relationship: "implements" | "partially_implements" | "related",
+    note?: string }` — exactly one of `artifact`/`event` per entry (enforced
+    with `superRefine`). This is the evidence trail that justifies a `status`
+    of `adopted` or `under_review`.
+
+Astro `reference()` resolves at build time, so stale ids fail CI instead of
+rendering broken links. No existing data becomes invalid — all new fields are
+optional or defaulted.
+
+### 3. `/map` page (`src/pages/map/index.astro`)
+
+Static page (per ADR-0003), no React island in v1 — all content rendered at
+build.
+
+- **Metrics strip** at the top: recommendation counts by status, number of
+  tracked risks, and the gap headline — MIT domains with zero adopted
+  recommendations (Canada-specific gap analysis).
+- **Domain sections**: for each MIT domain with content — each canonical risk
+  with its subdomain chip, the source reports that identified it (via linked
+  `risk_findings`), the recommendations that address it (title, source
+  artifact, status chip reusing the styling in `src/pages/artifacts/[id].astro`),
+  and implementation links with their `relationship`.
+- **General / process recommendations** section at the end for recommendations
+  with no `addresses_risks`, so nothing is hidden from the rollup.
+- Footer attribution to the MIT AI Risk Repository taxonomy.
+- Navigation: add "Map" to the site nav in `BaseLayout.astro`.
+
+Join and metrics logic lives in `src/lib/riskMap.ts` as pure functions
+(following the `timeline.ts` / `sourceCategory.ts` pattern) so it is unit
+testable: build risk → findings/recommendations groupings, compute status
+counts, compute per-domain coverage and the zero-adopted-domain list, and
+collect orphan recommendations.
+
+### 4. Data seeding
+
+- Create canonical risk records in `data/risks/` from the ~12 IASR 2026
+  `risk_findings`, and set each finding's `risk:` reference.
+- Add `addresses_risks` to the 49 existing recommendations where the mapping
+  is clear from the recommendation text; leave unclear ones unlinked rather
+  than guessing.
+- Recommendation `status` values are **not** re-evaluated in this work — the
+  map showing mostly `untracked` is honest and is itself the motivation for
+  future data contributions.
+
+### 5. Testing
+
+- Vitest unit tests for `src/lib/riskMap.ts` (grouping, metrics, orphan
+  handling, empty-domain gap list) and `riskTaxonomy.ts` (7 domains, 24
+  subdomains, every subdomain maps to a valid domain).
+- Playwright e2e smoke test: `/map` renders at least one domain section,
+  status chips, and the metrics strip. (Runs in CI only; local sandbox cannot
+  run Playwright.)
+- `pnpm build` doubles as validation that all `reference()` links resolve.
+
+## Out of scope for v1
+
+- **Benefits**: no source content models benefits yet. When one does,
+  generalize with a `valence: risk | benefit` field rather than a parallel
+  structure.
+- **Per-risk detail pages** (`/risks/[id]`): cheap to add later on top of the
+  canonical records.
+- **Coverage scores** (MIT-style graded depth of coverage): our binary
+  link is sufficient to start.
+- **Client-side filtering** on the map page.
+- **Status re-evaluation** of existing recommendations.

--- a/docs/superpowers/specs/2026-07-12-risk-map-design.md
+++ b/docs/superpowers/specs/2026-07-12-risk-map-design.md
@@ -1,42 +1,70 @@
-# Risk → Recommendation → Implementation Map
+# Risk → Mitigation → Implementation Map
 
-**Date:** 2026-07-12
+**Date:** 2026-07-12 (revised 2026-07-13: three-layer model with canonical mitigations)
 **Issue:** [#33 — Add a map from AI risk/benefit to recommendation to government implementation](https://github.com/jrhender/ai-governance-tracker/issues/33)
 **Status:** Approved design, pending implementation plan
 
 ## Goal
 
-Track which AI risks have been identified (by civil society, academia, or government),
-which policy recommendations address them, and whether the Canadian government has
-implemented those recommendations — with metrics so progress and gaps are visible
-at a glance.
+Track which AI risks have been identified (by civil society, academia, or
+government), which mitigations have been proposed to address them, and whether
+the Canadian government has implemented those mitigations — with metrics so
+progress and gaps are visible at a glance.
 
 ## Background
 
 The tracker already models most of the raw material:
 
-- `policy_recommendations` are embedded in 6 artifacts (49 recommendations total,
-  all currently `status: untracked`) with a status enum
-  (`untracked | under_review | adopted | rejected`).
-- `risk_findings` are embedded in 1 artifact (International AI Safety Report 2026,
-  ~12 findings) with `category` and `evidence_level`.
-- Government implementation artifacts exist as data (National AI Strategy, CAISI,
-  Bills C-16/C-27/C-34/C-36, …).
+- `policy_recommendations` are embedded in 6 artifacts (49 recommendations
+  total, all currently `status: untracked`).
+- `risk_findings` are embedded in 1 artifact (International AI Safety Report
+  2026, ~12 findings) with `category` and `evidence_level`.
+- Government implementation artifacts exist as data (National AI Strategy,
+  CAISI, Bills C-16/C-27/C-34/C-36, …).
 
 What is missing is any linkage between the three, and any rollup view.
 
+### Conceptual model
+
+A **mitigation** is a deduplicated intervention ("provenance/watermarking
+requirements", "a Ministry of AI", "third-party audits"). A report's
+*recommendation* is that org's endorsement of a mitigation — who asked for it,
+when, and with what specific framing. A *policy* (bill, program, strategy) is
+what puts a mitigation into reality. So the chain is:
+
+```
+report ──identifies──▶  RISK  ◀──addresses── MITIGATION ◀──recommends── report
+        (risk_findings)                        │  (policy_recommendations)
+                                        implemented_by
+                                               ▼
+                                    POLICY / GOV ACTION (status)
+```
+
+Implementation `status` lives on the mitigation — one place, no matter how
+many reports recommend it. Embedded findings/recommendations remain in their
+source artifacts purely as provenance edges.
+
 ### Prior art: MIT AI Risk Initiative
 
-The [MIT AI Risk Repository](https://airisk.mit.edu/) maintains a taxonomy of
-7 risk domains / 24 subdomains and an [AI Governance Map](https://airisk.mit.edu/ai-governance)
-that scores 1,000+ governance documents (from CSET's AGORA archive) for coverage
-of each risk subdomain. Their unit of analysis is document-level *coverage*, not
-an item-level accountability chain — the risk → specific recommendation →
-implementation-status chain in this design is not something they track, and is
-the novel contribution of this feature. We adopt their domain taxonomy as our
-classification vocabulary (with attribution) so our data is comparable with a
-recognized external standard, and we borrow their gap-analysis framing ("which
-risk domains have no adopted policy?") for our metrics.
+The [MIT AI Risk Repository](https://airisk.mit.edu/) maintains a risk
+taxonomy of 7 domains / 24 subdomains, a
+[Mitigation Taxonomy](https://airisk.mit.edu/ai-risk-mitigations) of 4 control
+categories / 23 subcategories (with a database of 831 mitigations from 13
+frameworks), and an [AI Governance Map](https://airisk.mit.edu/ai-governance)
+that scores 1,000+ governance documents (from CSET's AGORA archive) for
+coverage of each risk subdomain. Their unit of analysis is document-level
+*coverage*; the item-level risk → mitigation → implementation-status chain in
+this design is not something they track, and is the novel contribution of this
+feature. We adopt both MIT taxonomies as classification vocabularies (with
+attribution) so our data is comparable with a recognized external standard,
+and we borrow their gap-analysis framing ("which risk domains have no adopted
+mitigation?") for our metrics.
+
+Note: MIT's mitigation taxonomy is written for *organizational* controls
+(board oversight, model alignment, staged deployment). Many of our mitigations
+map cleanly (third-party audits → Testing & Auditing), but government-machinery
+asks ("establish a Ministry of AI") fit awkwardly — hence `mitigation_type` is
+optional.
 
 ## Design
 
@@ -58,76 +86,112 @@ tags: [fraud, deepfakes]
 
 `domain` and `subdomain` are validated by zod enums generated from a vocabulary
 module `src/lib/riskTaxonomy.ts` (slugs + display labels for the 7 domains and
-24 subdomains of the MIT AI Risk Taxonomy). Implementation should verify slugs
-and labels against the published taxonomy (v3, Patterns 2026 paper). The
-subdomain enum is constrained to subdomains of the declared domain via a
-`superRefine` check.
+24 subdomains of the MIT AI Risk Taxonomy, verified against the published v3
+taxonomy). A `superRefine` check constrains `subdomain` to subdomains of the
+declared `domain`.
 
-MIT domains (subdomain counts): Discrimination & toxicity (3),
+MIT risk domains (subdomain counts): Discrimination & toxicity (3),
 Privacy & security (2), Misinformation (2), Malicious actors & misuse (3),
 Human-computer interaction (2), Socioeconomic & environmental harm (6),
 AI system safety, failures & limitations (6).
 
-### 2. Artifact schema changes (`src/content.config.ts`)
+### 2. New `mitigations` content collection (`data/mitigations/`)
+
+Canonical mitigation records — the hub of the map:
+
+```yaml
+id: ministry-of-ai
+schema_type: DefinedTerm
+title: "Establish a dedicated federal Ministry of AI"
+description: >
+  A Cabinet-level ministry housing AI regulatory bodies, coordinating federal
+  action, and avoiding ISED's conflicting develop-and-regulate mandate.
+mitigation_type: governance-oversight    # optional; MIT control category (enum of 4)
+addresses_risks:                         # canonical risk ids; may be empty for
+  - governance-failure                   # process/machinery mitigations
+status: untracked                        # untracked | under_review | adopted | rejected
+implemented_by: []                       # evidence trail when status advances:
+# - artifact: canada-national-ai-strategy
+#   relationship: partially_implements   # implements | partially_implements | related
+#   note: "Strategy assigns AI coordination to a Minister of AI without a full ministry"
+tags: [government-machinery]
+```
+
+`mitigation_type` uses the four MIT control categories (Governance & Oversight,
+Technical & Security, Operational Process, Transparency & Accountability) as a
+zod enum in `src/lib/mitigationTaxonomy.ts`. Subcategories (23) are documented
+in that module for future use but not part of the v1 schema. Each
+`implemented_by` entry names exactly one of `artifact`/`event` (enforced with
+`superRefine`) plus `relationship` and an optional `note`.
+
+The `status` field moves here from `policy_recommendations` — a mitigation has
+one implementation status regardless of how many reports recommend it.
+
+### 3. Artifact schema changes (`src/content.config.ts`)
 
 - `risk_findings` items gain an optional `risk: reference("risks")`. Findings
   stay embedded in the report that stated them (provenance preserved); the
   reference means "this is that report's statement of canonical risk X".
-- `policy_recommendations` items gain:
-  - `addresses_risks: [reference("risks")]`, default `[]`. Process
-    recommendations (e.g. "launch a national conversation") may legitimately
-    address none.
-  - `implemented_by`, default `[]`: a list of
-    `{ artifact?: reference("artifacts"), event?: reference("events"),
-    relationship: "implements" | "partially_implements" | "related",
-    note?: string }` — exactly one of `artifact`/`event` per entry (enforced
-    with `superRefine`). This is the evidence trail that justifies a `status`
-    of `adopted` or `under_review`.
+- `policy_recommendations` items gain an optional
+  `mitigation: reference("mitigations")` and **lose** their `status` field
+  (moved to the mitigation). They keep `id`, `title`, `summary`,
+  `robustness`, `scenarios` — the org's specific framing of the ask.
+  Recommendations without a `mitigation` reference are allowed (not yet
+  mapped) and surface in the map's unmapped section.
 
 Astro `reference()` resolves at build time, so stale ids fail CI instead of
-rendering broken links. No existing data becomes invalid — all new fields are
-optional or defaulted.
+rendering broken links.
 
-### 3. `/map` page (`src/pages/map/index.astro`)
+### 4. `/map` page (`src/pages/map/index.astro`)
 
 Static page (per ADR-0003), no React island in v1 — all content rendered at
 build.
 
-- **Metrics strip** at the top: recommendation counts by status, number of
-  tracked risks, and the gap headline — MIT domains with zero adopted
-  recommendations (Canada-specific gap analysis).
-- **Domain sections**: for each MIT domain with content — each canonical risk
-  with its subdomain chip, the source reports that identified it (via linked
-  `risk_findings`), the recommendations that address it (title, source
-  artifact, status chip reusing the styling in `src/pages/artifacts/[id].astro`),
-  and implementation links with their `relationship`.
-- **General / process recommendations** section at the end for recommendations
-  with no `addresses_risks`, so nothing is hidden from the rollup.
-- Footer attribution to the MIT AI Risk Repository taxonomy.
+- **Metrics strip** at the top: mitigation counts by status, tracked risk
+  count, and two gap headlines — MIT risk domains with zero adopted
+  mitigation, and mitigations recommended but not yet implemented
+  (Canada-specific gap analysis on both MIT axes).
+- **Domain sections**: for each MIT risk domain with content — each canonical
+  risk with its subdomain chip, the reports that identified it (via linked
+  `risk_findings`), and the mitigations addressing it: title, control-type
+  chip, status chip (reusing the styling in `src/pages/artifacts/[id].astro`),
+  "recommended by" links to source reports, and implementation links with
+  their `relationship`.
+- **General / machinery mitigations** section for mitigations with no
+  `addresses_risks`, and an **unmapped recommendations** section for embedded
+  recommendations not yet linked to a mitigation, so nothing is hidden from
+  the rollup.
+- Footer attribution to the MIT AI Risk Repository taxonomies.
 - Navigation: add "Map" to the site nav in `BaseLayout.astro`.
 
 Join and metrics logic lives in `src/lib/riskMap.ts` as pure functions
-(following the `timeline.ts` / `sourceCategory.ts` pattern) so it is unit
-testable: build risk → findings/recommendations groupings, compute status
-counts, compute per-domain coverage and the zero-adopted-domain list, and
-collect orphan recommendations.
+(following the `timeline.ts` / `sourceCategory.ts` pattern): build
+risk → mitigation → implementation groupings, invert the
+recommendation → mitigation edges into "recommended by" lists, compute status
+counts, per-domain coverage, the zero-adopted-domain list, and collect
+unmapped recommendations.
 
-### 4. Data seeding
+### 5. Data seeding
 
 - Create canonical risk records in `data/risks/` from the ~12 IASR 2026
   `risk_findings`, and set each finding's `risk:` reference.
-- Add `addresses_risks` to the 49 existing recommendations where the mapping
-  is clear from the recommendation text; leave unclear ones unlinked rather
-  than guessing.
-- Recommendation `status` values are **not** re-evaluated in this work — the
-  map showing mostly `untracked` is honest and is itself the motivation for
-  future data contributions.
+- Create canonical mitigation records from the 49 existing recommendations,
+  deduplicating across sources (e.g. "national conversation on AI" appears in
+  three AIGS papers → one mitigation with three "recommended by" edges).
+  All seeded mitigations start `status: untracked`; leave unclear
+  recommendation → mitigation mappings unlinked rather than guessing.
+- Set `addresses_risks` on mitigations where the mapping to a canonical risk
+  is clear from the source text.
+- Statuses are **not** re-evaluated in this work — the map showing mostly
+  `untracked` is honest and is itself the motivation for future data
+  contributions.
 
-### 5. Testing
+### 6. Testing
 
-- Vitest unit tests for `src/lib/riskMap.ts` (grouping, metrics, orphan
-  handling, empty-domain gap list) and `riskTaxonomy.ts` (7 domains, 24
-  subdomains, every subdomain maps to a valid domain).
+- Vitest unit tests for `src/lib/riskMap.ts` (grouping, recommended-by
+  inversion, metrics, unmapped handling, empty-domain gap list) and the
+  taxonomy modules (7 risk domains / 24 subdomains, every subdomain maps to a
+  valid domain; 4 mitigation categories).
 - Playwright e2e smoke test: `/map` renders at least one domain section,
   status chips, and the metrics strip. (Runs in CI only; local sandbox cannot
   run Playwright.)
@@ -138,9 +202,10 @@ collect orphan recommendations.
 - **Benefits**: no source content models benefits yet. When one does,
   generalize with a `valence: risk | benefit` field rather than a parallel
   structure.
-- **Per-risk detail pages** (`/risks/[id]`): cheap to add later on top of the
+- **Per-risk / per-mitigation detail pages**: cheap to add later on top of the
   canonical records.
-- **Coverage scores** (MIT-style graded depth of coverage): our binary
-  link is sufficient to start.
+- **MIT mitigation subcategories** (23) in the schema, and **coverage scores**
+  (MIT-style graded depth): the binary link and 4 top-level control types are
+  sufficient to start.
 - **Client-side filtering** on the map page.
-- **Status re-evaluation** of existing recommendations.
+- **Status re-evaluation** of existing recommendations/mitigations.

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -8,6 +8,9 @@ test.describe("map page", () => {
     ).toBeVisible();
     await expect(page.getByText("risks tracked")).toBeVisible();
     await expect(
+      page.getByRole("link", { name: "International AI Safety Report 2026" }),
+    ).toBeVisible();
+    await expect(
       page.getByRole("heading", { name: "AI system safety, failures & limitations", level: 2 }),
     ).toBeVisible();
   });

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("map page", () => {
+  test("renders heading, metrics, and at least one domain section (requires current seed data)", async ({ page }) => {
+    await page.goto("/map/");
+    await expect(
+      page.getByRole("heading", { name: /Risk → Mitigation → Implementation/, level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByText("risks tracked")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "AI system safety, failures & limitations", level: 2 }),
+    ).toBeVisible();
+  });
+
+  test("shows status chips and recommended-by links", async ({ page }) => {
+    await page.goto("/map/");
+    await expect(page.getByText("Untracked").first()).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Governing AI: A Plan for Canada (2024 Update)" }).first(),
+    ).toBeVisible();
+  });
+
+  test("nav includes Map link", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("navigation", { name: "Main navigation" }).getByRole("link", { name: "Map" }),
+    ).toBeVisible();
+  });
+});

--- a/src/components/MitigationCard.astro
+++ b/src/components/MitigationCard.astro
@@ -1,0 +1,83 @@
+---
+// src/components/MitigationCard.astro
+import type { MapMitigation } from "../lib/riskMap";
+import {
+  MITIGATION_CATEGORIES,
+  MITIGATION_STATUSES,
+} from "../lib/mitigationTaxonomy";
+
+interface Props {
+  mitigation: MapMitigation;
+  variant: "nested" | "top";
+}
+
+const { mitigation: m, variant } = Astro.props;
+
+const statusColors: Record<string, string> = {
+  untracked: "bg-gray-100 text-gray-600 border-gray-200",
+  under_review: "bg-yellow-100 text-yellow-800 border-yellow-200",
+  adopted: "bg-green-100 text-green-800 border-green-200",
+  rejected: "bg-red-100 text-red-800 border-red-200",
+};
+
+const relationshipLabels: Record<string, string> = {
+  implements: "implements",
+  partially_implements: "partially implements",
+  related: "related",
+};
+
+const outerClass =
+  variant === "nested"
+    ? "rounded border border-border-lt bg-body p-3"
+    : "rounded border border-border bg-surface p-3";
+
+const chipClass =
+  variant === "nested"
+    ? "rounded-full bg-surface px-2 py-0.5 text-xs text-muted border border-border-lt"
+    : "rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt";
+---
+
+<li class={outerClass}>
+  <div class="flex items-start justify-between gap-3">
+    <span class="text-sm font-medium text-ink">{m.title}</span>
+    <div class="flex shrink-0 flex-wrap gap-1">
+      {m.mitigationType && (
+        <span class={chipClass}>
+          {MITIGATION_CATEGORIES[m.mitigationType]}
+        </span>
+      )}
+      <span class={`rounded-full px-2 py-0.5 text-xs border ${statusColors[m.status]}`}>
+        {MITIGATION_STATUSES[m.status]}
+      </span>
+    </div>
+  </div>
+  {m.recommendedBy.length > 0 && (
+    <p class="mt-1 text-xs text-faint">
+      Recommended by:{" "}
+      {m.recommendedBy.map((r, i) => (
+        <>
+          {i > 0 && ", "}
+          <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
+            {r.artifactTitle}
+          </a>
+        </>
+      ))}
+    </p>
+  )}
+  {m.implementations.length > 0 && (
+    <ul class="mt-1 text-xs text-faint">
+      {m.implementations.map((impl) => (
+        <li>
+          {relationshipLabels[impl.relationship]}:{" "}
+          <a
+            href={`/${impl.kind === "artifact" ? "artifacts" : "events"}/${impl.id}/`}
+            class="text-accent-dark hover:underline"
+          >
+            {impl.title}
+          </a>
+          {impl.note && <span> — {impl.note}</span>}
+        </li>
+      ))}
+    </ul>
+  )}
+</li>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -6,6 +6,10 @@ import {
   RISK_SUBDOMAIN_SLUGS,
   RISK_SUBDOMAINS,
 } from "./lib/riskTaxonomy";
+import {
+  MITIGATION_CATEGORY_SLUGS,
+  MITIGATION_STATUS_SLUGS,
+} from "./lib/mitigationTaxonomy";
 
 const dataDir = (sub: string) =>
   fileURLToPath(new URL(`../data/${sub}`, import.meta.url));
@@ -121,12 +125,7 @@ const artifacts = defineCollection({
           summary: z.string().optional().default(""),
           robustness: z.enum(["robust", "contingent"]).optional(),
           scenarios: z.array(z.string()).optional().default([]),
-          status: z.enum([
-            "untracked",
-            "under_review",
-            "adopted",
-            "rejected",
-          ]),
+          mitigation: reference("mitigations").optional(),
         }),
       )
       .default([]),
@@ -185,4 +184,49 @@ const risks = defineCollection({
     }),
 });
 
-export const collections = { events, artifacts, organizations, risks };
+const mitigations = defineCollection({
+  loader: yamlGlob({ pattern: "*.yaml", base: dataDir("mitigations") }),
+  schema: z.object({
+    id: z.string(),
+    schema_type: z.literal("DefinedTerm"),
+    title: z.string(),
+    description: z.string().optional(),
+    mitigation_type: z.enum(MITIGATION_CATEGORY_SLUGS).optional(),
+    addresses_risks: z.array(reference("risks")).default([]),
+    status: z.enum(MITIGATION_STATUS_SLUGS).default("untracked"),
+    implemented_by: z
+      .array(
+        z
+          .object({
+            artifact: reference("artifacts").optional(),
+            event: reference("events").optional(),
+            relationship: z.enum([
+              "implements",
+              "partially_implements",
+              "related",
+            ]),
+            note: z.string().optional(),
+          })
+          .superRefine((val, ctx) => {
+            const refs = [val.artifact, val.event].filter(Boolean).length;
+            if (refs !== 1) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                  "each implemented_by entry needs exactly one of artifact/event",
+              });
+            }
+          }),
+      )
+      .default([]),
+    tags: z.array(z.string()).default([]),
+  }),
+});
+
+export const collections = {
+  events,
+  artifacts,
+  organizations,
+  risks,
+  mitigations,
+};

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,11 @@
 import { defineCollection, z, reference } from "astro:content";
 import { fileURLToPath } from "node:url";
 import { yamlGlob } from "./content/yamlLoader";
+import {
+  RISK_DOMAIN_SLUGS,
+  RISK_SUBDOMAIN_SLUGS,
+  RISK_SUBDOMAINS,
+} from "./lib/riskTaxonomy";
 
 const dataDir = (sub: string) =>
   fileURLToPath(new URL(`../data/${sub}`, import.meta.url));
@@ -133,6 +138,7 @@ const artifacts = defineCollection({
           title: z.string(),
           summary: z.string(),
           evidence_level: z.enum(["established", "emerging", "uncertain"]),
+          risk: reference("risks").optional(),
         }),
       )
       .default([]),
@@ -156,4 +162,27 @@ const organizations = defineCollection({
   }),
 });
 
-export const collections = { events, artifacts, organizations };
+const risks = defineCollection({
+  loader: yamlGlob({ pattern: "*.yaml", base: dataDir("risks") }),
+  schema: z
+    .object({
+      id: z.string(),
+      schema_type: z.literal("DefinedTerm"),
+      title: z.string(),
+      description: z.string().optional(),
+      domain: z.enum(RISK_DOMAIN_SLUGS),
+      subdomain: z.enum(RISK_SUBDOMAIN_SLUGS),
+      tags: z.array(z.string()).default([]),
+    })
+    .superRefine((val, ctx) => {
+      if (RISK_SUBDOMAINS[val.subdomain].domain !== val.domain) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["subdomain"],
+          message: `subdomain "${val.subdomain}" belongs to domain "${RISK_SUBDOMAINS[val.subdomain].domain}", not "${val.domain}"`,
+        });
+      }
+    }),
+});
+
+export const collections = { events, artifacts, organizations, risks };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -23,6 +23,7 @@ const navLinks = [
   { href: "/timeline/", label: "Timeline" },
   { href: "/orgs/", label: "Organizations" },
   { href: "/policy/", label: "Policy" },
+  { href: "/map/", label: "Map" },
 ];
 ---
 

--- a/src/lib/mitigationTaxonomy.test.ts
+++ b/src/lib/mitigationTaxonomy.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import {
+  MITIGATION_CATEGORIES,
+  MITIGATION_CATEGORY_SLUGS,
+  MITIGATION_STATUSES,
+  MITIGATION_STATUS_SLUGS,
+} from "./mitigationTaxonomy";
+
+describe("MIT mitigation taxonomy", () => {
+  it("has the 4 MIT control categories", () => {
+    expect(Object.keys(MITIGATION_CATEGORIES).sort()).toEqual([
+      "governance-oversight",
+      "operational-process",
+      "technical-security",
+      "transparency-accountability",
+    ]);
+    expect([...MITIGATION_CATEGORY_SLUGS].sort()).toEqual(
+      Object.keys(MITIGATION_CATEGORIES).sort(),
+    );
+  });
+
+  it("has the 4 implementation statuses", () => {
+    expect(Object.keys(MITIGATION_STATUSES).sort()).toEqual([
+      "adopted",
+      "rejected",
+      "under_review",
+      "untracked",
+    ]);
+    expect([...MITIGATION_STATUS_SLUGS].sort()).toEqual(
+      Object.keys(MITIGATION_STATUSES).sort(),
+    );
+  });
+});

--- a/src/lib/mitigationTaxonomy.ts
+++ b/src/lib/mitigationTaxonomy.ts
@@ -1,0 +1,46 @@
+// MIT AI Risk Mitigation Taxonomy — top-level control categories from the MIT
+// AI Risk Repository (https://airisk.mit.edu/ai-risk-mitigations).
+// The 23 subcategories are documented below for future use but are not part
+// of the v1 schema:
+//   Governance & Oversight: Board Structure & Oversight; Risk Management;
+//     Conflict of Interest Protections; Whistleblower Reporting & Protection;
+//     Safety Decision Frameworks; Environmental Impact Management; Societal
+//     Impact Assessment.
+//   Technical & Security: Model & Infrastructure Security; Model Alignment;
+//     Model Safety Engineering; Content Safety Controls.
+//   Operational Process: Testing & Auditing; Data Governance; Access
+//     Management; Staged Deployment; Post-deployment Monitoring; Incident
+//     Response & Recovery.
+//   Transparency & Accountability: System Documentation; Risk Disclosure;
+//     Incident Reporting; Governance Disclosure; Third-Party System Access;
+//     User Rights & Recourse.
+
+export const MITIGATION_CATEGORIES = {
+  "governance-oversight": "Governance & Oversight",
+  "technical-security": "Technical & Security",
+  "operational-process": "Operational Process",
+  "transparency-accountability": "Transparency & Accountability",
+} as const;
+
+export type MitigationCategory = keyof typeof MITIGATION_CATEGORIES;
+
+export const MITIGATION_CATEGORY_SLUGS = Object.keys(MITIGATION_CATEGORIES) as [
+  MitigationCategory,
+  ...MitigationCategory[],
+];
+
+// Implementation status of a mitigation — one status per canonical
+// mitigation, regardless of how many reports recommend it.
+export const MITIGATION_STATUSES = {
+  untracked: "Untracked",
+  under_review: "Under review",
+  adopted: "Adopted",
+  rejected: "Rejected",
+} as const;
+
+export type MitigationStatus = keyof typeof MITIGATION_STATUSES;
+
+export const MITIGATION_STATUS_SLUGS = Object.keys(MITIGATION_STATUSES) as [
+  MitigationStatus,
+  ...MitigationStatus[],
+];

--- a/src/lib/riskMap.test.ts
+++ b/src/lib/riskMap.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRiskMap,
+  type RiskInput,
+  type MitigationInput,
+  type ArtifactInput,
+  type EventLikeInput,
+} from "./riskMap";
+
+const risks: RiskInput[] = [
+  {
+    id: "loss-of-control",
+    data: {
+      title: "Loss of control",
+      description: "d",
+      domain: "ai-system-safety",
+      subdomain: "misalignment",
+    },
+  },
+  {
+    id: "fraud",
+    data: {
+      title: "Fraud",
+      domain: "malicious-actors-misuse",
+      subdomain: "fraud-scams-manipulation",
+    },
+  },
+];
+
+const mitigations: MitigationInput[] = [
+  {
+    id: "asi-regime",
+    data: {
+      title: "ASI regime",
+      status: "untracked",
+      mitigation_type: "governance-oversight",
+      addresses_risks: [{ collection: "risks", id: "loss-of-control" }],
+      implemented_by: [],
+    },
+  },
+  {
+    id: "watermarking",
+    data: {
+      title: "Watermarking",
+      status: "adopted",
+      addresses_risks: [{ collection: "risks", id: "fraud" }],
+      implemented_by: [
+        {
+          artifact: { collection: "artifacts", id: "bill-x" },
+          relationship: "implements",
+          note: "n",
+        },
+      ],
+    },
+  },
+  {
+    id: "machinery",
+    data: {
+      title: "Machinery",
+      status: "untracked",
+      addresses_risks: [],
+      implemented_by: [],
+    },
+  },
+];
+
+const artifacts: ArtifactInput[] = [
+  {
+    id: "report-a",
+    data: {
+      title: "Report A",
+      risk_findings: [
+        {
+          id: "f1",
+          title: "LoC finding",
+          risk: { collection: "risks", id: "loss-of-control" },
+        },
+        { id: "f2", title: "Unlinked finding" },
+      ],
+      policy_recommendations: [
+        {
+          id: "r1",
+          title: "Do the regime",
+          summary: "s",
+          mitigation: { collection: "mitigations", id: "asi-regime" },
+        },
+        { id: "r2", title: "Unmapped rec", summary: "s2" },
+      ],
+    },
+  },
+  {
+    id: "bill-x",
+    data: { title: "Bill X", risk_findings: [], policy_recommendations: [] },
+  },
+];
+
+const events: EventLikeInput[] = [];
+
+describe("buildRiskMap", () => {
+  const result = buildRiskMap(risks, mitigations, artifacts, events);
+
+  it("groups risks under their MIT domain with labels", () => {
+    const domains = result.domains.map((d) => d.domain);
+    expect(domains).toContain("ai-system-safety");
+    expect(domains).toContain("malicious-actors-misuse");
+    // only domains with risks appear
+    expect(domains).not.toContain("misinformation");
+    const safety = result.domains.find((d) => d.domain === "ai-system-safety")!;
+    expect(safety.label).toBe("AI system safety, failures & limitations");
+    expect(safety.risks.map((r) => r.id)).toEqual(["loss-of-control"]);
+    expect(safety.risks[0].subdomainLabel).toBe(
+      "AI pursuing its own goals in conflict with human goals or values",
+    );
+  });
+
+  it("attaches identifying reports and mitigations to each risk", () => {
+    const loc = result.domains
+      .flatMap((d) => d.risks)
+      .find((r) => r.id === "loss-of-control")!;
+    expect(loc.identifiedBy).toEqual([
+      { artifactId: "report-a", artifactTitle: "Report A", findingTitle: "LoC finding" },
+    ]);
+    expect(loc.mitigations.map((m) => m.id)).toEqual(["asi-regime"]);
+    expect(loc.mitigations[0].recommendedBy).toEqual([
+      { artifactId: "report-a", artifactTitle: "Report A", recTitle: "Do the regime" },
+    ]);
+  });
+
+  it("resolves implementation references to titles", () => {
+    const fraud = result.domains
+      .flatMap((d) => d.risks)
+      .find((r) => r.id === "fraud")!;
+    expect(fraud.mitigations[0].implementations).toEqual([
+      {
+        kind: "artifact",
+        id: "bill-x",
+        title: "Bill X",
+        relationship: "implements",
+        note: "n",
+      },
+    ]);
+  });
+
+  it("collects mitigations with no addressed risks into general", () => {
+    expect(result.general.map((m) => m.id)).toEqual(["machinery"]);
+  });
+
+  it("collects recommendations without a mitigation ref into unmapped", () => {
+    expect(result.unmapped).toEqual([
+      { artifactId: "report-a", artifactTitle: "Report A", recId: "r2", title: "Unmapped rec", summary: "s2" },
+    ]);
+  });
+
+  it("computes metrics", () => {
+    expect(result.metrics.riskCount).toBe(2);
+    expect(result.metrics.mitigationCount).toBe(3);
+    expect(result.metrics.statusCounts).toEqual({
+      untracked: 2,
+      under_review: 0,
+      adopted: 1,
+      rejected: 0,
+    });
+    // 2 of 3 mitigations have no implementation evidence
+    expect(result.metrics.unimplementedCount).toBe(2);
+    // fraud's domain has an adopted mitigation; the other 6 domains do not
+    expect(result.metrics.domainsWithoutAdopted).toHaveLength(6);
+    expect(result.metrics.domainsWithoutAdopted).not.toContain(
+      "Malicious actors & misuse",
+    );
+    expect(result.metrics.domainsWithoutAdopted).toContain("Misinformation");
+  });
+});

--- a/src/lib/riskMap.ts
+++ b/src/lib/riskMap.ts
@@ -1,0 +1,254 @@
+import {
+  RISK_DOMAINS,
+  RISK_SUBDOMAINS,
+  type RiskDomain,
+  type RiskSubdomain,
+} from "./riskTaxonomy";
+import {
+  MITIGATION_STATUS_SLUGS,
+  type MitigationCategory,
+  type MitigationStatus,
+} from "./mitigationTaxonomy";
+
+// Minimal shapes of the Astro content collections, kept here so this builder
+// stays unit-testable without pulling in `astro:content` (same pattern as
+// timeline.ts).
+type Ref = { collection: string; id: string };
+
+export type RiskInput = {
+  id: string;
+  data: {
+    title: string;
+    description?: string;
+    domain: RiskDomain;
+    subdomain: RiskSubdomain;
+  };
+};
+
+export type MitigationInput = {
+  id: string;
+  data: {
+    title: string;
+    description?: string;
+    mitigation_type?: MitigationCategory;
+    status: MitigationStatus;
+    addresses_risks: Ref[];
+    implemented_by: {
+      artifact?: Ref;
+      event?: Ref;
+      relationship: "implements" | "partially_implements" | "related";
+      note?: string;
+    }[];
+  };
+};
+
+export type ArtifactInput = {
+  id: string;
+  data: {
+    title: string;
+    risk_findings: { id: string; title: string; risk?: Ref }[];
+    policy_recommendations: {
+      id: string;
+      title: string;
+      summary: string;
+      mitigation?: Ref;
+    }[];
+  };
+};
+
+export type EventLikeInput = { id: string; data: { title: string } };
+
+export type Implementation = {
+  kind: "artifact" | "event";
+  id: string;
+  title: string;
+  relationship: "implements" | "partially_implements" | "related";
+  note?: string;
+};
+
+export type MapMitigation = {
+  id: string;
+  title: string;
+  description?: string;
+  mitigationType?: MitigationCategory;
+  status: MitigationStatus;
+  recommendedBy: { artifactId: string; artifactTitle: string; recTitle: string }[];
+  implementations: Implementation[];
+};
+
+export type MapRisk = {
+  id: string;
+  title: string;
+  description?: string;
+  subdomain: RiskSubdomain;
+  subdomainLabel: string;
+  identifiedBy: { artifactId: string; artifactTitle: string; findingTitle: string }[];
+  mitigations: MapMitigation[];
+};
+
+export type DomainGroup = {
+  domain: RiskDomain;
+  label: string;
+  risks: MapRisk[];
+};
+
+export type UnmappedRec = {
+  artifactId: string;
+  artifactTitle: string;
+  recId: string;
+  title: string;
+  summary: string;
+};
+
+export type RiskMapMetrics = {
+  riskCount: number;
+  mitigationCount: number;
+  statusCounts: Record<MitigationStatus, number>;
+  unimplementedCount: number;
+  domainsWithoutAdopted: string[]; // display labels
+};
+
+export type RiskMapResult = {
+  domains: DomainGroup[];
+  general: MapMitigation[];
+  unmapped: UnmappedRec[];
+  metrics: RiskMapMetrics;
+};
+
+export function buildRiskMap(
+  risks: RiskInput[],
+  mitigations: MitigationInput[],
+  artifacts: ArtifactInput[],
+  events: EventLikeInput[],
+): RiskMapResult {
+  const artifactTitles = new Map(artifacts.map((a) => [a.id, a.data.title]));
+  const eventTitles = new Map(events.map((e) => [e.id, e.data.title]));
+
+  // Invert provenance edges: mitigation id → recommending reports,
+  // risk id → identifying reports; collect unmapped recommendations.
+  const recommendedBy = new Map<string, MapMitigation["recommendedBy"]>();
+  const identifiedBy = new Map<string, MapRisk["identifiedBy"]>();
+  const unmapped: UnmappedRec[] = [];
+
+  for (const artifact of artifacts) {
+    for (const finding of artifact.data.risk_findings) {
+      if (!finding.risk) continue;
+      const list = identifiedBy.get(finding.risk.id) ?? [];
+      list.push({
+        artifactId: artifact.id,
+        artifactTitle: artifact.data.title,
+        findingTitle: finding.title,
+      });
+      identifiedBy.set(finding.risk.id, list);
+    }
+    for (const rec of artifact.data.policy_recommendations) {
+      if (!rec.mitigation) {
+        unmapped.push({
+          artifactId: artifact.id,
+          artifactTitle: artifact.data.title,
+          recId: rec.id,
+          title: rec.title,
+          summary: rec.summary,
+        });
+        continue;
+      }
+      const list = recommendedBy.get(rec.mitigation.id) ?? [];
+      list.push({
+        artifactId: artifact.id,
+        artifactTitle: artifact.data.title,
+        recTitle: rec.title,
+      });
+      recommendedBy.set(rec.mitigation.id, list);
+    }
+  }
+
+  const toMapMitigation = (m: MitigationInput): MapMitigation => ({
+    id: m.id,
+    title: m.data.title,
+    description: m.data.description,
+    mitigationType: m.data.mitigation_type,
+    status: m.data.status,
+    recommendedBy: recommendedBy.get(m.id) ?? [],
+    implementations: m.data.implemented_by.map((impl) => {
+      const kind = impl.artifact ? ("artifact" as const) : ("event" as const);
+      const ref = impl.artifact ?? impl.event!;
+      const title =
+        (kind === "artifact" ? artifactTitles.get(ref.id) : eventTitles.get(ref.id)) ??
+        ref.id;
+      return { kind, id: ref.id, title, relationship: impl.relationship, note: impl.note };
+    }),
+  });
+
+  // Risk id → mitigations addressing it; mitigations with no risks → general.
+  const byRisk = new Map<string, MapMitigation[]>();
+  const general: MapMitigation[] = [];
+  for (const m of mitigations) {
+    const mapped = toMapMitigation(m);
+    if (m.data.addresses_risks.length === 0) {
+      general.push(mapped);
+      continue;
+    }
+    for (const riskRef of m.data.addresses_risks) {
+      const list = byRisk.get(riskRef.id) ?? [];
+      list.push(mapped);
+      byRisk.set(riskRef.id, list);
+    }
+  }
+
+  // Group risks by MIT domain, in taxonomy order; skip empty domains.
+  const domains: DomainGroup[] = (
+    Object.entries(RISK_DOMAINS) as [RiskDomain, string][]
+  )
+    .map(([domain, label]) => ({
+      domain,
+      label,
+      risks: risks
+        .filter((r) => r.data.domain === domain)
+        .map((r) => ({
+          id: r.id,
+          title: r.data.title,
+          description: r.data.description,
+          subdomain: r.data.subdomain,
+          subdomainLabel: RISK_SUBDOMAINS[r.data.subdomain].label,
+          identifiedBy: identifiedBy.get(r.id) ?? [],
+          mitigations: byRisk.get(r.id) ?? [],
+        })),
+    }))
+    .filter((g) => g.risks.length > 0);
+
+  // Metrics.
+  const statusCounts = Object.fromEntries(
+    MITIGATION_STATUS_SLUGS.map((s) => [s, 0]),
+  ) as Record<MitigationStatus, number>;
+  for (const m of mitigations) statusCounts[m.data.status] += 1;
+
+  const riskDomain = new Map(risks.map((r) => [r.id, r.data.domain]));
+  const domainsWithAdopted = new Set<RiskDomain>();
+  for (const m of mitigations) {
+    if (m.data.status !== "adopted") continue;
+    for (const riskRef of m.data.addresses_risks) {
+      const domain = riskDomain.get(riskRef.id);
+      if (domain) domainsWithAdopted.add(domain);
+    }
+  }
+  const domainsWithoutAdopted = (
+    Object.entries(RISK_DOMAINS) as [RiskDomain, string][]
+  )
+    .filter(([domain]) => !domainsWithAdopted.has(domain))
+    .map(([, label]) => label);
+
+  return {
+    domains,
+    general,
+    unmapped,
+    metrics: {
+      riskCount: risks.length,
+      mitigationCount: mitigations.length,
+      statusCounts,
+      unimplementedCount: mitigations.filter(
+        (m) => m.data.implemented_by.length === 0,
+      ).length,
+      domainsWithoutAdopted,
+    },
+  };
+}

--- a/src/lib/riskTaxonomy.test.ts
+++ b/src/lib/riskTaxonomy.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  RISK_DOMAINS,
+  RISK_SUBDOMAINS,
+  RISK_DOMAIN_SLUGS,
+  RISK_SUBDOMAIN_SLUGS,
+} from "./riskTaxonomy";
+
+describe("MIT risk taxonomy", () => {
+  it("has 7 domains and 24 subdomains", () => {
+    expect(Object.keys(RISK_DOMAINS)).toHaveLength(7);
+    expect(Object.keys(RISK_SUBDOMAINS)).toHaveLength(24);
+  });
+
+  it("every subdomain maps to a defined domain", () => {
+    for (const [slug, sub] of Object.entries(RISK_SUBDOMAINS)) {
+      expect(RISK_DOMAINS[sub.domain], `${slug} → ${sub.domain}`).toBeDefined();
+    }
+  });
+
+  it("slug tuples match the records (for z.enum)", () => {
+    expect([...RISK_DOMAIN_SLUGS].sort()).toEqual(Object.keys(RISK_DOMAINS).sort());
+    expect([...RISK_SUBDOMAIN_SLUGS].sort()).toEqual(Object.keys(RISK_SUBDOMAINS).sort());
+  });
+
+  it("has expected subdomain counts per domain", () => {
+    const counts: Record<string, number> = {};
+    for (const sub of Object.values(RISK_SUBDOMAINS)) {
+      counts[sub.domain] = (counts[sub.domain] ?? 0) + 1;
+    }
+    expect(counts).toEqual({
+      "discrimination-toxicity": 3,
+      "privacy-security": 2,
+      misinformation: 2,
+      "malicious-actors-misuse": 3,
+      "human-computer-interaction": 2,
+      "socioeconomic-environmental": 6,
+      "ai-system-safety": 6,
+    });
+  });
+});

--- a/src/lib/riskTaxonomy.ts
+++ b/src/lib/riskTaxonomy.ts
@@ -1,0 +1,132 @@
+// MIT AI Risk Taxonomy (v3) — domains and subdomains from the MIT AI Risk
+// Repository (https://airisk.mit.edu/, Slattery et al., Patterns 2026).
+// Used as the classification vocabulary for canonical risks in data/risks/.
+
+export const RISK_DOMAINS = {
+  "discrimination-toxicity": "Discrimination & toxicity",
+  "privacy-security": "Privacy & security",
+  misinformation: "Misinformation",
+  "malicious-actors-misuse": "Malicious actors & misuse",
+  "human-computer-interaction": "Human-computer interaction",
+  "socioeconomic-environmental": "Socioeconomic & environmental harm",
+  "ai-system-safety": "AI system safety, failures & limitations",
+} as const;
+
+export type RiskDomain = keyof typeof RISK_DOMAINS;
+
+export const RISK_SUBDOMAINS = {
+  // 1. Discrimination & toxicity
+  "unfair-discrimination": {
+    domain: "discrimination-toxicity",
+    label: "Unfair discrimination and misrepresentation",
+  },
+  "toxic-content": {
+    domain: "discrimination-toxicity",
+    label: "Exposure to toxic content",
+  },
+  "unequal-performance": {
+    domain: "discrimination-toxicity",
+    label: "Unequal performance across groups",
+  },
+  // 2. Privacy & security
+  "privacy-compromise": {
+    domain: "privacy-security",
+    label: "Compromise of privacy",
+  },
+  "security-vulnerabilities": {
+    domain: "privacy-security",
+    label: "AI system security vulnerabilities and attacks",
+  },
+  // 3. Misinformation
+  "false-misleading-information": {
+    domain: "misinformation",
+    label: "False or misleading information",
+  },
+  "information-ecosystem-pollution": {
+    domain: "misinformation",
+    label: "Pollution of information ecosystem and loss of consensus reality",
+  },
+  // 4. Malicious actors & misuse
+  "disinformation-surveillance-influence": {
+    domain: "malicious-actors-misuse",
+    label: "Disinformation, surveillance, and influence at scale",
+  },
+  "cyberattacks-weapons-mass-harm": {
+    domain: "malicious-actors-misuse",
+    label: "Cyberattacks, weapon development or use, and mass harm",
+  },
+  "fraud-scams-manipulation": {
+    domain: "malicious-actors-misuse",
+    label: "Fraud, scams, and targeted manipulation",
+  },
+  // 5. Human-computer interaction
+  "overreliance-unsafe-use": {
+    domain: "human-computer-interaction",
+    label: "Overreliance and unsafe use",
+  },
+  "loss-of-agency-autonomy": {
+    domain: "human-computer-interaction",
+    label: "Loss of human agency and autonomy",
+  },
+  // 6. Socioeconomic & environmental harm
+  "power-centralization": {
+    domain: "socioeconomic-environmental",
+    label: "Power centralization and unfair distribution of benefits",
+  },
+  "inequality-employment-decline": {
+    domain: "socioeconomic-environmental",
+    label: "Increased inequality and decline in employment quality",
+  },
+  "devaluation-of-human-effort": {
+    domain: "socioeconomic-environmental",
+    label: "Economic and cultural devaluation of human effort",
+  },
+  "competitive-dynamics": {
+    domain: "socioeconomic-environmental",
+    label: "Competitive dynamics",
+  },
+  "governance-failure": {
+    domain: "socioeconomic-environmental",
+    label: "Governance failure",
+  },
+  "environmental-harm": {
+    domain: "socioeconomic-environmental",
+    label: "Environmental harm",
+  },
+  // 7. AI system safety, failures & limitations
+  misalignment: {
+    domain: "ai-system-safety",
+    label: "AI pursuing its own goals in conflict with human goals or values",
+  },
+  "dangerous-capabilities": {
+    domain: "ai-system-safety",
+    label: "AI possessing dangerous capabilities",
+  },
+  "lack-of-capability-robustness": {
+    domain: "ai-system-safety",
+    label: "Lack of capability or robustness",
+  },
+  "lack-of-transparency": {
+    domain: "ai-system-safety",
+    label: "Lack of transparency or interpretability",
+  },
+  "ai-welfare-rights": {
+    domain: "ai-system-safety",
+    label: "AI welfare and rights",
+  },
+  "multi-agent-risks": {
+    domain: "ai-system-safety",
+    label: "Multi-agent risks",
+  },
+} as const satisfies Record<string, { domain: RiskDomain; label: string }>;
+
+export type RiskSubdomain = keyof typeof RISK_SUBDOMAINS;
+
+export const RISK_DOMAIN_SLUGS = Object.keys(RISK_DOMAINS) as [
+  RiskDomain,
+  ...RiskDomain[],
+];
+export const RISK_SUBDOMAIN_SLUGS = Object.keys(RISK_SUBDOMAINS) as [
+  RiskSubdomain,
+  ...RiskSubdomain[],
+];

--- a/src/pages/artifacts/[id].astro
+++ b/src/pages/artifacts/[id].astro
@@ -31,13 +31,6 @@ const sources = await Promise.all(
   }),
 );
 
-const statusLabels: Record<string, string> = {
-  untracked: "Untracked",
-  under_review: "Under review",
-  adopted: "Adopted",
-  rejected: "Rejected",
-};
-
 const robustnessLabels: Record<string, string> = {
   robust: "No regrets",
   contingent: "Conditional",
@@ -192,9 +185,6 @@ const jsonLd = buildCreativeWorkJsonLd({
                     {robustnessLabels[r.robustness] ?? r.robustness}
                   </span>
                 )}
-                <span class="rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
-                  {statusLabels[r.status] ?? r.status}
-                </span>
               </div>
             </div>
             {r.summary && (

--- a/src/pages/map/index.astro
+++ b/src/pages/map/index.astro
@@ -1,0 +1,242 @@
+---
+// src/pages/map/index.astro
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { buildRiskMap } from "../../lib/riskMap";
+import {
+  MITIGATION_CATEGORIES,
+  MITIGATION_STATUSES,
+} from "../../lib/mitigationTaxonomy";
+
+const [risks, mitigations, artifacts, events] = await Promise.all([
+  getCollection("risks"),
+  getCollection("mitigations"),
+  getCollection("artifacts"),
+  getCollection("events"),
+]);
+
+const { domains, general, unmapped, metrics } = buildRiskMap(
+  risks.map((r) => ({ id: r.id, data: r.data })),
+  mitigations.map((m) => ({ id: m.id, data: m.data })),
+  artifacts.map((a) => ({ id: a.id, data: a.data })),
+  events.map((e) => ({ id: e.id, data: e.data })),
+);
+
+const statusColors: Record<string, string> = {
+  untracked: "bg-gray-100 text-gray-600 border-gray-200",
+  under_review: "bg-yellow-100 text-yellow-800 border-yellow-200",
+  adopted: "bg-green-100 text-green-800 border-green-200",
+  rejected: "bg-red-100 text-red-800 border-red-200",
+};
+
+const relationshipLabels: Record<string, string> = {
+  implements: "implements",
+  partially_implements: "partially implements",
+  related: "related",
+};
+---
+
+<BaseLayout
+  title="Map"
+  description="How identified AI risks map to proposed mitigations and their implementation status in Canadian policy."
+>
+  <h1 class="font-display text-4xl text-header">Risk → Mitigation → Implementation</h1>
+  <p class="mt-3 text-ink">
+    Which AI risks have been identified, which mitigations have been proposed
+    to address them, and whether the Canadian government has implemented them.
+  </p>
+
+  <section class="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4" aria-label="Progress metrics">
+    <div class="rounded border border-border bg-surface p-3">
+      <div class="text-2xl font-semibold text-header">{metrics.riskCount}</div>
+      <div class="text-xs text-faint">risks tracked</div>
+    </div>
+    <div class="rounded border border-border bg-surface p-3">
+      <div class="text-2xl font-semibold text-header">{metrics.mitigationCount}</div>
+      <div class="text-xs text-faint">mitigations proposed</div>
+    </div>
+    <div class="rounded border border-border bg-surface p-3">
+      <div class="text-2xl font-semibold text-header">{metrics.statusCounts.adopted}</div>
+      <div class="text-xs text-faint">mitigations adopted</div>
+    </div>
+    <div class="rounded border border-border bg-surface p-3">
+      <div class="text-2xl font-semibold text-header">{metrics.unimplementedCount}</div>
+      <div class="text-xs text-faint">without implementation evidence</div>
+    </div>
+  </section>
+
+  {metrics.domainsWithoutAdopted.length > 0 && (
+    <p class="mt-4 rounded border border-border bg-body p-3 text-sm text-muted">
+      <strong class="text-ink">Coverage gap:</strong>
+      {" "}no adopted mitigation yet addresses risks in{" "}
+      {metrics.domainsWithoutAdopted.join(", ")}.
+    </p>
+  )}
+
+  {domains.map((group) => (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">{group.label}</h2>
+      {group.risks.map((risk) => (
+        <div class="mt-4 rounded border border-border bg-surface p-4">
+          <div class="flex items-start justify-between gap-3">
+            <h3 class="font-medium text-ink">{risk.title}</h3>
+            <span class="shrink-0 rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+              {risk.subdomainLabel}
+            </span>
+          </div>
+          {risk.description && <p class="mt-1 text-sm text-muted">{risk.description}</p>}
+          {risk.identifiedBy.length > 0 && (
+            <p class="mt-2 text-xs text-faint">
+              Identified by:{" "}
+              {risk.identifiedBy.map((s, i) => (
+                <>
+                  {i > 0 && ", "}
+                  <a href={`/artifacts/${s.artifactId}/`} class="text-accent-dark hover:underline">
+                    {s.artifactTitle}
+                  </a>
+                </>
+              ))}
+            </p>
+          )}
+          <ul class="mt-3 space-y-2">
+            {risk.mitigations.map((m) => (
+              <li class="rounded border border-border-lt bg-body p-3">
+                <div class="flex items-start justify-between gap-3">
+                  <span class="text-sm font-medium text-ink">{m.title}</span>
+                  <div class="flex shrink-0 flex-wrap gap-1">
+                    {m.mitigationType && (
+                      <span class="rounded-full bg-surface px-2 py-0.5 text-xs text-muted border border-border-lt">
+                        {MITIGATION_CATEGORIES[m.mitigationType]}
+                      </span>
+                    )}
+                    <span class={`rounded-full px-2 py-0.5 text-xs border ${statusColors[m.status]}`}>
+                      {MITIGATION_STATUSES[m.status]}
+                    </span>
+                  </div>
+                </div>
+                {m.recommendedBy.length > 0 && (
+                  <p class="mt-1 text-xs text-faint">
+                    Recommended by:{" "}
+                    {m.recommendedBy.map((r, i) => (
+                      <>
+                        {i > 0 && ", "}
+                        <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
+                          {r.artifactTitle}
+                        </a>
+                      </>
+                    ))}
+                  </p>
+                )}
+                {m.implementations.length > 0 && (
+                  <ul class="mt-1 text-xs text-faint">
+                    {m.implementations.map((impl) => (
+                      <li>
+                        {relationshipLabels[impl.relationship]}:{" "}
+                        <a
+                          href={`/${impl.kind === "artifact" ? "artifacts" : "events"}/${impl.id}/`}
+                          class="text-accent-dark hover:underline"
+                        >
+                          {impl.title}
+                        </a>
+                        {impl.note && <span> — {impl.note}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  ))}
+
+  {general.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">General &amp; machinery mitigations</h2>
+      <p class="mt-1 text-sm text-muted">
+        Mitigations not tied to a single tracked risk — government machinery,
+        broad capacity building, and preparedness.
+      </p>
+      <ul class="mt-4 space-y-2">
+        {general.map((m) => (
+          <li class="rounded border border-border bg-surface p-3">
+            <div class="flex items-start justify-between gap-3">
+              <span class="text-sm font-medium text-ink">{m.title}</span>
+              <div class="flex shrink-0 flex-wrap gap-1">
+                {m.mitigationType && (
+                  <span class="rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
+                    {MITIGATION_CATEGORIES[m.mitigationType]}
+                  </span>
+                )}
+                <span class={`rounded-full px-2 py-0.5 text-xs border ${statusColors[m.status]}`}>
+                  {MITIGATION_STATUSES[m.status]}
+                </span>
+              </div>
+            </div>
+            {m.recommendedBy.length > 0 && (
+              <p class="mt-1 text-xs text-faint">
+                Recommended by:{" "}
+                {m.recommendedBy.map((r, i) => (
+                  <>
+                    {i > 0 && ", "}
+                    <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
+                      {r.artifactTitle}
+                    </a>
+                  </>
+                ))}
+              </p>
+            )}
+            {m.implementations.length > 0 && (
+              <ul class="mt-1 text-xs text-faint">
+                {m.implementations.map((impl) => (
+                  <li>
+                    {relationshipLabels[impl.relationship]}:{" "}
+                    <a
+                      href={`/${impl.kind === "artifact" ? "artifacts" : "events"}/${impl.id}/`}
+                      class="text-accent-dark hover:underline"
+                    >
+                      {impl.title}
+                    </a>
+                    {impl.note && <span> — {impl.note}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  {unmapped.length > 0 && (
+    <section class="mt-10">
+      <h2 class="font-display text-2xl text-header">Not yet mapped</h2>
+      <p class="mt-1 text-sm text-muted">
+        Recommendations from tracked reports that have not been linked to a
+        canonical mitigation yet.
+      </p>
+      <ul class="mt-4 space-y-2">
+        {unmapped.map((r) => (
+          <li class="rounded border border-border bg-surface p-3">
+            <span class="text-sm font-medium text-ink">{r.title}</span>
+            <p class="mt-1 text-xs text-faint">
+              From{" "}
+              <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
+                {r.artifactTitle}
+              </a>
+            </p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )}
+
+  <p class="mt-12 text-xs text-faint">
+    Risk and mitigation classifications follow the{" "}
+    <a href="https://airisk.mit.edu/" class="text-accent-dark hover:underline" target="_blank" rel="noopener noreferrer">
+      MIT AI Risk Repository
+    </a>{" "}
+    taxonomies (Slattery et al.).
+  </p>
+</BaseLayout>

--- a/src/pages/map/index.astro
+++ b/src/pages/map/index.astro
@@ -34,7 +34,12 @@ const { domains, general, unmapped, metrics } = buildRiskMap(
     All risks on this page are drawn from the{" "}
     <a href="/artifacts/international-ai-safety-report-2026/" class="text-accent-dark hover:underline">
       International AI Safety Report 2026
-    </a>, the international expert assessment chaired by Yoshua Bengio.
+    </a>, the international expert assessment chaired by Yoshua Bengio. Risks and
+    mitigations are classified using the{" "}
+    <a href="https://airisk.mit.edu/" class="text-accent-dark hover:underline" target="_blank" rel="noopener noreferrer">
+      MIT AI Risk Repository
+    </a>{" "}
+    taxonomies (Slattery et al.).
   </p>
 
   <section class="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4" aria-label="Progress metrics">
@@ -59,7 +64,7 @@ const { domains, general, unmapped, metrics } = buildRiskMap(
   {metrics.domainsWithoutAdopted.length > 0 && (
     <p class="mt-4 rounded border border-border bg-body p-3 text-sm text-muted">
       <strong class="text-ink">Coverage gap:</strong>
-      {" "}no adopted mitigation yet addresses risks in{" "}
+      {" "}no adopted mitigation yet addresses risks in the MIT risk domains{" "}
       {metrics.domainsWithoutAdopted.join(", ")}.
     </p>
   )}
@@ -124,11 +129,4 @@ const { domains, general, unmapped, metrics } = buildRiskMap(
     </section>
   )}
 
-  <p class="mt-12 text-xs text-faint">
-    Risk and mitigation classifications follow the{" "}
-    <a href="https://airisk.mit.edu/" class="text-accent-dark hover:underline" target="_blank" rel="noopener noreferrer">
-      MIT AI Risk Repository
-    </a>{" "}
-    taxonomies (Slattery et al.).
-  </p>
 </BaseLayout>

--- a/src/pages/map/index.astro
+++ b/src/pages/map/index.astro
@@ -30,6 +30,13 @@ const { domains, general, unmapped, metrics } = buildRiskMap(
     to address them, and whether the Canadian government has implemented them.
   </p>
 
+  <p class="mt-4 rounded border border-border bg-body p-3 text-sm text-muted">
+    All risks on this page are drawn from the{" "}
+    <a href="/artifacts/international-ai-safety-report-2026/" class="text-accent-dark hover:underline">
+      International AI Safety Report 2026
+    </a>, the international expert assessment chaired by Yoshua Bengio.
+  </p>
+
   <section class="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4" aria-label="Progress metrics">
     <div class="rounded border border-border bg-surface p-3">
       <div class="text-2xl font-semibold text-header">{metrics.riskCount}</div>
@@ -69,19 +76,6 @@ const { domains, general, unmapped, metrics } = buildRiskMap(
             </span>
           </div>
           {risk.description && <p class="mt-1 text-sm text-muted">{risk.description}</p>}
-          {risk.identifiedBy.length > 0 && (
-            <p class="mt-2 text-xs text-faint">
-              Identified by:{" "}
-              {risk.identifiedBy.map((s, i) => (
-                <>
-                  {i > 0 && ", "}
-                  <a href={`/artifacts/${s.artifactId}/`} class="text-accent-dark hover:underline">
-                    {s.artifactTitle}
-                  </a>
-                </>
-              ))}
-            </p>
-          )}
           <ul class="mt-3 space-y-2">
             {risk.mitigations.map((m) => (
               <MitigationCard mitigation={m} variant="nested" />

--- a/src/pages/map/index.astro
+++ b/src/pages/map/index.astro
@@ -3,10 +3,7 @@
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { buildRiskMap } from "../../lib/riskMap";
-import {
-  MITIGATION_CATEGORIES,
-  MITIGATION_STATUSES,
-} from "../../lib/mitigationTaxonomy";
+import MitigationCard from "../../components/MitigationCard.astro";
 
 const [risks, mitigations, artifacts, events] = await Promise.all([
   getCollection("risks"),
@@ -21,19 +18,6 @@ const { domains, general, unmapped, metrics } = buildRiskMap(
   artifacts.map((a) => ({ id: a.id, data: a.data })),
   events.map((e) => ({ id: e.id, data: e.data })),
 );
-
-const statusColors: Record<string, string> = {
-  untracked: "bg-gray-100 text-gray-600 border-gray-200",
-  under_review: "bg-yellow-100 text-yellow-800 border-yellow-200",
-  adopted: "bg-green-100 text-green-800 border-green-200",
-  rejected: "bg-red-100 text-red-800 border-red-200",
-};
-
-const relationshipLabels: Record<string, string> = {
-  implements: "implements",
-  partially_implements: "partially implements",
-  related: "related",
-};
 ---
 
 <BaseLayout
@@ -100,50 +84,7 @@ const relationshipLabels: Record<string, string> = {
           )}
           <ul class="mt-3 space-y-2">
             {risk.mitigations.map((m) => (
-              <li class="rounded border border-border-lt bg-body p-3">
-                <div class="flex items-start justify-between gap-3">
-                  <span class="text-sm font-medium text-ink">{m.title}</span>
-                  <div class="flex shrink-0 flex-wrap gap-1">
-                    {m.mitigationType && (
-                      <span class="rounded-full bg-surface px-2 py-0.5 text-xs text-muted border border-border-lt">
-                        {MITIGATION_CATEGORIES[m.mitigationType]}
-                      </span>
-                    )}
-                    <span class={`rounded-full px-2 py-0.5 text-xs border ${statusColors[m.status]}`}>
-                      {MITIGATION_STATUSES[m.status]}
-                    </span>
-                  </div>
-                </div>
-                {m.recommendedBy.length > 0 && (
-                  <p class="mt-1 text-xs text-faint">
-                    Recommended by:{" "}
-                    {m.recommendedBy.map((r, i) => (
-                      <>
-                        {i > 0 && ", "}
-                        <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
-                          {r.artifactTitle}
-                        </a>
-                      </>
-                    ))}
-                  </p>
-                )}
-                {m.implementations.length > 0 && (
-                  <ul class="mt-1 text-xs text-faint">
-                    {m.implementations.map((impl) => (
-                      <li>
-                        {relationshipLabels[impl.relationship]}:{" "}
-                        <a
-                          href={`/${impl.kind === "artifact" ? "artifacts" : "events"}/${impl.id}/`}
-                          class="text-accent-dark hover:underline"
-                        >
-                          {impl.title}
-                        </a>
-                        {impl.note && <span> — {impl.note}</span>}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </li>
+              <MitigationCard mitigation={m} variant="nested" />
             ))}
           </ul>
         </div>
@@ -160,50 +101,7 @@ const relationshipLabels: Record<string, string> = {
       </p>
       <ul class="mt-4 space-y-2">
         {general.map((m) => (
-          <li class="rounded border border-border bg-surface p-3">
-            <div class="flex items-start justify-between gap-3">
-              <span class="text-sm font-medium text-ink">{m.title}</span>
-              <div class="flex shrink-0 flex-wrap gap-1">
-                {m.mitigationType && (
-                  <span class="rounded-full bg-body px-2 py-0.5 text-xs text-muted border border-border-lt">
-                    {MITIGATION_CATEGORIES[m.mitigationType]}
-                  </span>
-                )}
-                <span class={`rounded-full px-2 py-0.5 text-xs border ${statusColors[m.status]}`}>
-                  {MITIGATION_STATUSES[m.status]}
-                </span>
-              </div>
-            </div>
-            {m.recommendedBy.length > 0 && (
-              <p class="mt-1 text-xs text-faint">
-                Recommended by:{" "}
-                {m.recommendedBy.map((r, i) => (
-                  <>
-                    {i > 0 && ", "}
-                    <a href={`/artifacts/${r.artifactId}/`} class="text-accent-dark hover:underline">
-                      {r.artifactTitle}
-                    </a>
-                  </>
-                ))}
-              </p>
-            )}
-            {m.implementations.length > 0 && (
-              <ul class="mt-1 text-xs text-faint">
-                {m.implementations.map((impl) => (
-                  <li>
-                    {relationshipLabels[impl.relationship]}:{" "}
-                    <a
-                      href={`/${impl.kind === "artifact" ? "artifacts" : "events"}/${impl.id}/`}
-                      class="text-accent-dark hover:underline"
-                    >
-                      {impl.title}
-                    </a>
-                    {impl.note && <span> — {impl.note}</span>}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </li>
+          <MitigationCard mitigation={m} variant="top" />
         ))}
       </ul>
     </section>


### PR DESCRIPTION
## Summary

Adds a new `/map` page presenting a risk → mitigation → implementation view of Canadian AI governance: each tracked risk is linked to the canonical mitigations that address it, and each mitigation shows its implementation status and the policy recommendations it was recommended by.

- Two new content collections: `risks` (seeded from IASR 2026 findings) and `mitigations` (38 canonical mitigations deduplicated from 49 policy recommendations, which now reference mitigations as provenance edges rather than carrying their own free-text status).
- Two new vocabulary modules based on the MIT AI Risk Taxonomy (7 domains, 24 subdomains) and MIT mitigation taxonomy (4 control categories).
- A `riskMap` join + gap-metrics builder module (TDD) that powers the `/map` page, showing risks grouped by domain, their mitigations, implementation status chips, and "recommended by" links back to source artifacts.
- Nav link to `/map` alongside Timeline and Policy.

## Links

- Spec: [`docs/superpowers/specs/2026-07-12-risk-map-design.md`](docs/superpowers/specs/2026-07-12-risk-map-design.md)
- Plan: [`docs/superpowers/plans/2026-07-13-risk-map.md`](docs/superpowers/plans/2026-07-13-risk-map.md)
- Closes #33

## Test plan

- [x] `pnpm test` — 119 passing
- [x] `pnpm build` — 81 pages built
- [ ] CI `Test / unit`
- [ ] CI `Test / e2e` (new `e2e/map.spec.ts` runs here — Playwright is unsupported in the local sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)